### PR TITLE
fix: clip x, minimum gap in project thumbnail bar

### DIFF
--- a/app/assets/stylesheets/landing/_project_thumbs.scss
+++ b/app/assets/stylesheets/landing/_project_thumbs.scss
@@ -4,7 +4,9 @@
   display: flex;
   justify-content: space-evenly;
   align-items: flex-start;
+  gap: var(--space-m);
   width: 100%;
+  overflow-x: clip;
   min-height: 36rem;
   margin-top: -80px;
   z-index: 5;


### PR DESCRIPTION
Fixes how the stardance project thumbnail bar fold causes the entire page to have a horizontal scroll on my school computer (at regular/100% zoom)

Also added a tiny amount of gap between these items so it doesn't feel so cramped

Previous appearance:

<img width="1366" height="608" alt="image" src="https://github.com/user-attachments/assets/d65cf899-97fe-4b0f-91c5-35c3723ccd99" />

After (no horizontal scroll :yay:)

<img width="1366" height="617" alt="image" src="https://github.com/user-attachments/assets/50986492-433f-4561-8e13-75597928d8c7" />

To be clear, the previous even spacing behavior on  bigger screens is retained

<img width="1366" height="607" alt="image" src="https://github.com/user-attachments/assets/3730635a-7c91-4307-9c6f-0ed9a4f4bb97" />
