### PR TITLE
fix: remove unused databases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,19 +91,9 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
-      postgres_embed:
-        image: pgvector/pgvector:pg16
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: stardance_test_embed
-        ports:
-          - 5433:5432
-        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
     env:
       RAILS_ENV: test
       DATABASE_URL: postgresql://postgres:password@localhost:5432/stardance_test
-      EMBEDDINGS_DATABASE_URL: postgresql://postgres:password@localhost:5433/stardance_test_embed
     steps:
       - uses: actions/checkout@v6
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,6 @@ services:
       - FERRET=${FERRET:-}
     depends_on:
       - db
-      - dbe
 
   db:
     image: pgvector/pgvector:pg16
@@ -28,19 +27,7 @@ services:
     ports:
       - "5432:5432"
 
-  dbe:
-    image: pgvector/pgvector:pg16
-    volumes:
-      - stardance_postgres_data_e:/var/lib/postgresql/data
-    environment:
-      - POSTGRES_PASSWORD=pass
-      - POSTGRES_USER=postgres
-      - POSTGRES_DB=stardance_development_embed
-    ports:
-      - "5433:5432"
-
 volumes:
   stardance_postgres_data:
-  stardance_postgres_data_e:
   bundle_cache:
   node_modules_cache:


### PR DESCRIPTION
i got a dev environment working with this compose setup! hopefully i nailed the CI on the first try as well.

(this is basically hackclub/flavortown#2112 again with the new database setup)

similar to that PR, if you've already tried to set up the repository (i.e. running `docker compose` of some sort), you'll want to:
- `docker compose down --remove-orphans`
- delete the volumes containing the databases (`docker volume ls` then `docker volume rm`)
- run `docker compose up -d db`