### PR TITLE
Replace mention of kitchen with spaceport in 404.html

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -89,7 +89,7 @@
       <h1>404...</h1>
       <h2>This dish isn't on the menu!</h2>
       <p>The page you're looking for doesn't seem to exist.<br/> Let's get you back to Stardance?</p>
-      <a href="/kitchen" class="btn">Back to Kitchen</a>
+      <a href="/kitchen" class="btn">Back to spaceport</a>
     </main>
   </body>
 </html>


### PR DESCRIPTION
Replace the word 'kitchen' with 'starport' in `404.html` to prevent confusion between stardance and flavortown.