### PR TITLE
Remove duplicated has_commented?

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -364,10 +364,6 @@ class User < ApplicationRecord
     SendSlackDmJob.perform_later(slack_id, message)
   end
 
-  def has_commented?
-    comments.exists?
-  end
-
   def earned_achievement_slugs
     @earned_achievement_slugs ||= achievements.pluck(:achievement_slug).to_set
   end


### PR DESCRIPTION
I think this was a merge conflict or accidental copy + paste-- this method is already defined in the file