### PR TITLE
Update landing footer links

### DIFF
--- a/app/assets/stylesheets/landing/_landing_footer.scss
+++ b/app/assets/stylesheets/landing/_landing_footer.scss
@@ -100,18 +100,10 @@
     flex-direction: column;
     gap: 8px;
     font-size: var(--font-body);
-    font-weight: 700;
+    font-weight: 400;
     text-align: left;
     margin-top: 1.75rem;
-    letter-spacing: 0.07em;
-
-    a {
-      color: white;
-      text-decoration: none;
-      &:hover {
-        text-decoration: underline;
-      }
-    }
+    letter-spacing: 0;
   }
 
   &__text {
@@ -127,6 +119,13 @@
         margin-bottom: 0;
       }
     }
+  }
+
+  &__links a,
+  &__text a {
+    color: white;
+    text-decoration: underline;
+    text-decoration-color: currentColor;
   }
 
   &__creature {

--- a/app/views/landing/sections/_footer.html.erb
+++ b/app/views/landing/sections/_footer.html.erb
@@ -25,7 +25,7 @@
         </nav>
       </div>
       <div class="landing-footer__text">
-        <p>Hack Club is a 501(c)(3) nonprofit and network of 100k+ technical high schoolers. We believe you learn best by building, so we're creating community and providing grants so you can make awesome projects. In the past few years, we've partnered with GitHub to run Summer of Making, hosted the world's longest hackathon on land, and ran Canada's largest high school hackathon.</p>
+        <p>Hack Club is a 501(c)(3) nonprofit and network of 100k+ technical high schoolers. We believe you learn best by building, so we're creating community and providing grants so you can make awesome projects. In the past few years, we've partnered with GitHub to run <a href="https://flavortown.hackclub.com/" target="_blank" rel="noopener">Flavortown</a>, hosted <a href="https://www.youtube.com/watch?v=2BID8_pGuqA" target="_blank" rel="noopener">the world's longest hackathon on land</a>, and ran <a href="https://www.youtube.com/watch?v=QvCoISXfcE8" target="_blank" rel="noopener">Canada's largest high school hackathon</a>.</p>
         <p>At Hack Club, students aren't just learning, they're shipping.</p>
         <p>Made with &#9829;&#xFE0E; by teenagers, for teenagers at Hack Club</p>
       </div>


### PR DESCRIPTION
Updates the landing footer copy and links:
- renames the Flavortown mention and links it to flavortown.hackclub.com
- links the Hackathon references to their requested YouTube videos
- simplifies footer link styling to plain white underlined links