### PR TITLE
fix(landing): prevent partners extending past screen width

### DIFF
--- a/app/assets/stylesheets/landing/_header.scss
+++ b/app/assets/stylesheets/landing/_header.scss
@@ -19,6 +19,8 @@
   &__partners {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
+    justify-content: flex-end;
     gap: clamp(1.25rem, 1.55vw, 2.25rem);
     background: rgba(8, 6, 30, 0.35);
     padding: clamp(0.5rem, 0.6vw, 0.85rem) clamp(1.25rem, 1.4vw, 2rem);


### PR DESCRIPTION
woah the new Stardance site looks sick

i noticed that the partners thingy push the viewport horizontally on mobile or when the user tries to zoom and figured I'd give fixing it a try...

<img width="1680" height="623" alt="image" src="https://github.com/user-attachments/assets/a0d16bd7-6b1f-404d-aa76-5c28402f875b" />
^ what the fix looks like (i didn't actually test it locally cause im lazy, i popped the attributes in on devtools on stardance.hackclub.com and there's no way I messed up the code for css.... _right_?