### PR TITLE
fix(edu): replace artemis patch image with misc patches image

### DIFF
--- a/app/views/landing/edu.erb
+++ b/app/views/landing/edu.erb
@@ -8,7 +8,7 @@
 
 <% poster_request_url = "https://forms.hackclub.com/t/k4g4nCuSbLus" %>
 <% patch_request_url  = "https://forms.hackclub.com/t/g7PK8MCKgbus" %>
-<% artemis_patch_image_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Artemis_II_patch.png/960px-Artemis_II_patch.png" %>
+<% artemis_patch_image_url = "https://cdn.hackclub.com/019e36ed-c55b-7a02-8bc0-779bbeba0913/nasa-patches.png" %>
 
 <div class="educator-toolkit">
   <%= render "landing/sections/header" %>
@@ -48,7 +48,7 @@
                         aria_hidden: "true",
                         class: "educator-toolkit__hero-patch-mascot" %>
           <p class="educator-toolkit__hero-patch-note">
-            Get this patch free for showing the video to your classroom!
+            Get a NASA patch free for showing the video to your classroom!
           </p>
         </div>
       </div>


### PR DESCRIPTION
Requested by Deven! Should be done asap so we aren't misleading educators.

<img width="433" alt="image" src="https://github.com/user-attachments/assets/11c09d17-43ff-4cbc-a9c1-790bb1d171f5" />
