### PR TITLE
fix: Change what's cooking to what's launching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stardance
 
-what's cooking in the hack club kitchen :fire:
+what's launching on the hack club spaceport :fire:
 
 check out [CONTRIBUTING.md](./CONTRIBUTING.md) for a more detailed guide on how to get up and running with this repo!
 


### PR DESCRIPTION
i don't have the time to change the whole thing right now, but this changes the opening line of the README to be space themed. there isn't a space emoji usable on Github, but the fire emoji seems to still work.