### PR TITLE
fix(shop): lock shop item row to prevent stock overselling

### DIFF
--- a/app/controllers/shop_controller.rb
+++ b/app/controllers/shop_controller.rb
@@ -176,7 +176,8 @@ class ShopController < ApplicationController
 
     begin
       ActiveRecord::Base.transaction do
-        current_user.lock!
+        current_user.lock! # Lock user to prevent race-condition from overspending on user balance
+        @shop_item.lock! if @shop_item.limited? # Lock item if limited stock to prevent overselling
 
         if @mission_submission.nil?
           user_balance = current_user.balance


### PR DESCRIPTION
We had a lock to prevent users over spending, but no lock to prevent 2 users from buying an item with stock of 1 at the same time!