### PR TITLE
Refactor notifications + Add notification tab

### DIFF
--- a/.annotaterb.yml
+++ b/.annotaterb.yml
@@ -14,7 +14,7 @@
 :exclude_helpers: true
 :exclude_scaffolds: true
 :exclude_serializers: false
-:exclude_sti_subclasses: false
+:exclude_sti_subclasses: true
 :exclude_tests: false
 :force: false
 :format_markdown: false

--- a/app/assets/images/icons/notifications/alert-triangle.svg
+++ b/app/assets/images/icons/notifications/alert-triangle.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+  <line x1="12" y1="9" x2="12" y2="13"/>
+  <line x1="12" y1="17" x2="12.01" y2="17"/>
+</svg>

--- a/app/assets/images/icons/notifications/bag.svg
+++ b/app/assets/images/icons/notifications/bag.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 2L3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z"/>
+  <line x1="3" y1="6" x2="21" y2="6"/>
+  <path d="M16 10a4 4 0 0 1-8 0"/>
+</svg>

--- a/app/assets/images/icons/notifications/bell.svg
+++ b/app/assets/images/icons/notifications/bell.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
+  <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+</svg>

--- a/app/assets/images/icons/notifications/check-circle.svg
+++ b/app/assets/images/icons/notifications/check-circle.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/>
+  <polyline points="22 4 12 14.01 9 11.01"/>
+</svg>

--- a/app/assets/images/icons/notifications/clipboard.svg
+++ b/app/assets/images/icons/notifications/clipboard.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/>
+  <rect x="8" y="2" width="8" height="4" rx="1" ry="1"/>
+</svg>

--- a/app/assets/images/icons/notifications/comment.svg
+++ b/app/assets/images/icons/notifications/comment.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+</svg>

--- a/app/assets/images/icons/notifications/pencil.svg
+++ b/app/assets/images/icons/notifications/pencil.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 20h9"/>
+  <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/>
+</svg>

--- a/app/assets/images/icons/notifications/person.svg
+++ b/app/assets/images/icons/notifications/person.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
+  <circle cx="12" cy="7" r="4"/>
+</svg>

--- a/app/assets/images/icons/notifications/rocket.svg
+++ b/app/assets/images/icons/notifications/rocket.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/>
+  <path d="M12 15l-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/>
+  <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/>
+  <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/>
+</svg>

--- a/app/assets/images/icons/notifications/sparkle.svg
+++ b/app/assets/images/icons/notifications/sparkle.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.5 5.5l2 2M16.5 16.5l2 2M5.5 18.5l2-2M16.5 7.5l2-2"/>
+  <circle cx="12" cy="12" r="3"/>
+</svg>

--- a/app/assets/images/icons/notifications/star.svg
+++ b/app/assets/images/icons/notifications/star.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+</svg>

--- a/app/assets/images/icons/notifications/thumbs-up.svg
+++ b/app/assets/images/icons/notifications/thumbs-up.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/>
+</svg>

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -83,3 +83,5 @@
 @use "pages/admin/_super_mega_dashboard";
 @use "pages/admin/missions" as admin_missions;
 @use "pages/admin/_voting_dashboard";
+@use "pages/notifications" as notifications_page;
+@use "pages/notification_settings" as notification_settings_page;

--- a/app/assets/stylesheets/components/_sidebar.scss
+++ b/app/assets/stylesheets/components/_sidebar.scss
@@ -154,6 +154,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  align-self: center;
   min-width: 1.4rem;
   height: 1.4rem;
   padding: 0 0.45rem;
@@ -165,6 +166,10 @@
   font-weight: 700;
   line-height: 1;
   margin-left: auto;
+
+  &[hidden] {
+    display: none;
+  }
 }
 
 button.sidebar__nav-link {
@@ -330,6 +335,8 @@ button.sidebar__nav-link {
   white-space: nowrap;
   flex-shrink: 0;
   margin-left: var(--space-xs);
+  line-height: 1;
+  transform: translateY(var(--nav-label-optical-offset));
 }
 
 .sidebar__user {

--- a/app/assets/stylesheets/config/_variables.scss
+++ b/app/assets/stylesheets/config/_variables.scss
@@ -193,6 +193,13 @@
   --space-xxl: 2.5rem; // 40px
   --space-xxxl: 3rem; // 48px
   --space-xxxxl: 4rem; // 64px
+
+  // Manual optical-centering offset for Exo 2 text against the larger sidebar
+  // nav icons. The font's ascender takes up more space than its descender, so
+  // `align-items: center` lands the glyphs slightly low against the icon's
+  // visual midline. Empirically tuned at the current type scale; revisit if
+  // --font-size-xxxl or the sidebar icon size changes.
+  --nav-label-optical-offset: -5px;
 }
 
 // Mobile shrinks for the landing typography scale.

--- a/app/assets/stylesheets/pages/_notification_settings.scss
+++ b/app/assets/stylesheets/pages/_notification_settings.scss
@@ -1,0 +1,125 @@
+.notification-settings {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: var(--space-xl) var(--space-l);
+  color: var(--color-space-text);
+
+  &__header {
+    margin-bottom: var(--space-l);
+  }
+
+  &__title {
+    font-family: var(--font-family-subtitle);
+    font-size: var(--font-size-xxxl);
+    margin: 0 0 var(--space-xs);
+  }
+
+  &__hint {
+    color: var(--color-space-text-muted);
+    font-size: var(--font-size-s);
+    max-width: 60ch;
+  }
+
+  &__matrix {
+    width: 100%;
+    // `separate` (not `collapse`) so the rounded corners on the table actually
+    // clip the border — with `collapse`, the border lives on cells and
+    // squares off past the radius.
+    border-collapse: separate;
+    border-spacing: 0;
+    background: var(--color-space-surface-faint);
+    border: 1px solid var(--color-space-surface-soft);
+    border-radius: var(--border-radius);
+    overflow: hidden;
+
+    th,
+    td {
+      padding: var(--space-s) var(--space-m);
+      border-bottom: 1px solid var(--color-space-surface-soft);
+    }
+
+    tr:last-child > td {
+      border-bottom: 0;
+    }
+
+    th {
+      text-align: left;
+      color: var(--color-space-text-muted);
+      font-weight: 600;
+      font-size: var(--font-size-xs);
+      text-transform: uppercase;
+      background: var(--color-space-surface-faint);
+    }
+  }
+
+  &__matrix-toggle {
+    width: 80px;
+    text-align: center;
+  }
+
+  &__row:last-child td {
+    border-bottom: 0;
+  }
+
+  &__group {
+    margin-bottom: var(--space-l);
+  }
+
+  &__group-title {
+    font-family: var(--font-family-subtitle);
+    font-size: var(--font-size-xl);
+    margin: 0 0 var(--space-s);
+    color: var(--color-space-text);
+  }
+
+  &__cell--meta {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xxs);
+  }
+
+  &__category-label {
+    color: var(--color-space-text);
+  }
+
+  &__category-description {
+    color: var(--color-space-text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  &__cell--toggle {
+    text-align: center;
+
+    input[type="checkbox"] {
+      width: 18px;
+      height: 18px;
+      accent-color: var(--color-brand-mint);
+    }
+
+    input[disabled] {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: var(--space-l);
+  }
+
+  &__submit {
+    background: var(--color-brand-mint);
+    border: 0;
+    color: var(--color-space-bg);
+    border-radius: 999px;
+    padding: var(--space-s) var(--space-l);
+    font-weight: 600;
+    cursor: pointer;
+    font-family: inherit;
+
+    &:hover {
+      filter: brightness(1.1);
+    }
+  }
+}

--- a/app/assets/stylesheets/pages/_notifications.scss
+++ b/app/assets/stylesheets/pages/_notifications.scss
@@ -1,0 +1,236 @@
+.notifications-page {
+  // Lives inside .app-layout which already handles inset; constrain content
+  // width here so the column doesn't fight with the right rail at wide widths.
+  max-width: 720px;
+  width: 100%;
+  margin: 0 auto;
+  color: var(--color-space-text);
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-m);
+    margin-bottom: var(--space-m);
+    padding-bottom: var(--space-s);
+    border-bottom: 1px solid var(--color-space-surface-soft);
+  }
+
+  &__title {
+    font-family: var(--font-family-subtitle);
+    font-size: var(--font-size-xxl);
+    margin: 0;
+  }
+
+  &__actions {
+    display: flex;
+    gap: var(--space-xs);
+    align-items: center;
+  }
+
+  &__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
+
+  &__action {
+    background: transparent;
+    border: 1px solid var(--color-space-border);
+    color: var(--color-space-text);
+    border-radius: 999px;
+    padding: var(--space-xxs) var(--space-s);
+    font-size: var(--font-size-xs);
+    font-family: inherit;
+    cursor: pointer;
+    text-decoration: none;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+
+    &:hover:not(:disabled) {
+      background: var(--color-space-surface-faint);
+    }
+
+    &:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+
+    &--danger {
+      border-color: var(--color-brand-salmon);
+      color: var(--color-brand-salmon);
+
+      &:hover:not(:disabled) {
+        background: var(--color-brand-salmon-soft);
+      }
+    }
+
+    &--ghost {
+      border-color: transparent;
+      color: var(--color-space-text-muted);
+
+      &:hover {
+        color: var(--color-space-text);
+        background: var(--color-space-surface-faint);
+      }
+    }
+  }
+
+  &__empty {
+    padding: var(--space-xl) var(--space-l);
+    text-align: center;
+    border: 1px dashed var(--color-space-border);
+    border-radius: 8px;
+    margin-top: var(--space-m);
+  }
+
+  &__empty-title {
+    font-family: var(--font-family-subtitle);
+    font-size: var(--font-size-l);
+    margin: 0 0 var(--space-xxs);
+    color: var(--color-space-text);
+  }
+
+  &__empty-hint {
+    margin: 0;
+    color: var(--color-space-text-muted);
+    font-size: var(--font-size-s);
+  }
+}
+
+.notifications-item {
+  border: 1px solid var(--color-space-border);
+  border-radius: 6px;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease;
+
+  &--unread {
+    border-color: var(--color-brand-lilac);
+  }
+
+  &--priority-high {
+    border-color: var(--color-brand-peach);
+  }
+
+  &--priority-critical {
+    border-color: var(--color-brand-salmon);
+  }
+
+  &__form {
+    margin: 0;
+  }
+
+  &__link {
+    display: flex;
+    align-items: center;
+    gap: var(--space-s);
+    width: 100%;
+    padding: var(--space-s) var(--space-m);
+    background: transparent;
+    border: 0;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+    border-radius: inherit;
+
+    &:hover {
+      background: var(--color-space-surface-faint);
+    }
+  }
+
+  &__icon {
+    flex: 0 0 auto;
+    width: 28px;
+    height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-space-text);
+    opacity: 0.75;
+  }
+
+  &__icon-svg {
+    width: 22px;
+    height: 22px;
+    display: block;
+  }
+
+  &__main {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xxs);
+    min-width: 0;
+  }
+
+  &__actors {
+    display: flex;
+    align-items: center;
+    gap: 0;
+
+    .notifications-item__avatar {
+      width: 28px;
+      height: 28px;
+    }
+
+    .notifications-item__avatar + .notifications-item__avatar {
+      margin-left: -8px;
+    }
+  }
+
+  &__avatar {
+    border-radius: 50%;
+    object-fit: cover;
+    display: block;
+    border: 1px solid var(--color-space-bg);
+  }
+
+  &__title {
+    font-family: var(--font-family-text);
+    font-weight: 600;
+    font-size: var(--font-size-s);
+    line-height: 1.4;
+    color: var(--color-space-text);
+    word-break: break-word;
+  }
+
+  &__actor {
+    color: var(--color-space-text);
+    text-decoration: none;
+    font-weight: 700;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  &__verb {
+    font-weight: 400;
+    color: var(--color-space-text);
+  }
+
+  &__time {
+    opacity: 0.5;
+    font-weight: 400;
+    font-family: var(--font-family-text);
+  }
+
+  &__preview {
+    display: -webkit-box;
+    font-style: italic;
+    font-weight: 400;
+    font-size: var(--font-size-s);
+    line-height: 1.4;
+    color: rgba(255, 255, 255, 0.6);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+  }
+}

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,0 +1,23 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      # Always-on: anonymous visitors must be able to open a cable connection
+      # so they can subscribe to public Turbo Streams (e.g. the landing-page
+      # RSVP counter). Per-user channels (NotificationsChannel) enforce auth
+      # themselves by rejecting subscriptions when current_user is nil.
+      self.current_user = find_verified_user
+    end
+
+    private
+
+    def find_verified_user
+      session_key = Rails.application.config.session_options[:key]
+      user_id = cookies.encrypted[session_key]&.dig("user_id")
+      return nil if user_id.blank?
+
+      User.find_by(id: user_id)
+    end
+  end
+end

--- a/app/channels/notifications_channel.rb
+++ b/app/channels/notifications_channel.rb
@@ -1,0 +1,33 @@
+class NotificationsChannel < ApplicationCable::Channel
+  def subscribed
+    return reject if current_user.nil?
+
+    stream_for current_user
+  end
+
+  # Fires on any seen-state change. Inbox controller ignores the absence of
+  # `row_html` and just updates the badge.
+  def self.broadcast_unseen_count(user)
+    broadcast_to(user, { unseen_count: user.notifications.unseen.count })
+  end
+
+  # Fires when a new notification is created or an existing aggregate is
+  # updated. Carries both the rendered row HTML (for live inbox insertion)
+  # and the refreshed unseen count (for the sidebar badge).
+  def self.broadcast_notification(notification, aggregated:)
+    row_html = ApplicationController.render(
+      partial: "notifications/inbox_row",
+      locals: { notification: notification }
+    )
+
+    broadcast_to(
+      notification.recipient,
+      {
+        unseen_count: notification.recipient.notifications.unseen.count,
+        row_html: row_html,
+        notification_id: notification.id,
+        aggregated: aggregated
+      }
+    )
+  end
+end

--- a/app/components/notifications/item_component.html.erb
+++ b/app/components/notifications/item_component.html.erb
@@ -1,0 +1,27 @@
+<li class="<%= li_classes %>" data-notification-id="<%= notification.id %>">
+  <%= button_to mark_read_my_notification_path(notification),
+                method: :post,
+                class: "notifications-item__link",
+                form: { class: "notifications-item__form", data: { turbo: false } } do %>
+    <span class="notifications-item__icon" aria-hidden="true">
+      <%= inline_svg_tag type_icon_path, class: "notifications-item__icon-svg" %>
+    </span>
+
+    <span class="notifications-item__main">
+      <% if avatar_actor %>
+        <span class="notifications-item__actors" aria-hidden="true">
+          <%= image_tag avatar_actor.avatar, alt: "", class: "notifications-item__avatar" %>
+        </span>
+      <% end %>
+
+      <span class="notifications-item__title">
+        <%= render notification.inbox_partial, notification: notification %>
+        <span class="notifications-item__time"> · <%= time_text %></span>
+      </span>
+
+      <% if notification.preview_text.present? %>
+        <span class="notifications-item__preview"><%= notification.preview_text %></span>
+      <% end %>
+    </span>
+  <% end %>
+</li>

--- a/app/components/notifications/item_component.rb
+++ b/app/components/notifications/item_component.rb
@@ -1,0 +1,53 @@
+module Notifications
+  class ItemComponent < ViewComponent::Base
+    delegate :inline_svg_tag, to: :helpers
+
+    TYPE_ICONS = {
+      "Notifications::NewFollower"                              => "person",
+      "Notifications::ProjectFollowed"                          => "person",
+      "Notifications::ProjectCommentReceived"                   => "comment",
+      "Notifications::FollowedDevlogCreated"                    => "pencil",
+      "Notifications::StardustBalanceChanged"                   => "sparkle",
+      "Notifications::Payouts::ShipEventIssued"                 => "rocket",
+      "Notifications::Payouts::VoteDeficitBlocked"              => "thumbs-up",
+      "Notifications::Projects::SuperStar"                      => "star",
+      "Notifications::Missions::SubmissionApproved"             => "check-circle",
+      "Notifications::Missions::SubmissionRejected"             => "alert-triangle",
+      "Notifications::Missions::SubmissionPendingForReviewer"   => "clipboard",
+      "Notifications::ShopOrders::StatusChanged"                => "bag"
+    }.freeze
+
+    attr_reader :notification
+
+    def initialize(notification:)
+      @notification = notification
+    end
+
+    def li_classes
+      [
+        "notifications-item",
+        ("notifications-item--unread" if notification.read_at.nil?),
+        "notifications-item--priority-#{notification.priority}"
+      ].compact.join(" ")
+    end
+
+    def time_text
+      helpers.time_ago_in_words(notification.created_at) + " ago"
+    end
+
+    def type_icon_path
+      name = TYPE_ICONS[notification.type] || "bell"
+      "icons/notifications/#{name}.svg"
+    end
+
+    def avatar_actor
+      notification.actor
+    end
+
+    def others_count
+      return 0 if notification.group_count.to_i <= 1
+
+      notification.group_count - 1
+    end
+  end
+end

--- a/app/components/sidebar_component.html.erb
+++ b/app/components/sidebar_component.html.erb
@@ -49,9 +49,18 @@
               <span class="sidebar__nav-label"><%= item[:label] %></span>
             </span>
           <% else %>
-            <%= link_to item[:path], class: link_classes, aria: (active?(item) ? { current: "page" } : {}), data: { turbo: true, active_prefix: item[:active_prefix], slug: item[:slug] }.compact do %>
+            <% link_data = { turbo: true, active_prefix: item[:active_prefix], slug: item[:slug] }.compact %>
+            <% link_data[:controller] = "notifications-badge" if item[:slug] == "notifications" %>
+            <%= link_to item[:path], class: link_classes, aria: (active?(item) ? { current: "page" } : {}), data: link_data do %>
               <%= icon_block %>
               <span class="sidebar__nav-label"><%= item[:label] %></span>
+              <% if item.key?(:badge) %>
+                <% count = item[:badge].to_i %>
+                <span class="sidebar__nav-badge"
+                      data-notifications-badge-target="badge"
+                      aria-label="<%= count %> unread"
+                      <%= "hidden" if count == 0 %>><%= count %></span>
+              <% end %>
             <% end %>
           <% end %>
         </li>
@@ -111,35 +120,10 @@
       </div>
 
       <div class="settings-form__field">
-        <label class="settings-form__checkbox">
-          <%= check_box_tag :stardust_balance_notifications, "1", preference.stardust_balance_notifications, id: "stardust_balance_notifications" %>
-          <span>Balance change notifications</span>
-        </label>
-        <small class="settings-form__hint">Receive a Slack DM when your Stardust balance changes</small>
-      </div>
-
-      <div class="settings-form__field">
-        <label class="settings-form__checkbox">
-          <%= check_box_tag :send_notifications_for_followed_projects, "1", preference.send_notifications_for_followed_projects, id: "send_notifications_for_followed_projects" %>
-          <span>Followed project notifications</span>
-        </label>
-        <small class="settings-form__hint">Receive a Slack DM when a project you're following has a new devlog</small>
-      </div>
-
-      <div class="settings-form__field">
-        <label class="settings-form__checkbox">
-          <%= check_box_tag :send_notifications_for_new_followers, "1", preference.send_notifications_for_new_followers, id: "send_notifications_for_new_followers" %>
-          <span>New follower notifications</span>
-        </label>
-        <small class="settings-form__hint">Receive a Slack DM when someone starts following a project you're making</small>
-      </div>
-
-      <div class="settings-form__field">
-        <label class="settings-form__checkbox">
-          <%= check_box_tag :send_notifications_for_new_comments, "1", preference.send_notifications_for_new_comments, id: "send_notifications_for_new_comments" %>
-          <span>New comment notifications</span>
-        </label>
-        <small class="settings-form__hint">Receive a Slack DM when someone comments on a project you made</small>
+        <p class="settings-form__hint">
+          Per-category notification controls (Slack, email) moved to a dedicated page:
+          <%= link_to "Manage notifications →", my_notification_settings_path %>
+        </p>
       </div>
 
       <div class="settings-form__field">

--- a/app/components/sidebar_component.rb
+++ b/app/components/sidebar_component.rb
@@ -28,8 +28,8 @@ class SidebarComponent < ViewComponent::Base
     items = [
       { slug: "home",          label: "home",          path: helpers.home_path,
         icon: { idle: "rocket", active: "rocket_active" } },
-      { slug: "notifications", label: "notifications", path: "#",
-        icon: { idle: "bell", active: "bell_active" } },
+      { slug: "notifications", label: "notifications", path: helpers.my_notifications_path,
+        icon: { idle: "bell", active: "bell_active" }, badge: unseen_notifications_count },
       { slug: "vote",          label: "vote",          path: helpers.new_vote_path,
         icon: { idle: "box", active: "box_active" },
         locked: !user.shipped_projects.exists?,
@@ -73,5 +73,13 @@ class SidebarComponent < ViewComponent::Base
 
   def link_classes_for(item)
     [ "sidebar__nav-link", ("sidebar__nav-link--active" if active?(item)) ].compact.join(" ")
+  end
+
+  def unseen_notifications_count
+    return 0 unless user
+
+    # First-render value only; ActionCable pushes live updates after the page
+    # loads, so a brief staleness here is invisible to the user.
+    @unseen_notifications_count ||= user.notifications.unseen.count
   end
 end

--- a/app/controllers/mission_submissions_controller.rb
+++ b/app/controllers/mission_submissions_controller.rb
@@ -91,13 +91,15 @@ class MissionSubmissionsController < ApplicationController
 
   def notify_builder(template_basename)
     builder = @submission.ship_event&.post&.user
-    return unless builder&.slack_id.present?
+    return unless builder
 
-    SendSlackDmJob.perform_later(
-      builder.slack_id,
-      blocks_path: "notifications/missions/#{template_basename}.slack_message",
-      locals: @submission.notification_locals
-    )
+    klass = case template_basename
+    when "submission_approved" then Notifications::Missions::SubmissionApproved
+    when "submission_rejected" then Notifications::Missions::SubmissionRejected
+    end
+    return unless klass
+
+    klass.notify(recipient: builder, actor: current_user, record: @submission)
   rescue StandardError => e
     Rails.logger.warn("MissionSubmissions notify_builder: #{e.message}")
   end

--- a/app/controllers/my/notification_settings_controller.rb
+++ b/app/controllers/my/notification_settings_controller.rb
@@ -1,0 +1,52 @@
+class My::NotificationSettingsController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    authorize :my, :show_notification_settings?
+
+    @grouped_types = Notifications::Registry.all.group_by(&:category_group)
+    @preferences_by_category = current_user.notification_preferences.index_by(&:category)
+  end
+
+  def update
+    authorize :my, :update_notification_settings?
+
+    submitted = permitted_preferences
+
+    Notifications::Registry.all.each do |klass|
+      next if klass.default_priority.to_s == "critical"
+
+      category = klass.category_key.to_s
+      data = submitted[category] || {}
+
+      pref = current_user.notification_preferences.find_or_initialize_by(category: category)
+      pref.slack_enabled = parse_bool(data["slack"])
+      pref.email_enabled = parse_bool(data["email"])
+      pref.save!
+    end
+
+    redirect_to my_notification_settings_path, notice: "Notification preferences saved"
+  end
+
+  private
+
+  def authenticate_user!
+    return if current_user.present?
+
+    store_return_to
+    redirect_to root_path, alert: "Please sign in to continue."
+  end
+
+  def parse_bool(value)
+    case value
+    when "1", "true", true then true
+    when "0", "false", false then false
+    end
+  end
+
+  def permitted_preferences
+    categories = Notifications::Registry.all.map { |k| k.category_key.to_s }
+    nested = categories.index_with { [ :slack, :email ] }
+    params.fetch(:preferences, {}).permit(nested).to_h
+  end
+end

--- a/app/controllers/my/notifications_controller.rb
+++ b/app/controllers/my/notifications_controller.rb
@@ -1,0 +1,72 @@
+class My::NotificationsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    authorize :my, :show_notifications?
+
+    @body_class = "app-layout-page"
+
+    @pagy, @notifications = pagy(
+      Notification.inbox_for(current_user).includes(:actor),
+      limit: 25
+    )
+
+    Notification.preload_inbox_records!(@notifications)
+    @notifications = @notifications.reject(&:orphaned?)
+    @has_any_notifications = current_user.notifications.exists?
+    @has_unread = @notifications.any? { |n| n.read_at.nil? }
+
+    mark_all_unseen_as_seen!
+  end
+
+  def mark_read
+    authorize :my, :update_notification?
+
+    notification = current_user.notifications.find(params[:id])
+    notification.mark_read!
+
+    target = notification.target_path
+    redirect_to(target.presence || my_notifications_path)
+  end
+
+  def mark_all_seen
+    authorize :my, :update_notification?
+    current_user.notifications.unseen.update_all(seen_at: Time.current)
+    BroadcastUnseenCountJob.perform_later(current_user.id)
+    redirect_back fallback_location: my_notifications_path
+  end
+
+  def mark_all_read
+    authorize :my, :update_notification?
+    current_user.notifications.unread.update_all(read_at: Time.current, seen_at: Time.current)
+    BroadcastUnseenCountJob.perform_later(current_user.id)
+    redirect_back fallback_location: my_notifications_path
+  end
+
+  def clear_all
+    authorize :my, :update_notification?
+    current_user.notifications.destroy_all
+    BroadcastUnseenCountJob.perform_later(current_user.id)
+    redirect_back fallback_location: my_notifications_path
+  end
+
+  private
+
+  def authenticate_user!
+    return if current_user.present?
+
+    store_return_to
+    redirect_to root_path, alert: "Please sign in to continue."
+  end
+
+  # Opening the inbox semantically means "I'm here, I've seen them" — so we
+  # mark ALL unseen rows, not just the loaded page. Otherwise a user with
+  # 100 unseen and a 25-per-page inbox would walk away with the badge stuck
+  # at 75.
+  def mark_all_unseen_as_seen!
+    return if request.headers["Purpose"] == "prefetch"
+
+    affected = current_user.notifications.unseen.update_all(seen_at: Time.current)
+    BroadcastUnseenCountJob.perform_later(current_user.id) if affected.positive?
+  end
+end

--- a/app/controllers/my/settings_controller.rb
+++ b/app/controllers/my/settings_controller.rb
@@ -6,10 +6,6 @@ class My::SettingsController < ApplicationController
     current_user.preference.update!(
       send_votes_to_slack: params[:send_votes_to_slack] == "1",
       leaderboard_optin: params[:leaderboard_optin] == "1",
-      stardust_balance_notifications: params[:stardust_balance_notifications] == "1",
-      send_notifications_for_followed_projects: params[:send_notifications_for_followed_projects] == "1",
-      send_notifications_for_new_followers: params[:send_notifications_for_new_followers] == "1",
-      send_notifications_for_new_comments: params[:send_notifications_for_new_comments] == "1",
       search_engine_indexing_off: params[:search_engine_indexing_off] == "1"
     )
     redirect_back fallback_location: root_path, notice: "Settings saved"

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -266,19 +266,8 @@ class ProjectsController < ApplicationController
 
     follow = current_user.project_follows.build(project: @project)
     if follow.save
-      @project.users.includes(:preference).each do |member|
-        if member.preference.send_notifications_for_new_followers && current_user.slack_id && member.slack_id
-          SendSlackDmJob.perform_later(
-            member.slack_id,
-            "#{current_user.display_name} is now following your project #{@project.title}!",
-            blocks_path: "notifications/new_follower",
-            locals: {
-              project_title: @project.title,
-              project_url: project_url(@project, host: "flavortown.hackclub.com", protocol: "https"),
-              follower_id: current_user.slack_id
-            }
-          )
-        end
+      @project.users.find_each do |member|
+        Notifications::ProjectFollowed.notify(recipient: member, actor: current_user, record: @project)
       end
       redirect_to project_path(@project), notice: "You are now following this project."
     else

--- a/app/javascript/channels/consumer.js
+++ b/app/javascript/channels/consumer.js
@@ -1,0 +1,3 @@
+import { createConsumer } from "@rails/actioncable";
+
+export default createConsumer();

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -73,6 +73,12 @@ application.register("markdown-preview", MarkdownPreviewController);
 import ModalController from "./modal_controller";
 application.register("modal", ModalController);
 
+import NotificationsBadgeController from "./notifications_badge_controller";
+application.register("notifications-badge", NotificationsBadgeController);
+
+import NotificationsInboxController from "./notifications_inbox_controller";
+application.register("notifications-inbox", NotificationsInboxController);
+
 import OnboardingInterestsController from "./onboarding_interests_controller";
 application.register("onboarding-interests", OnboardingInterestsController);
 

--- a/app/javascript/controllers/notifications_badge_controller.js
+++ b/app/javascript/controllers/notifications_badge_controller.js
@@ -1,0 +1,35 @@
+import { Controller } from "@hotwired/stimulus";
+import consumer from "../channels/consumer";
+
+// Subscribes to the per-user notifications channel and updates the sidebar
+// badge in real time as the unseen count changes.
+//
+// Markup:
+//   <a class="sidebar__nav-link" data-controller="notifications-badge">
+//     <span data-notifications-badge-target="badge" class="sidebar__nav-badge" hidden>0</span>
+//   </a>
+export default class extends Controller {
+  static targets = ["badge"];
+
+  connect() {
+    this.subscription = consumer.subscriptions.create("NotificationsChannel", {
+      received: (data) => this.updateBadge(data.unseen_count),
+    });
+  }
+
+  disconnect() {
+    this.subscription?.unsubscribe();
+    this.subscription = null;
+  }
+
+  updateBadge(count) {
+    if (!this.hasBadgeTarget) return;
+
+    const safeCount = Number.isFinite(count)
+      ? Math.max(0, Math.floor(count))
+      : 0;
+    this.badgeTarget.textContent = safeCount;
+    this.badgeTarget.setAttribute("aria-label", `${safeCount} unread`);
+    this.badgeTarget.hidden = safeCount === 0;
+  }
+}

--- a/app/javascript/controllers/notifications_inbox_controller.js
+++ b/app/javascript/controllers/notifications_inbox_controller.js
@@ -1,0 +1,107 @@
+import { Controller } from "@hotwired/stimulus";
+import consumer from "../channels/consumer";
+
+// Live-updates the inbox list as new notifications arrive. Receives the same
+// NotificationsChannel broadcast as the badge controller; ignores messages
+// that don't carry a `row_html` payload (count-only updates).
+//
+//   <main data-controller="notifications-inbox"
+//         data-notifications-inbox-mark-seen-url-value="/my/notifications/mark_all_seen">
+//     <ol data-notifications-inbox-target="list">
+//       <li data-notification-id="…">…</li>
+//     </ol>
+//     <div data-notifications-inbox-target="empty">…</div>
+//   </main>
+const MARK_SEEN_DEBOUNCE_MS = 1500;
+
+export default class extends Controller {
+  static targets = ["list", "empty"];
+  static values = { markSeenUrl: String };
+
+  connect() {
+    console.log("[notifications-inbox] connected");
+    this.subscription = consumer.subscriptions.create("NotificationsChannel", {
+      connected: () => console.log("[notifications-inbox] cable connected"),
+      disconnected: () => console.log("[notifications-inbox] cable disconnected"),
+      rejected: () => console.warn("[notifications-inbox] cable rejected"),
+      received: (data) => this.handleMessage(data),
+    });
+    this._markSeenTimer = null;
+  }
+
+  disconnect() {
+    this.subscription?.unsubscribe();
+    this.subscription = null;
+    clearTimeout(this._markSeenTimer);
+  }
+
+  handleMessage(data) {
+    console.log("[notifications-inbox] received", {
+      hasRow: !!data.row_html,
+      id: data.notification_id,
+      aggregated: data.aggregated,
+      unseen: data.unseen_count,
+    });
+
+    if (!data.row_html) {
+      console.log("[notifications-inbox] ignoring count-only message");
+      return;
+    }
+    if (!this.hasListTarget) {
+      console.warn("[notifications-inbox] no list target on element");
+      return;
+    }
+
+    try {
+      const existing = this.listTarget.querySelector(
+        `[data-notification-id="${data.notification_id}"]`,
+      );
+
+      if (existing) {
+        console.log("[notifications-inbox] replacing existing row", data.notification_id);
+        existing.outerHTML = data.row_html;
+      } else {
+        console.log("[notifications-inbox] prepending new row", data.notification_id);
+        this.listTarget.insertAdjacentHTML("afterbegin", data.row_html);
+        this.hideEmptyState();
+      }
+
+      this.scheduleMarkSeen();
+    } catch (err) {
+      console.error("[notifications-inbox] handler failed", err, data);
+    }
+  }
+
+  hideEmptyState() {
+    if (this.hasEmptyTarget) this.emptyTarget.hidden = true;
+  }
+
+  // Debounced POST to mark_all_seen — the user is looking at the inbox, so
+  // any newly-arrived row counts as seen. Debounce so a burst of broadcasts
+  // collapses into one request.
+  scheduleMarkSeen() {
+    if (!this.markSeenUrlValue) return;
+
+    clearTimeout(this._markSeenTimer);
+    this._markSeenTimer = setTimeout(
+      () => this.markAllSeen(),
+      MARK_SEEN_DEBOUNCE_MS,
+    );
+  }
+
+  markAllSeen() {
+    const token = document.querySelector('meta[name="csrf-token"]')?.content;
+    if (!token) return;
+
+    fetch(this.markSeenUrlValue, {
+      method: "POST",
+      headers: {
+        "X-CSRF-Token": token,
+        Accept: "text/html",
+      },
+      credentials: "same-origin",
+    }).catch((err) =>
+      console.warn("[notifications-inbox] mark_all_seen failed", err),
+    );
+  }
+}

--- a/app/jobs/broadcast_notification_job.rb
+++ b/app/jobs/broadcast_notification_job.rb
@@ -1,0 +1,12 @@
+class BroadcastNotificationJob < ApplicationJob
+  queue_as :latency_5m
+
+  discard_on ActiveJob::DeserializationError
+
+  def perform(notification_id, aggregated:)
+    notification = Notification.find_by(id: notification_id)
+    return unless notification
+
+    NotificationsChannel.broadcast_notification(notification, aggregated: aggregated)
+  end
+end

--- a/app/jobs/broadcast_unseen_count_job.rb
+++ b/app/jobs/broadcast_unseen_count_job.rb
@@ -1,0 +1,12 @@
+class BroadcastUnseenCountJob < ApplicationJob
+  queue_as :latency_5m
+
+  discard_on ActiveJob::DeserializationError
+
+  def perform(user_id)
+    user = User.find_by(id: user_id)
+    return unless user
+
+    NotificationsChannel.broadcast_unseen_count(user)
+  end
+end

--- a/app/jobs/notification_delivery_job.rb
+++ b/app/jobs/notification_delivery_job.rb
@@ -1,0 +1,51 @@
+class NotificationDeliveryJob < ApplicationJob
+  queue_as :latency_5m
+
+  discard_on ActiveJob::DeserializationError
+
+  def perform(notification_id, channel)
+    notification = Notification.find_by(id: notification_id)
+    return unless notification
+
+    case channel.to_s
+    when "slack" then deliver_slack(notification)
+    when "email" then deliver_email(notification)
+    else
+      Rails.logger.warn("NotificationDeliveryJob: unknown channel #{channel.inspect}")
+    end
+  end
+
+  private
+
+  def deliver_slack(notification)
+    return if notification.slack_enqueued_at.present?
+
+    recipient = notification.recipient
+    return unless recipient&.slack_id.present?
+
+    payload = notification.slack_payload
+    return if payload[:message].blank? && payload[:blocks_path].blank?
+
+    SendSlackDmJob.perform_later(
+      recipient.slack_id,
+      payload[:message],
+      blocks_path: payload[:blocks_path],
+      locals: payload[:locals] || {}
+    )
+
+    notification.update_column(:slack_enqueued_at, Time.current)
+  end
+
+  def deliver_email(notification)
+    return if notification.email_delivered_at.present?
+
+    recipient = notification.recipient
+    return unless recipient&.email.present?
+
+    NotificationMailer.notification(notification.id).deliver_now
+    notification.update_column(:email_delivered_at, Time.current)
+  rescue StandardError => e
+    Rails.logger.error("NotificationDeliveryJob email delivery failed (#{notification.id}): #{e.message}")
+    Sentry.capture_exception(e) if defined?(Sentry)
+  end
+end

--- a/app/jobs/post_creation_to_slack_job.rb
+++ b/app/jobs/post_creation_to_slack_job.rb
@@ -10,8 +10,6 @@ class PostCreationToSlackJob < ApplicationJob
   include Rails.application.routes.url_helpers
 
   def perform(record)
-    return if Rails.env.development?
-
     case record
     when Post::Devlog
       post_devlog(record)
@@ -32,21 +30,11 @@ class PostCreationToSlackJob < ApplicationJob
     author = post.user
     return unless project && author
 
-    project.followers.includes(:preference).each do |follower|
-      if follower.preference.send_notifications_for_followed_projects
-        SendSlackDmJob.perform_later(
-          follower.slack_id,
-          "New devlog on #{project.title} by #{author.display_name}!",
-          blocks_path: "notifications/creations/followed_devlog_created",
-          locals: {
-            project_title: sanitize_mentions(project.title),
-            project_url: project_url(project, host: "flavortown.hackclub.com", protocol: "https"),
-            author_name: sanitize_mentions(author.display_name) || "Someone",
-            devlog_body: sanitize_mentions(devlog.body.to_s.truncate(200))
-          }
-        )
-      end
+    project.followers.find_each do |follower|
+      Notifications::FollowedDevlogCreated.notify(recipient: follower, actor: author, record: devlog)
     end
+
+    return if Rails.env.development?
 
     SendSlackDmJob.perform_later(
       CHANNEL_ID,
@@ -63,6 +51,7 @@ class PostCreationToSlackJob < ApplicationJob
 
   def post_project(project)
     return if project.deleted?
+    return if Rails.env.development?
 
     owner = project.memberships.owner.first&.user
     return unless owner
@@ -87,22 +76,13 @@ class PostCreationToSlackJob < ApplicationJob
 
     commentable_url, commentable_title, commentable_users = resolve_commentable(commentable)
     return unless commentable_url
+
     commentable_users.each do |member|
-      next if member.id == author.id
-      if member.slack_id && member.preference.send_notifications_for_new_comments
-        SendSlackDmJob.perform_later(
-          member.slack_id,
-          "New comment on your project #{commentable_title} by #{author.display_name || "Someone"}",
-          blocks_path: "notifications/creations/comment_created_dm",
-          locals: {
-            commentable_title: sanitize_mentions(commentable_title),
-            commentable_url: commentable_url,
-            author_name: sanitize_mentions(author.display_name) || "Someone",
-            comment_body: sanitize_mentions(comment.body.to_s.truncate(200))
-          }
-        )
-      end
+      Notifications::ProjectCommentReceived.notify(recipient: member, actor: author, record: comment)
     end
+
+    return if Rails.env.development?
+
     SendSlackDmJob.perform_later(
       CHANNEL_ID,
       nil,

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,0 +1,17 @@
+class NotificationMailer < ApplicationMailer
+  def notification(notification_id)
+    @notification = Notification.find_by(id: notification_id)
+    return if @notification.nil?
+    return if @notification.recipient.email.blank?
+
+    @recipient = @notification.recipient
+    @actor     = @notification.actor
+    @record    = @notification.record
+
+    mail(
+      to:            @recipient.email,
+      subject:       @notification.email_subject,
+      template_name: @notification.template_key
+    )
+  end
+end

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -37,8 +37,6 @@ class Follow < ApplicationRecord
   end
 
   def notify_followed
-    return unless followed.preference.send_notifications_for_new_followers? && followed.slack_id.present?
-
-    followed.dm_user("✨ <@#{follower.slack_id}> just started following you on Stardance!")
+    Notifications::NewFollower.notify(recipient: followed, actor: follower, record: self)
   end
 end

--- a/app/models/ledger_entry.rb
+++ b/app/models/ledger_entry.rb
@@ -70,8 +70,6 @@ class LedgerEntry < ApplicationRecord
   end
 
   def notify_balance_change
-    return unless user.preference.stardust_balance_notifications?
-
     source = case ledgerable_type
     when "ShopOrder" then "shop purchase"
     when "Post::ShipEvent" then "ship event payout"
@@ -84,8 +82,15 @@ class LedgerEntry < ApplicationRecord
     change_emoji = amount.positive? ? "📈" : "📉"
     message = "#{change_emoji} Balance #{amount.positive? ? '+' : ''}#{amount} :stardust: (#{source}) → #{user.balance} :stardust:"
 
-    SendSlackDmJob.perform_later(user.slack_id, message)
-    SendSlackDmJob.perform_later("C0A3JN1CMNE", "<@#{user.slack_id}>: #{message}")
+    Notifications::StardustBalanceChanged.notify(
+      recipient: user,
+      record: self,
+      params: { "message" => message, "amount" => amount, "source" => source }
+    )
+
+    # Audit broadcast to the finance review channel — not a user notification,
+    # not preference-gated, intentional separate path.
+    SendSlackDmJob.perform_later("C0A3JN1CMNE", "<@#{user.slack_id}>: #{message}") if user.slack_id.present?
   end
 
   def invalidate_user_balance_cache = user.invalidate_balance_cache!

--- a/app/models/mission/submission.rb
+++ b/app/models/mission/submission.rb
@@ -102,7 +102,6 @@ class Mission::Submission < ApplicationRecord
     global_ids = User.where("? = ANY (granted_roles)", "mission_reviewer").pluck(:id)
 
     User.where(id: (per_mission_ids + global_ids).uniq - teammate_ids)
-        .where(mission_review_notifications: true)
         .where.not(slack_id: [ nil, "" ])
   end
 
@@ -128,12 +127,9 @@ class Mission::Submission < ApplicationRecord
   private
 
   def notify_reviewers
+    builder = ship_event&.post&.user
     reviewer_recipients.find_each do |reviewer|
-      SendSlackDmJob.perform_later(
-        reviewer.slack_id,
-        blocks_path: "notifications/missions/submission_pending_for_reviewer.slack_message",
-        locals: notification_locals
-      )
+      Notifications::Missions::SubmissionPendingForReviewer.notify(recipient: reviewer, actor: builder, record: self)
     end
   rescue StandardError => e
     Rails.logger.warn("Mission::Submission notify_reviewers (#{id}): #{e.message}")

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,271 @@
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                 :bigint           not null, primary key
+#  email_delivered_at :datetime
+#  group_count        :integer          default(1), not null
+#  group_key          :string
+#  params             :jsonb            not null
+#  priority           :integer          default("low"), not null
+#  read_at            :datetime
+#  record_type        :string
+#  seen_at            :datetime
+#  slack_enqueued_at  :datetime
+#  type               :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  actor_id           :bigint
+#  recipient_id       :bigint           not null
+#  record_id          :bigint
+#
+# Indexes
+#
+#  index_notifications_on_actor_id                                (actor_id)
+#  index_notifications_on_recipient_id                            (recipient_id)
+#  index_notifications_on_recipient_id_and_created_at             (recipient_id,created_at)
+#  index_notifications_on_recipient_id_and_group_key_and_read_at  (recipient_id,group_key,read_at) WHERE (group_key IS NOT NULL)
+#  index_notifications_on_recipient_id_and_seen_at                (recipient_id,seen_at)
+#  index_notifications_on_record_type_and_record_id               (record_type,record_id)
+#  index_notifications_on_type_and_created_at                     (type,created_at)
+#  index_notifications_unique_unread_aggregate                    (recipient_id,type,group_key) UNIQUE WHERE ((read_at IS NULL) AND (group_key IS NOT NULL))
+#
+# Foreign Keys
+#
+#  fk_rails_...  (actor_id => users.id) ON DELETE => nullify
+#  fk_rails_...  (recipient_id => users.id) ON DELETE => cascade
+#
+class Notification < ApplicationRecord
+  PRIORITY_CHANNEL_DEFAULTS = {
+    "low"      => { slack: false, email: false },
+    "medium"   => { slack: false, email: false },
+    "high"     => { slack: true,  email: true  },
+    "critical" => { slack: true,  email: true  }
+  }.freeze
+
+  # Strips Slack broadcast/group mentions so user-authored content can't ping
+  # @channel/@here when re-rendered into a Slack DM.
+  SLACK_MENTION_PATTERN = /<!(?:here|channel|everyone|subteam\^[A-Z0-9]+)(?:\|[^>]+)?>|@(?:here|channel|everyone)/i
+
+  class_attribute :default_priority,     default: :low
+  class_attribute :slack_template_path,  default: nil
+  class_attribute :aggregatable,         default: false
+  class_attribute :allow_self_notify,    default: false
+  class_attribute :category_key,         default: nil
+  class_attribute :category_label,       default: nil
+  class_attribute :category_description, default: nil
+  class_attribute :category_group,       default: "General"
+  class_attribute :inbox_record_preloads, default: nil
+  # Delay for slack/email delivery so aggregated rows fire one DM/email with
+  # the final group_count instead of one per event. nil = immediate.
+  class_attribute :digest_delay,         default: nil
+
+  enum :priority, { low: 0, medium: 1, high: 2, critical: 3 }, validate: true
+  # Override the column default of 0 (=low) so apply_default_priority's `||=`
+  # can actually assign each subclass's declared default. Without this, new
+  # records arrive at the callback already set to "low" and never upgrade.
+  attribute :priority, default: nil
+
+  belongs_to :recipient, class_name: "User"
+  belongs_to :actor,     class_name: "User", optional: true
+  belongs_to :record,    polymorphic: true,  optional: true
+
+  after_initialize :apply_default_priority, if: :new_record?
+
+  scope :unseen, -> { where(seen_at: nil) }
+  scope :unread, -> { where(read_at: nil) }
+
+  def self.notify(recipient:, actor: nil, record: nil, params: {}, priority: nil)
+    return nil if recipient.nil?
+    return nil if actor && actor.id == recipient.id && !allow_self_notify
+
+    notification = nil
+    attempts = 0
+
+    begin
+      attempts += 1
+      transaction do
+        notification = aggregate_or_build(recipient: recipient, actor: actor, record: record, params: params)
+        notification.priority = priority if priority
+        notification.save!
+      end
+    rescue ActiveRecord::RecordNotUnique
+      # Race: another notify call inserted the aggregate row between our
+      # lookup and insert. Retry once — the second pass finds the row that
+      # the racing call created and merges into it instead.
+      retry if attempts < 2
+      raise
+    end
+
+    enqueue_deliveries(notification)
+    # previously_new_record? is false when aggregate_or_build merged into an
+    # existing row (no new INSERT); true when this notify spawned a fresh row.
+    BroadcastNotificationJob.perform_later(notification.id, aggregated: !notification.previously_new_record?)
+    notification
+  end
+
+  def self.aggregate_or_build(recipient:, actor:, record:, params:)
+    if aggregatable
+      existing = recipient.notifications
+        .where(type: name, group_key: build_group_key(recipient: recipient, actor: actor, record: record, params: params), read_at: nil)
+        .order(created_at: :desc)
+        .lock
+        .first
+
+      if existing
+        existing.merge_aggregated_actor!(actor)
+        return existing
+      end
+    end
+
+    new(
+      recipient: recipient,
+      actor: actor,
+      record: record,
+      params: params,
+      group_key: aggregatable ? build_group_key(recipient: recipient, actor: actor, record: record, params: params) : nil
+    )
+  end
+
+  def self.build_group_key(recipient:, actor:, record:, params:)
+    nil
+  end
+
+  def self.enqueue_deliveries(notification)
+    notification.effective_channels.each do |channel|
+      if digest_delay
+        NotificationDeliveryJob.set(wait: digest_delay).perform_later(notification.id, channel.to_s)
+      else
+        NotificationDeliveryJob.perform_later(notification.id, channel.to_s)
+      end
+    end
+  end
+
+  def self.inbox_for(user)
+    user.notifications.order(created_at: :desc)
+  end
+
+  # Conditionally preload polymorphic records + their chains per notification
+  # type so we don't pay for `:record` loads on types that don't use them,
+  # and so types that need a deeper chain (e.g. Devlog#post#project) don't N+1.
+  #
+  # inbox_record_preloads contract per subclass:
+  #   nil   - skip record load entirely (record_id is nil or partial doesn't use it)
+  #   []    - load :record only
+  #   spec  - load :record plus this chain (symbol, array, or hash) on the record
+  def self.preload_inbox_records!(notifications)
+    notifications.group_by(&:class).each do |klass, group|
+      spec = klass.inbox_record_preloads
+      next if spec.nil?
+      next if group.empty?
+
+      associations = spec.is_a?(Array) && spec.empty? ? :record : { record: spec }
+
+      ActiveRecord::Associations::Preloader.new(
+        records: group,
+        associations: associations
+      ).call
+    end
+  end
+
+  def effective_channels
+    defaults = PRIORITY_CHANNEL_DEFAULTS.fetch(priority.to_s)
+    pref = preference_row
+
+    slack_on = critical? || channel_enabled?(:slack, pref, defaults)
+    email_on = critical? || channel_enabled?(:email, pref, defaults)
+
+    channels = []
+    channels << :slack if slack_on
+    channels << :email if email_on
+    channels
+  end
+
+  def merge_aggregated_actor!(actor)
+    self.group_count = (group_count || 1) + 1
+    self.actor = actor if actor
+    self.updated_at = Time.current
+    # Resurface as fully unseen/unread — a new actor means there's something
+    # new to look at, even if the user had already read the previous version.
+    self.seen_at = nil
+    self.read_at = nil
+    save!
+  end
+
+  def mark_seen!
+    return if seen_at.present?
+
+    update!(seen_at: Time.current)
+    BroadcastUnseenCountJob.perform_later(recipient_id)
+  end
+
+  def mark_read!
+    update!(read_at: Time.current) if read_at.nil?
+  end
+
+  def orphaned?
+    record_type.present? && record_id.present? && record.nil?
+  end
+
+  def target_path
+    nil
+  end
+
+  def template_key
+    self.class.name.demodulize.underscore
+  end
+
+  def inbox_partial
+    "notifications/inbox/#{template_key}"
+  end
+
+  def preview_text
+    nil
+  end
+
+  def slack_payload
+    {
+      message: slack_message,
+      blocks_path: self.class.slack_template_path,
+      locals: slack_locals
+    }
+  end
+
+  def slack_message
+    nil
+  end
+
+  def slack_locals
+    {}
+  end
+
+  def email_subject
+    "Stardance notification"
+  end
+
+  def sanitize_slack_mentions(text)
+    text.to_s.gsub(SLACK_MENTION_PATTERN, "")
+  end
+
+  private
+
+  def preference_row
+    key = self.class.category_key
+    return nil if key.nil? || recipient.nil?
+
+    recipient.notification_preferences.find_by(category: key.to_s)
+  end
+
+  def channel_enabled?(channel, pref, defaults)
+    column = "#{channel}_enabled"
+    if pref && !pref[column].nil?
+      pref[column]
+    else
+      defaults[channel]
+    end
+  end
+
+  def apply_default_priority
+    self.priority ||= self.class.default_priority
+  end
+end

--- a/app/models/notifications/followed_devlog_created.rb
+++ b/app/models/notifications/followed_devlog_created.rb
@@ -1,0 +1,45 @@
+module Notifications
+  class FollowedDevlogCreated < ::Notification
+    self.default_priority     = :low
+    self.aggregatable         = true
+    self.slack_template_path  = "notifications/creations/followed_devlog_created"
+    self.category_key         = :followed_devlog_created
+    self.category_label       = "Devlogs on followed projects"
+    self.category_description = "A new devlog was posted on a project you follow"
+    self.category_group       = "Social"
+    self.inbox_record_preloads = { post: :project }
+
+    def self.build_group_key(record:, recipient:, **)
+      project = record.is_a?(Post::Devlog) ? record.post&.project : nil
+      "followed_devlog:#{project&.id || 0}:#{recipient.id}"
+    end
+
+    def slack_locals
+      devlog = record
+      project = devlog&.post&.project
+      author = devlog&.post&.user
+      return {} unless project && author
+
+      {
+        project_title: sanitize_slack_mentions(project.title),
+        project_url:   Rails.application.routes.url_helpers.project_url(project, host: "stardance.hackclub.com", protocol: "https"),
+        author_name:   sanitize_slack_mentions(author.display_name) || "Someone",
+        devlog_body:   sanitize_slack_mentions(devlog.body.to_s.truncate(200))
+      }
+    end
+
+    def target_path
+      project = record&.post&.project
+      project ? Rails.application.routes.url_helpers.project_path(project) : nil
+    end
+
+    def preview_text
+      record&.body.to_s.truncate(140).presence
+    end
+
+    def email_subject
+      project = record&.post&.project
+      project&.title.present? ? "New devlog on #{project.title}" : "New devlog on a project you follow"
+    end
+  end
+end

--- a/app/models/notifications/missions/submission_approved.rb
+++ b/app/models/notifications/missions/submission_approved.rb
@@ -1,0 +1,27 @@
+module Notifications
+  module Missions
+    class SubmissionApproved < ::Notification
+      self.default_priority     = :high
+      self.aggregatable         = false
+      self.slack_template_path  = "notifications/missions/submission_approved.slack_message"
+      self.category_key         = :mission_submission_approved
+      self.category_label       = "Mission submission approved"
+      self.category_description = "Your ship event passed mission review"
+      self.category_group       = "Missions"
+      self.inbox_record_preloads = :mission
+
+      def slack_locals
+        record&.notification_locals || {}
+      end
+
+      def target_path
+        record ? Rails.application.routes.url_helpers.mission_submission_path(record) : nil
+      end
+
+      def email_subject
+        mission = record&.mission&.name
+        mission.present? ? "#{mission} submission approved" : "Your mission submission was approved"
+      end
+    end
+  end
+end

--- a/app/models/notifications/missions/submission_pending_for_reviewer.rb
+++ b/app/models/notifications/missions/submission_pending_for_reviewer.rb
@@ -1,0 +1,27 @@
+module Notifications
+  module Missions
+    class SubmissionPendingForReviewer < ::Notification
+      self.default_priority     = :medium
+      self.aggregatable         = false
+      self.slack_template_path  = "notifications/missions/submission_pending_for_reviewer.slack_message"
+      self.category_key         = :mission_submission_pending_for_reviewer
+      self.category_label       = "Mission submission pending review"
+      self.category_description = "A submission is waiting for your review"
+      self.category_group       = "Missions"
+      self.inbox_record_preloads = :mission
+
+      def slack_locals
+        record&.notification_locals || {}
+      end
+
+      def target_path
+        record ? Rails.application.routes.url_helpers.mission_submission_path(record) : nil
+      end
+
+      def email_subject
+        mission = record&.mission&.name
+        mission.present? ? "Submission awaiting your review on #{mission}" : "A submission is awaiting your review"
+      end
+    end
+  end
+end

--- a/app/models/notifications/missions/submission_rejected.rb
+++ b/app/models/notifications/missions/submission_rejected.rb
@@ -1,0 +1,27 @@
+module Notifications
+  module Missions
+    class SubmissionRejected < ::Notification
+      self.default_priority     = :high
+      self.aggregatable         = false
+      self.slack_template_path  = "notifications/missions/submission_rejected.slack_message"
+      self.category_key         = :mission_submission_rejected
+      self.category_label       = "Mission submission rejected"
+      self.category_description = "Your ship event was sent back with feedback"
+      self.category_group       = "Missions"
+      self.inbox_record_preloads = :mission
+
+      def slack_locals
+        record&.notification_locals || {}
+      end
+
+      def target_path
+        record ? Rails.application.routes.url_helpers.mission_submission_path(record) : nil
+      end
+
+      def email_subject
+        mission = record&.mission&.name
+        mission.present? ? "#{mission} submission needs revisions" : "Your mission submission needs revisions"
+      end
+    end
+  end
+end

--- a/app/models/notifications/new_follower.rb
+++ b/app/models/notifications/new_follower.rb
@@ -1,0 +1,32 @@
+module Notifications
+  class NewFollower < ::Notification
+    self.default_priority     = :low
+    self.aggregatable         = true
+    self.category_key         = :new_follower
+    self.category_label       = "New followers"
+    self.category_description = "Someone started following you on Stardance"
+    self.category_group       = "Social"
+    self.digest_delay         = 1.hour
+
+    def self.build_group_key(recipient:, **)
+      "user_followed:#{recipient.id}"
+    end
+
+    def slack_message
+      return nil unless actor&.slack_id.present?
+
+      "✨ <@#{actor.slack_id}> just started following you on Stardance!"
+    end
+
+    def target_path
+      return nil unless actor
+
+      Rails.application.routes.url_helpers.user_path(actor)
+    end
+
+    def email_subject
+      name = actor&.display_name
+      name.present? ? "@#{name} started following you on Stardance" : "You have a new follower on Stardance"
+    end
+  end
+end

--- a/app/models/notifications/payouts/ship_event_issued.rb
+++ b/app/models/notifications/payouts/ship_event_issued.rb
@@ -1,0 +1,26 @@
+module Notifications
+  module Payouts
+    class ShipEventIssued < ::Notification
+      self.default_priority     = :high
+      self.aggregatable         = false
+      self.slack_template_path  = "notifications/payouts/ship_event_issued"
+      self.category_key         = :ship_event_payout_issued
+      self.category_label       = "Ship event payouts"
+      self.category_description = "Stardust was paid out for one of your ship events"
+      self.category_group       = "Stardust"
+
+      def slack_locals
+        params.symbolize_keys.slice(:project_title, :ship_date, :hours, :stardust, :multiplier, :blessing)
+      end
+
+      def target_path
+        Rails.application.routes.url_helpers.my_balance_path
+      end
+
+      def email_subject
+        title = params["project_title"]
+        title.present? ? "Payout issued for #{title}" : "Ship event payout issued"
+      end
+    end
+  end
+end

--- a/app/models/notifications/payouts/vote_deficit_blocked.rb
+++ b/app/models/notifications/payouts/vote_deficit_blocked.rb
@@ -1,0 +1,31 @@
+module Notifications
+  module Payouts
+    class VoteDeficitBlocked < ::Notification
+      self.default_priority     = :medium
+      self.aggregatable         = false
+      self.slack_template_path  = "notifications/payouts/vote_deficit_blocked"
+      self.category_key         = :vote_deficit_blocked
+      self.category_label       = "Vote deficit blocking payout"
+      self.category_description = "A ship event payout is blocked until you cast more votes"
+      self.category_group       = "Stardust"
+
+      def slack_locals
+        ship = record
+        {
+          ship_event: ship,
+          votes_needed: params["votes_needed"].to_i,
+          project_title: params["project_title"]
+        }
+      end
+
+      def target_path
+        Rails.application.routes.url_helpers.new_vote_path
+      end
+
+      def email_subject
+        n = params["votes_needed"].to_i
+        n.positive? ? "Vote #{n} more time#{'s' if n != 1} to unlock your payout" : "Vote more to unlock your payout"
+      end
+    end
+  end
+end

--- a/app/models/notifications/project_comment_received.rb
+++ b/app/models/notifications/project_comment_received.rb
@@ -1,0 +1,54 @@
+module Notifications
+  class ProjectCommentReceived < ::Notification
+    self.default_priority     = :medium
+    self.aggregatable         = true
+    self.slack_template_path  = "notifications/creations/comment_created_dm"
+    self.category_key         = :project_comment_received
+    self.category_label       = "Comments on your project"
+    self.category_description = "Someone commented on your project devlog or ship event"
+    self.category_group       = "Social"
+    self.digest_delay         = 5.minutes
+    self.inbox_record_preloads = { commentable: { post: :project } }
+
+    def self.build_group_key(record:, recipient:, **)
+      "comment:#{record&.commentable_type}:#{record&.commentable_id}:#{recipient.id}"
+    end
+
+    def slack_locals
+      comment = record
+      return {} unless comment
+
+      commentable = comment.commentable
+      project = commentable.respond_to?(:post) ? commentable.post&.project : nil
+      return {} unless project
+
+      {
+        commentable_title: sanitize_slack_mentions(project.title),
+        commentable_url:   Rails.application.routes.url_helpers.project_url(project, host: "stardance.hackclub.com", protocol: "https"),
+        author_name:       sanitize_slack_mentions(actor&.display_name) || "Someone",
+        comment_body:      sanitize_slack_mentions(comment.body.to_s.truncate(200))
+      }
+    end
+
+    def target_path
+      project = record&.commentable.respond_to?(:post) ? record.commentable.post&.project : nil
+      project ? Rails.application.routes.url_helpers.project_path(project) : nil
+    end
+
+    def preview_text
+      record&.body.to_s.truncate(140).presence
+    end
+
+    def email_subject
+      project = record&.commentable.respond_to?(:post) ? record.commentable.post&.project : nil
+      who = actor&.display_name
+      if project&.title.present? && who.present?
+        "@#{who} commented on #{project.title}"
+      elsif project&.title.present?
+        "New comment on #{project.title}"
+      else
+        "New comment on your project"
+      end
+    end
+  end
+end

--- a/app/models/notifications/project_followed.rb
+++ b/app/models/notifications/project_followed.rb
@@ -1,0 +1,44 @@
+module Notifications
+  class ProjectFollowed < ::Notification
+    self.default_priority     = :medium
+    self.aggregatable         = true
+    self.slack_template_path  = "notifications/new_follower"
+    self.category_key         = :project_followed
+    self.category_label       = "New project followers"
+    self.category_description = "Someone started following one of your projects"
+    self.category_group       = "Social"
+    self.digest_delay         = 1.hour
+    self.inbox_record_preloads = []
+
+    def self.build_group_key(record:, recipient:, **)
+      "project_followed:#{record&.id || 0}:#{recipient.id}"
+    end
+
+    def slack_locals
+      project = record
+      return {} unless project
+
+      {
+        project_title: project.title,
+        project_url:   Rails.application.routes.url_helpers.project_url(project, host: "stardance.hackclub.com", protocol: "https"),
+        follower_id:   actor&.slack_id
+      }
+    end
+
+    def target_path
+      record ? Rails.application.routes.url_helpers.project_path(record) : nil
+    end
+
+    def email_subject
+      who = actor&.display_name
+      what = record&.title
+      if who.present? && what.present?
+        "@#{who} started following #{what}"
+      elsif what.present?
+        "Someone started following #{what}"
+      else
+        "Someone started following your project"
+      end
+    end
+  end
+end

--- a/app/models/notifications/projects/super_star.rb
+++ b/app/models/notifications/projects/super_star.rb
@@ -1,0 +1,27 @@
+module Notifications
+  module Projects
+    class SuperStar < ::Notification
+      self.default_priority     = :high
+      self.aggregatable         = false
+      self.slack_template_path  = "notifications/projects/super_star"
+      self.category_key         = :project_super_star
+      self.category_label       = "Super Star projects"
+      self.category_description = "Your project was marked as a Super Star"
+      self.category_group       = "Missions"
+      self.inbox_record_preloads = []
+
+      def slack_locals
+        record ? { project: record } : {}
+      end
+
+      def target_path
+        record ? Rails.application.routes.url_helpers.project_path(record) : nil
+      end
+
+      def email_subject
+        title = record&.title
+        title.present? ? "#{title} was marked a Super Star" : "Your project was marked a Super Star"
+      end
+    end
+  end
+end

--- a/app/models/notifications/registry.rb
+++ b/app/models/notifications/registry.rb
@@ -1,0 +1,36 @@
+module Notifications
+  module Registry
+    # Explicit list of registered notification subclasses. New types must be
+    # added here so they show up in the preferences UI and the dev lab.
+    # An explicit list is used instead of `Notification.descendants` because
+    # STI descendants are not reliably loaded in development.
+    TYPES = %w[
+      Notifications::NewFollower
+      Notifications::ProjectFollowed
+      Notifications::FollowedDevlogCreated
+      Notifications::ProjectCommentReceived
+      Notifications::Missions::SubmissionApproved
+      Notifications::Missions::SubmissionRejected
+      Notifications::Missions::SubmissionPendingForReviewer
+      Notifications::Projects::SuperStar
+      Notifications::StardustBalanceChanged
+      Notifications::Payouts::ShipEventIssued
+      Notifications::Payouts::VoteDeficitBlocked
+      Notifications::ShopOrders::StatusChanged
+    ].freeze
+
+    module_function
+
+    def all
+      TYPES.map(&:constantize)
+    end
+
+    def by_category(category)
+      all.find { |klass| klass.category_key.to_s == category.to_s }
+    end
+
+    def grouped_by_priority
+      all.group_by(&:default_priority)
+    end
+  end
+end

--- a/app/models/notifications/shop_orders/status_changed.rb
+++ b/app/models/notifications/shop_orders/status_changed.rb
@@ -1,0 +1,57 @@
+module Notifications
+  module ShopOrders
+    class StatusChanged < ::Notification
+      self.aggregatable         = false
+      self.category_key         = :shop_order_status_changed
+      self.category_label       = "Shop order updates"
+      self.category_description = "Your shop order moved to a new state"
+      self.category_group       = "Shop"
+      self.inbox_record_preloads = :shop_item
+
+      STATE_CONFIG = {
+        "rejected"                        => { priority: :high,     template: "rejected",                    headline: "was rejected" },
+        "awaiting_verification"           => { priority: :high,     template: "awaiting_verification",       headline: "needs verification" },
+        "awaiting_verification_call"      => { priority: :critical, template: "awaiting_verification_call",  headline: "needs a verification call" },
+        "awaiting_periodical_fulfillment" => { priority: :medium,   template: "awaiting_fulfillment",        headline: "is queued for fulfillment" },
+        "fulfilled"                       => { priority: :high,     template: "fulfilled",                   headline: "was fulfilled" }
+      }.freeze
+
+      DEFAULT_CONFIG = { priority: :medium, template: "default", headline: nil }.freeze
+
+      def self.priority_for(state)
+        STATE_CONFIG.fetch(state, DEFAULT_CONFIG)[:priority]
+      end
+
+      def self.template_for(state)
+        "notifications/shop_orders/#{STATE_CONFIG.fetch(state, DEFAULT_CONFIG)[:template]}"
+      end
+
+      def headline
+        state = params["state"].to_s
+        config_headline = STATE_CONFIG.fetch(state, DEFAULT_CONFIG)[:headline]
+        return config_headline if config_headline
+        return "was updated" if state.blank?
+
+        "moved to #{state.humanize}"
+      end
+
+      def slack_payload
+        {
+          message: nil,
+          blocks_path: self.class.template_for(params["state"].to_s),
+          locals: { order: record }
+        }
+      end
+
+      def target_path
+        Rails.application.routes.url_helpers.shop_my_orders_path
+      end
+
+      def email_subject
+        item = record&.shop_item&.name
+        verb = headline
+        item.present? ? "Your shop order for #{item} #{verb}" : "Your shop order #{verb}"
+      end
+    end
+  end
+end

--- a/app/models/notifications/stardust_balance_changed.rb
+++ b/app/models/notifications/stardust_balance_changed.rb
@@ -1,0 +1,33 @@
+module Notifications
+  class StardustBalanceChanged < ::Notification
+    self.default_priority     = :low
+    self.aggregatable         = true
+    self.category_key         = :stardust_balance_changed
+    self.category_label       = "Stardust balance changes"
+    self.category_description = "Your stardust balance went up or down"
+    self.category_group       = "Stardust"
+
+    def self.build_group_key(recipient:, **)
+      "stardust_balance:#{recipient.id}"
+    end
+
+    def slack_message
+      params["message"].presence
+    end
+
+    def target_path
+      Rails.application.routes.url_helpers.my_balance_path
+    end
+
+    def email_subject
+      amount = params["amount"].to_i
+      if amount.positive?
+        "+#{amount} stardust on your balance"
+      elsif amount.negative?
+        "#{amount} stardust on your balance"
+      else
+        "Stardust balance updated"
+      end
+    end
+  end
+end

--- a/app/models/project/magic.rb
+++ b/app/models/project/magic.rb
@@ -59,12 +59,8 @@ class Project::Magic
   def enqueue_magic_jobs
     Project::PostToMagicJob.perform_later(project)
     Project::MagicHappeningLetterJob.perform_later(project)
-    project.users.each do |user|
-      SendSlackDmJob.perform_later(
-        user.slack_id,
-        blocks_path: "notifications/projects/super_star",
-        locals: { project: project },
-      )
+    project.users.find_each do |user|
+      Notifications::Projects::SuperStar.notify(recipient: user, actor: project.marked_fire_by, record: project)
     end
   end
 end

--- a/app/models/shop_order.rb
+++ b/app/models/shop_order.rb
@@ -107,7 +107,6 @@ class ShopOrder < ApplicationRecord
   before_create :freeze_item_price
   before_create :set_region_from_address
   after_commit :notify_user_of_status_change, if: :saved_change_to_aasm_state?
-  # after_save :notify_assigned_user, if: :saved_change_to_assigned_to_user_id?
 
   scope :worth_counting, -> { where.not(aasm_state: %w[rejected refunded]) }
   scope :real, -> { without_item_type("ShopItem::FreeStickers") }
@@ -304,25 +303,14 @@ class ShopOrder < ApplicationRecord
   def get_agh_contents = shop_item.get_agh_contents(self)
 
   def notify_user_of_status_change
-    return unless user.slack_id.present?
-
     # Don't notify the user when an order is placed on hold — they shouldn't know
     return if aasm_state == "on_hold"
 
-    template = case aasm_state
-    when "rejected" then "notifications/shop_orders/rejected"
-    when "awaiting_verification" then "notifications/shop_orders/awaiting_verification"
-    when "awaiting_verification_call" then "notifications/shop_orders/awaiting_verification_call"
-    when "awaiting_periodical_fulfillment" then "notifications/shop_orders/awaiting_fulfillment"
-    when "fulfilled" then "notifications/shop_orders/fulfilled"
-    else "notifications/shop_orders/default"
-    end
-
-    SendSlackDmJob.perform_later(
-      user.slack_id,
-      nil,
-      blocks_path: template,
-      locals: { order: self }
+    Notifications::ShopOrders::StatusChanged.notify(
+      recipient: user,
+      record: self,
+      params: { "state" => aasm_state },
+      priority: Notifications::ShopOrders::StatusChanged.priority_for(aasm_state)
     )
   end
 
@@ -534,21 +522,5 @@ class ShopOrder < ApplicationRecord
     return unless USPS_SUSPENDED_COUNTRIES.include?(address_country.upcase)
 
     place_on_hold! if may_place_on_hold?
-  end
-
-  def notify_assigned_user
-    return unless assigned_to_user_id.present?
-
-    user = assigned_to_user
-    return unless user&.slack_id.present?
-
-    Rails.logger.info "[ShopOrder] Sending assignment notification to #{user.display_name} (#{user.slack_id})"
-
-    SendSlackDmJob.perform_later(
-      user.slack_id,
-      nil,
-      blocks_path: "notifications/shop_orders/assigned",
-      locals: { order: self, admin_url: Rails.application.routes.url_helpers.admin_shop_order_url(self, host: "flavortown.hackclub.com", protocol: "https") }
-    )
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,42 +2,41 @@
 #
 # Table name: users
 #
-#  id                           :bigint           not null, primary key
-#  age_attestation              :string
-#  banned                       :boolean          default(FALSE), not null
-#  banned_at                    :datetime
-#  banned_reason                :text
-#  bio                          :text
-#  display_name                 :string
-#  email                        :string
-#  enriched_ref                 :string
-#  experience_level             :string
-#  first_name                   :string
-#  granted_roles                :string           default([]), not null, is an Array
-#  has_gotten_free_stickers     :boolean          default(FALSE)
-#  has_pending_achievements     :boolean          default(FALSE), not null
-#  hcb_email                    :string
-#  interests                    :string           default([]), is an Array
-#  internal_notes               :text
-#  last_name                    :string
-#  manual_ysws_override         :boolean
-#  mission_review_notifications :boolean          default(TRUE), not null
-#  onboarded_at                 :datetime
-#  ref                          :string
-#  regions                      :string           default([]), is an Array
-#  session_token                :string
-#  shop_region                  :enum
-#  synced_at                    :datetime
-#  things_dismissed             :string           default([]), not null, is an Array
-#  tutorial_steps_completed     :string           default([]), is an Array
-#  verification_status          :string           default("needs_submission"), not null
-#  vote_balance                 :integer          default(0), not null
-#  votes_count                  :integer
-#  voting_locked                :boolean          default(FALSE), not null
-#  ysws_eligible                :boolean          default(FALSE), not null
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
-#  slack_id                     :string
+#  id                       :bigint           not null, primary key
+#  age_attestation          :string
+#  banned                   :boolean          default(FALSE), not null
+#  banned_at                :datetime
+#  banned_reason            :text
+#  bio                      :text
+#  display_name             :string
+#  email                    :string
+#  enriched_ref             :string
+#  experience_level         :string
+#  first_name               :string
+#  granted_roles            :string           default([]), not null, is an Array
+#  has_gotten_free_stickers :boolean          default(FALSE)
+#  has_pending_achievements :boolean          default(FALSE), not null
+#  hcb_email                :string
+#  interests                :string           default([]), is an Array
+#  internal_notes           :text
+#  last_name                :string
+#  manual_ysws_override     :boolean
+#  onboarded_at             :datetime
+#  ref                      :string
+#  regions                  :string           default([]), is an Array
+#  session_token            :string
+#  shop_region              :enum
+#  synced_at                :datetime
+#  things_dismissed         :string           default([]), not null, is an Array
+#  tutorial_steps_completed :string           default([]), is an Array
+#  verification_status      :string           default("needs_submission"), not null
+#  vote_balance             :integer          default(0), not null
+#  votes_count              :integer
+#  voting_locked            :boolean          default(FALSE), not null
+#  ysws_eligible            :boolean          default(FALSE), not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  slack_id                 :string
 #
 # Indexes
 #
@@ -77,6 +76,10 @@ class User < ApplicationRecord
   has_many :follows_as_followed, class_name: "Follow", foreign_key: :followed_id, dependent: :destroy, inverse_of: :followed
   has_many :following, through: :follows_as_follower, source: :followed
   has_many :followers, through: :follows_as_followed, source: :follower
+
+  has_many :notifications, foreign_key: :recipient_id, dependent: :destroy, inverse_of: :recipient
+  has_many :actor_notifications, class_name: "Notification", foreign_key: :actor_id, dependent: :nullify, inverse_of: :actor
+  has_many :notification_preferences, class_name: "User::NotificationPreference", dependent: :destroy
 
   has_many :mission_memberships, class_name: "Mission::Membership", dependent: :destroy
   has_many :owned_missions,      -> { merge(Mission::Membership.owner_role) },

--- a/app/models/user/notification_preference.rb
+++ b/app/models/user/notification_preference.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: user_notification_preferences
+#
+#  id            :bigint           not null, primary key
+#  category      :string           not null
+#  email_enabled :boolean
+#  slack_enabled :boolean
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  user_id       :bigint           not null
+#
+# Indexes
+#
+#  index_user_notification_preferences_on_user_id               (user_id)
+#  index_user_notification_preferences_on_user_id_and_category  (user_id,category) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id) ON DELETE => cascade
+#
+class User::NotificationPreference < ApplicationRecord
+  self.table_name = "user_notification_preferences"
+
+  belongs_to :user
+
+  validates :category, presence: true, uniqueness: { scope: :user_id }
+end

--- a/app/models/user/preference.rb
+++ b/app/models/user/preference.rb
@@ -2,18 +2,13 @@
 #
 # Table name: user_preferences
 #
-#  id                                       :bigint           not null, primary key
-#  leaderboard_optin                        :boolean          default(FALSE), not null
-#  search_engine_indexing_off               :boolean          default(FALSE), not null
-#  send_notifications_for_followed_projects :boolean          default(TRUE), not null
-#  send_notifications_for_followed_users    :boolean          default(TRUE), not null
-#  send_notifications_for_new_comments      :boolean          default(TRUE), not null
-#  send_notifications_for_new_followers     :boolean          default(TRUE), not null
-#  send_votes_to_slack                      :boolean          default(FALSE), not null
-#  stardust_balance_notifications           :boolean          default(FALSE), not null
-#  created_at                               :datetime         not null
-#  updated_at                               :datetime         not null
-#  user_id                                  :bigint           not null
+#  id                         :bigint           not null, primary key
+#  leaderboard_optin          :boolean          default(FALSE), not null
+#  search_engine_indexing_off :boolean          default(FALSE), not null
+#  send_votes_to_slack        :boolean          default(FALSE), not null
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  user_id                    :bigint           not null
 #
 # Indexes
 #

--- a/app/policies/my_policy.rb
+++ b/app/policies/my_policy.rb
@@ -10,4 +10,20 @@ class MyPolicy < ApplicationPolicy
   def create_dismissal?
     signed_in_any?
   end
+
+  def show_notifications?
+    signed_in_any?
+  end
+
+  def update_notification?
+    signed_in_any?
+  end
+
+  def show_notification_settings?
+    signed_in_any?
+  end
+
+  def update_notification_settings?
+    signed_in_any?
+  end
 end

--- a/app/services/ship_event_payout_calculator.rb
+++ b/app/services/ship_event_payout_calculator.rb
@@ -165,30 +165,27 @@ class ShipEventPayoutCalculator
   end
 
   def notify_payout_issued(user, stardust:, hours:, multiplier:, blessing: "neutral")
-    return unless user.slack_id.present?
-
     project = @ship_event.post&.project
     ship_date = @ship_event.post&.created_at&.strftime("%b %-d, %Y")
     project_title = project&.title || "Ship ##{@ship_event.id}"
 
-    SendSlackDmJob.perform_later(
-      user.slack_id,
-      nil,
-      blocks_path: "notifications/payouts/ship_event_issued",
-      locals: {
-        project_title: project_title,
-        ship_date: ship_date,
-        hours: hours&.round(2),
-        stardust: stardust&.to_i,
-        multiplier: multiplier&.round(2),
-        blessing: blessing
+    Notifications::Payouts::ShipEventIssued.notify(
+      recipient: user,
+      record: @ship_event,
+      params: {
+        "project_title" => project_title,
+        "ship_date"     => ship_date,
+        "hours"         => hours&.round(2),
+        "stardust"      => stardust&.to_i,
+        "multiplier"    => multiplier&.round(2),
+        "blessing"      => blessing
       }
     )
   end
 
   def notify_vote_deficit(user, votes_needed)
-    return unless user.slack_id.present?
     return unless Flipper.enabled?(:voting)
+
     cache_key = "vote_deficit_notified:#{@ship_event.id}"
     return if Rails.cache.exist?(cache_key)
 
@@ -197,14 +194,12 @@ class ShipEventPayoutCalculator
     project = @ship_event.post&.project
     project_title = project&.title
 
-    SendSlackDmJob.perform_later(
-      user.slack_id,
-      nil,
-      blocks_path: "notifications/payouts/vote_deficit_blocked",
-      locals: {
-        ship_event: @ship_event,
-        votes_needed: votes_needed,
-        project_title: project_title
+    Notifications::Payouts::VoteDeficitBlocked.notify(
+      recipient: user,
+      record: @ship_event,
+      params: {
+        "votes_needed"  => votes_needed,
+        "project_title" => project_title
       }
     )
   end

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,13 +1,38 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <style>
-      /* Email styles need to be inline */
-    </style>
+    <meta name="color-scheme" content="light">
+    <meta name="supported-color-schemes" content="light">
+    <title><%= content_for?(:email_title) ? yield(:email_title) : "Stardance" %></title>
   </head>
-
-  <body>
-    <%= yield %>
+  <body style="margin:0;padding:0;background:#f5f3ec;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:#1a1a2e;line-height:1.5;">
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background:#f5f3ec;">
+      <tr>
+        <td align="center" style="padding:32px 16px;">
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width:560px;background:#ffffff;border-radius:12px;border:1px solid #e6e2d6;overflow:hidden;">
+            <tr>
+              <td style="padding:20px 32px;border-bottom:1px solid #f0eddf;">
+                <%= image_tag image_url("landing/header/stardance-logo.png"),
+                              alt: "Hack Club Stardance Challenge",
+                              width: "180",
+                              style: "display:block;height:auto;max-width:180px;border:0;" %>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:28px 32px;color:#1a1a2e;font-size:15px;line-height:1.55;">
+                <%= yield %>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:18px 32px;border-top:1px solid #f0eddf;color:#8e8b81;font-size:12px;line-height:1.5;">
+                You're receiving this notification from Hack Club's Stardance Challenge because you have email notifications enabled.
+                <a href="<%= my_notification_settings_url %>" style="color:#8e8b81;text-decoration:underline;">Manage your preferences here.</a>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
   </body>
 </html>

--- a/app/views/layouts/mailer.text.erb
+++ b/app/views/layouts/mailer.text.erb
@@ -1,1 +1,7 @@
 <%= yield %>
+
+--
+Hack Club's Stardance Challenge
+
+You're receiving this notification because you have email notifications enabled.
+Manage your preferences here: <%= my_notification_settings_url %>

--- a/app/views/my/notification_settings/show.html.erb
+++ b/app/views/my/notification_settings/show.html.erb
@@ -1,0 +1,64 @@
+<% content_for :title, "Notification Settings" %>
+<% @active_nav_slug = "notifications" %>
+
+<main class="notification-settings">
+  <header class="notification-settings__header">
+    <h1 class="notification-settings__title">Notification settings</h1>
+    <p class="notification-settings__hint">
+      The notifications inbox always shows every notification. Use these toggles to also send some categories to Slack or email.
+      Critical alerts are always delivered everywhere and can't be turned off.
+    </p>
+  </header>
+
+  <%= form_with url: my_notification_settings_path, method: :patch, local: true, class: "notification-settings__form", data: { turbo: false } do |f| %>
+    <% @grouped_types.each do |group_name, types| %>
+      <section class="notification-settings__group">
+        <h2 class="notification-settings__group-title"><%= group_name %></h2>
+
+        <table class="notification-settings__matrix">
+          <thead>
+            <tr>
+              <th class="notification-settings__matrix-category">Category</th>
+              <th class="notification-settings__matrix-toggle">Slack</th>
+              <th class="notification-settings__matrix-toggle">Email</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% types.each do |klass| %>
+              <% category = klass.category_key.to_s %>
+              <% pref = @preferences_by_category[category] %>
+              <% priority = klass.default_priority.to_s %>
+              <% defaults = Notification::PRIORITY_CHANNEL_DEFAULTS[priority] %>
+              <% locked = priority == "critical" %>
+              <% slack_checked = locked || (pref&.slack_enabled.nil? ? defaults[:slack] : pref.slack_enabled) %>
+              <% email_checked = locked || (pref&.email_enabled.nil? ? defaults[:email] : pref.email_enabled) %>
+
+              <tr class="notification-settings__row">
+                <td class="notification-settings__cell notification-settings__cell--meta">
+                  <strong class="notification-settings__category-label"><%= klass.category_label %></strong>
+                  <span class="notification-settings__category-description"><%= klass.category_description %></span>
+                </td>
+                <td class="notification-settings__cell notification-settings__cell--toggle">
+                  <%= check_box_tag "preferences[#{category}][slack]", "1", slack_checked, disabled: locked, id: "pref_#{category}_slack" %>
+                  <% if locked %>
+                    <input type="hidden" name="preferences[<%= category %>][slack]" value="1">
+                  <% end %>
+                </td>
+                <td class="notification-settings__cell notification-settings__cell--toggle">
+                  <%= check_box_tag "preferences[#{category}][email]", "1", email_checked, disabled: locked, id: "pref_#{category}_email" %>
+                  <% if locked %>
+                    <input type="hidden" name="preferences[<%= category %>][email]" value="1">
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </section>
+    <% end %>
+
+    <div class="notification-settings__actions">
+      <%= f.submit "Save preferences", class: "notification-settings__submit" %>
+    </div>
+  <% end %>
+</main>

--- a/app/views/my/notifications/index.html.erb
+++ b/app/views/my/notifications/index.html.erb
@@ -1,0 +1,48 @@
+<% content_for :title, "Notifications" %>
+<% @active_nav_slug = "notifications" %>
+
+<div class="app-layout">
+  <main class="app-layout__main notifications-page"
+        data-controller="notifications-inbox"
+        data-notifications-inbox-mark-seen-url-value="<%= mark_all_seen_my_notifications_path %>">
+
+    <header class="notifications-page__header">
+      <h1 class="notifications-page__title">Notifications</h1>
+
+      <div class="notifications-page__actions">
+        <%= button_to "Mark all as read", mark_all_read_my_notifications_path,
+                      method: :post,
+                      class: "notifications-page__action",
+                      disabled: !@has_unread,
+                      form: { data: { turbo: false } } %>
+
+        <%= button_to "Clear all", clear_all_my_notifications_path,
+                      method: :delete,
+                      class: "notifications-page__action notifications-page__action--danger",
+                      disabled: !@has_any_notifications,
+                      data: { turbo_confirm: "Delete all your notifications?" },
+                      form: { data: { turbo: false } } %>
+
+        <%= link_to "Settings", my_notification_settings_path,
+                    class: "notifications-page__action notifications-page__action--ghost" %>
+      </div>
+    </header>
+
+    <ol class="notifications-page__list" data-notifications-inbox-target="list">
+      <% @notifications.each do |notification| %>
+        <%= render "notifications/inbox_row", notification: notification %>
+      <% end %>
+    </ol>
+
+    <div class="notifications-page__empty"
+         data-notifications-inbox-target="empty"
+         <%= "hidden" if @notifications.any? %>>
+      <p class="notifications-page__empty-title">No notifications yet</p>
+      <p class="notifications-page__empty-hint">When someone follows you, comments on your project, or your ship gets reviewed, you'll see it here.</p>
+    </div>
+
+    <%== pagy_nav(@pagy) if @pagy.pages > 1 %>
+  </main>
+
+  <%= render DiscoverRailComponent.new %>
+</div>

--- a/app/views/notification_mailer/followed_devlog_created.html.erb
+++ b/app/views/notification_mailer/followed_devlog_created.html.erb
@@ -1,0 +1,33 @@
+<% project = @record&.post&.project %>
+<% author = @record&.post&.user %>
+<% body = @notification.preview_text %>
+
+<h1 style="margin:0 0 12px;font-size:22px;font-weight:700;line-height:1.3;color:#1a1a2e;">
+  <% if project&.title.present? %>
+    Fresh devlog on <%= project.title %>!
+  <% else %>
+    Fresh devlog on a project you follow!
+  <% end %>
+</h1>
+
+<p style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#3a3a4a;">
+  <% if author && project&.title.present? %>
+    <strong>@<%= author.display_name %></strong> just posted an update on <strong><%= project.title %></strong>.
+  <% elsif project&.title.present? %>
+    A new devlog just landed on <strong><%= project.title %></strong>.
+  <% else %>
+    A project you follow just posted a new devlog.
+  <% end %>
+</p>
+
+<% if body.present? %>
+  <blockquote style="margin:0 0 24px;padding:14px 18px;background:#faf8ef;border-left:3px solid #d9d5c5;color:#3a3a4a;font-size:15px;line-height:1.55;border-radius:4px;">
+    <%= body %>
+  </blockquote>
+<% end %>
+
+<% if project %>
+  <div style="margin:24px 0 4px;">
+    <a href="<%= project_url(project) %>" style="display:inline-block;padding:11px 22px;background:#1a1a2e;color:#ffffff;text-decoration:none;border-radius:999px;font-weight:600;font-size:14px;line-height:1;">Read devlog</a>
+  </div>
+<% end %>

--- a/app/views/notification_mailer/followed_devlog_created.text.erb
+++ b/app/views/notification_mailer/followed_devlog_created.text.erb
@@ -1,0 +1,21 @@
+<% project = @record&.post&.project %>
+<% author = @record&.post&.user %>
+<% body = @notification.preview_text %>
+
+<% if project&.title.present? %>Fresh devlog on <%= project.title %>!<% else %>Fresh devlog on a project you follow!<% end %>
+
+<% if author && project&.title.present? %>
+@<%= author.display_name %> just posted an update on "<%= project.title %>".
+<% elsif project&.title.present? %>
+A new devlog just landed on "<%= project.title %>".
+<% else %>
+A project you follow just posted a new devlog.
+<% end %>
+
+<% if body.present? %>
+<%= body %>
+
+<% end %>
+<% if project %>
+Read devlog: <%= project_url(project) %>
+<% end %>

--- a/app/views/notification_mailer/new_follower.html.erb
+++ b/app/views/notification_mailer/new_follower.html.erb
@@ -1,0 +1,16 @@
+<h1 style="margin:0 0 12px;font-size:22px;font-weight:700;line-height:1.3;color:#1a1a2e;">You have a new follower!</h1>
+
+<p style="margin:0 0 20px;font-size:15px;line-height:1.55;color:#3a3a4a;">
+  <% if @actor %>
+    <strong>@<%= @actor.display_name %></strong> just started following you on Stardance.
+    Your devlogs and ship events will land in their feed from now on.
+  <% else %>
+    Someone just started following you on Stardance. Keep shipping — they'll be watching.
+  <% end %>
+</p>
+
+<% if @actor %>
+  <div style="margin:24px 0 4px;">
+    <a href="<%= user_url(@actor) %>" style="display:inline-block;padding:11px 22px;background:#1a1a2e;color:#ffffff;text-decoration:none;border-radius:999px;font-weight:600;font-size:14px;line-height:1;">View @<%= @actor.display_name %>'s profile</a>
+  </div>
+<% end %>

--- a/app/views/notification_mailer/new_follower.text.erb
+++ b/app/views/notification_mailer/new_follower.text.erb
@@ -1,0 +1,11 @@
+You have a new follower!
+
+<% if @actor %>
+@<%= @actor.display_name %> just started following you on Stardance. Your devlogs and ship events will land in their feed from now on.
+
+View their profile: <%= user_url(@actor) %>
+<% else %>
+Someone just started following you on Stardance. Keep shipping — they'll be watching.
+
+Open your inbox: <%= my_notifications_url %>
+<% end %>

--- a/app/views/notification_mailer/project_comment_received.html.erb
+++ b/app/views/notification_mailer/project_comment_received.html.erb
@@ -1,0 +1,25 @@
+<% comment = @record %>
+<% project = comment&.commentable.respond_to?(:post) ? comment.commentable.post&.project : nil %>
+<% body = @notification.preview_text %>
+
+<h1 style="margin:0 0 12px;font-size:22px;font-weight:700;line-height:1.3;color:#1a1a2e;">
+  <% if @actor && project&.title.present? %>
+    @<%= @actor.display_name %> just commented on <%= project.title %>!
+  <% elsif project&.title.present? %>
+    New comment on <%= project.title %>!
+  <% else %>
+    Someone just commented on your project!
+  <% end %>
+</h1>
+
+<% if body.present? %>
+  <blockquote style="margin:0 0 24px;padding:14px 18px;background:#faf8ef;border-left:3px solid #d9d5c5;color:#3a3a4a;font-size:15px;line-height:1.55;border-radius:4px;">
+    <%= body %>
+  </blockquote>
+<% end %>
+
+<% if project %>
+  <div style="margin:24px 0 4px;">
+    <a href="<%= project_url(project) %>" style="display:inline-block;padding:11px 22px;background:#1a1a2e;color:#ffffff;text-decoration:none;border-radius:999px;font-weight:600;font-size:14px;line-height:1;">Reply</a>
+  </div>
+<% end %>

--- a/app/views/notification_mailer/project_comment_received.text.erb
+++ b/app/views/notification_mailer/project_comment_received.text.erb
@@ -1,0 +1,13 @@
+<% comment = @record %>
+<% project = comment&.commentable.respond_to?(:post) ? comment.commentable.post&.project : nil %>
+<% body = @notification.preview_text %>
+
+<% if @actor && project&.title.present? %>@<%= @actor.display_name %> just commented on <%= project.title %>!<% elsif project&.title.present? %>New comment on <%= project.title %>!<% else %>Someone just commented on your project!<% end %>
+
+<% if body.present? %>
+<%= body %>
+
+<% end %>
+<% if project %>
+Reply: <%= project_url(project) %>
+<% end %>

--- a/app/views/notification_mailer/project_followed.html.erb
+++ b/app/views/notification_mailer/project_followed.html.erb
@@ -1,0 +1,22 @@
+<% project = @record %>
+
+<h1 style="margin:0 0 12px;font-size:22px;font-weight:700;line-height:1.3;color:#1a1a2e;">
+  Your project has a new follower!
+</h1>
+
+<p style="margin:0 0 20px;font-size:15px;line-height:1.55;color:#3a3a4a;">
+  <% if @actor && project&.title.present? %>
+    <strong>@<%= @actor.display_name %></strong> just started following <strong><%= project.title %></strong>.
+    They'll see your devlogs and ship events in their feed.
+  <% elsif project&.title.present? %>
+    Someone just started following <strong><%= project.title %></strong>.
+  <% else %>
+    A new follower jumped onto one of your projects.
+  <% end %>
+</p>
+
+<% if project %>
+  <div style="margin:24px 0 4px;">
+    <a href="<%= project_url(project) %>" style="display:inline-block;padding:11px 22px;background:#1a1a2e;color:#ffffff;text-decoration:none;border-radius:999px;font-weight:600;font-size:14px;line-height:1;">View project</a>
+  </div>
+<% end %>

--- a/app/views/notification_mailer/project_followed.text.erb
+++ b/app/views/notification_mailer/project_followed.text.erb
@@ -1,0 +1,15 @@
+<% project = @record %>
+
+Your project has a new follower!
+
+<% if @actor && project&.title.present? %>
+@<%= @actor.display_name %> just started following "<%= project.title %>". They'll see your devlogs and ship events in their feed.
+<% elsif project&.title.present? %>
+Someone just started following "<%= project.title %>".
+<% else %>
+A new follower jumped onto one of your projects.
+<% end %>
+
+<% if project %>
+View project: <%= project_url(project) %>
+<% end %>

--- a/app/views/notification_mailer/ship_event_issued.html.erb
+++ b/app/views/notification_mailer/ship_event_issued.html.erb
@@ -1,0 +1,49 @@
+<% project_title = @notification.params["project_title"] %>
+<% stardust = @notification.params["stardust"] %>
+<% hours = @notification.params["hours"] %>
+<% multiplier = @notification.params["multiplier"] %>
+<% ship_date = @notification.params["ship_date"] %>
+<% blessing = @notification.params["blessing"] %>
+
+<h1 style="margin:0 0 12px;font-size:22px;font-weight:700;line-height:1.3;color:#1a1a2e;">
+  Payout issued!
+</h1>
+
+<p style="margin:0 0 20px;font-size:15px;line-height:1.55;color:#3a3a4a;">
+  Thanks for shipping.
+  <% if stardust.present? %>
+    <strong><%= stardust %> stardust</strong> just landed on your balance
+  <% else %>
+    Your ship event payout just hit your balance
+  <% end %>
+  <% if project_title.present? %>for <strong><%= project_title %></strong><% end %>.
+</p>
+
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin:0 0 24px;border-collapse:separate;border-spacing:0;background:#faf8ef;border-radius:6px;">
+  <% if ship_date.present? %>
+    <tr><td style="padding:10px 16px;font-size:13px;color:#6b6961;width:120px;">Ship date</td><td style="padding:10px 16px;font-size:13px;color:#1a1a2e;font-weight:600;"><%= ship_date %></td></tr>
+  <% end %>
+  <% if hours.present? %>
+    <tr><td style="padding:10px 16px;font-size:13px;color:#6b6961;border-top:1px solid #efece0;">Hours</td><td style="padding:10px 16px;font-size:13px;color:#1a1a2e;font-weight:600;border-top:1px solid #efece0;"><%= hours %></td></tr>
+  <% end %>
+  <% if multiplier.present? %>
+    <tr><td style="padding:10px 16px;font-size:13px;color:#6b6961;border-top:1px solid #efece0;">Multiplier</td><td style="padding:10px 16px;font-size:13px;color:#1a1a2e;font-weight:600;border-top:1px solid #efece0;"><%= multiplier %> stardust/hr</td></tr>
+  <% end %>
+  <% if stardust.present? %>
+    <tr><td style="padding:10px 16px;font-size:13px;color:#6b6961;border-top:1px solid #efece0;">Stardust</td><td style="padding:10px 16px;font-size:13px;color:#1a1a2e;font-weight:700;border-top:1px solid #efece0;"><%= stardust %></td></tr>
+  <% end %>
+</table>
+
+<% if blessing == "blessed" %>
+  <p style="margin:0 0 20px;padding:12px 16px;background:#eaf6e9;border-radius:6px;font-size:14px;color:#2a5c2a;">
+    You're blessed — payout includes a 20% bonus for great feedback. Keep it up.
+  </p>
+<% elsif blessing == "cursed" %>
+  <p style="margin:0 0 20px;padding:12px 16px;background:#f7e7e4;border-radius:6px;font-size:14px;color:#7a3b32;">
+    You're cursed — payout reduced by 50%. Write more detailed feedback during voting (read demos, explain reasoning) to lift the curse.
+  </p>
+<% end %>
+
+<div style="margin:24px 0 4px;">
+  <a href="<%= my_balance_url %>" style="display:inline-block;padding:11px 22px;background:#1a1a2e;color:#ffffff;text-decoration:none;border-radius:999px;font-weight:600;font-size:14px;line-height:1;">View balance</a>
+</div>

--- a/app/views/notification_mailer/ship_event_issued.text.erb
+++ b/app/views/notification_mailer/ship_event_issued.text.erb
@@ -1,0 +1,24 @@
+<% project_title = @notification.params["project_title"] %>
+<% stardust = @notification.params["stardust"] %>
+<% hours = @notification.params["hours"] %>
+<% multiplier = @notification.params["multiplier"] %>
+<% ship_date = @notification.params["ship_date"] %>
+<% blessing = @notification.params["blessing"] %>
+
+Payout issued!
+
+Thanks for shipping. <% if stardust.present? %><%= stardust %> stardust<% else %>Your ship event payout<% end %> just landed on your balance<% if project_title.present? %> for "<%= project_title %>"<% end %>.
+
+<% if ship_date.present? %>Ship date: <%= ship_date %>
+<% end %><% if hours.present? %>Hours: <%= hours %>
+<% end %><% if multiplier.present? %>Multiplier: <%= multiplier %> stardust/hr
+<% end %><% if stardust.present? %>Stardust: <%= stardust %>
+<% end %>
+
+<% if blessing == "blessed" %>
+You're blessed — payout includes a 20% bonus for great feedback.
+<% elsif blessing == "cursed" %>
+You're cursed — payout reduced by 50%. Write more detailed feedback during voting to lift the curse.
+<% end %>
+
+View balance: <%= my_balance_url %>

--- a/app/views/notification_mailer/stardust_balance_changed.html.erb
+++ b/app/views/notification_mailer/stardust_balance_changed.html.erb
@@ -1,0 +1,23 @@
+<% amount = @notification.params["amount"].to_i %>
+<% source = @notification.params["source"] %>
+<% signed = amount.positive? ? "+#{amount}" : amount.to_s %>
+
+<h1 style="margin:0 0 12px;font-size:22px;font-weight:700;line-height:1.3;color:#1a1a2e;">
+  <% if amount.positive? %>
+    <%= signed %> stardust just hit your balance!
+  <% else %>
+    <%= signed %> stardust adjustment to your balance
+  <% end %>
+</h1>
+
+<p style="margin:0 0 24px;font-size:15px;line-height:1.55;color:#3a3a4a;">
+  <% if amount.positive? %>
+    You earned <strong><%= signed %> stardust</strong><% if source.present? %> from <strong><%= source %></strong><% end %>. Spend it in the shop or save it for something big.
+  <% else %>
+    Your balance changed by <strong><%= signed %></strong><% if source.present? %> (<%= source %>)<% end %>.
+  <% end %>
+</p>
+
+<div style="margin:24px 0 4px;">
+  <a href="<%= my_balance_url %>" style="display:inline-block;padding:11px 22px;background:#1a1a2e;color:#ffffff;text-decoration:none;border-radius:999px;font-weight:600;font-size:14px;line-height:1;">View balance history</a>
+</div>

--- a/app/views/notification_mailer/stardust_balance_changed.text.erb
+++ b/app/views/notification_mailer/stardust_balance_changed.text.erb
@@ -1,0 +1,9 @@
+<% amount = @notification.params["amount"].to_i %>
+<% source = @notification.params["source"] %>
+<% signed = amount.positive? ? "+#{amount}" : amount.to_s %>
+
+<% if amount.positive? %><%= signed %> stardust just hit your balance!<% else %><%= signed %> stardust adjustment to your balance<% end %>
+
+<% if amount.positive? %>You earned <%= signed %> stardust<% if source.present? %> from <%= source %><% end %>. Spend it in the shop or save it for something big.<% else %>Your balance changed by <%= signed %><% if source.present? %> (<%= source %>)<% end %>.<% end %>
+
+View balance history: <%= my_balance_url %>

--- a/app/views/notification_mailer/status_changed.html.erb
+++ b/app/views/notification_mailer/status_changed.html.erb
@@ -1,0 +1,34 @@
+<% state = @notification.params["state"].to_s %>
+<% item = @record&.shop_item&.name %>
+<% headline = @notification.headline %>
+
+<% guidance_by_state = {
+  "awaiting_verification"      => "Send the required verification materials so we can release your order.",
+  "awaiting_verification_call" => "Schedule the verification call linked from your order page so we can release your order.",
+  "awaiting_periodical_fulfillment" => "We'll ship this in the next batch — no action needed from you.",
+  "fulfilled" => "Tracking and shipment details (where applicable) are on the order page.",
+  "rejected"  => "If you think this is a mistake, reply in the shop support thread."
+} %>
+<% guidance = guidance_by_state[state] %>
+
+<h1 style="margin:0 0 12px;font-size:22px;font-weight:700;line-height:1.3;color:#1a1a2e;">
+  Your order <%= headline %>
+</h1>
+
+<p style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#3a3a4a;">
+  <% if item.present? %>
+    Your order for <strong><%= item %></strong> <%= headline %>.
+  <% else %>
+    Your shop order <%= headline %>.
+  <% end %>
+</p>
+
+<% if guidance %>
+  <p style="margin:0 0 24px;font-size:15px;line-height:1.55;color:#3a3a4a;">
+    <%= guidance %>
+  </p>
+<% end %>
+
+<div style="margin:24px 0 4px;">
+  <a href="<%= shop_my_orders_url %>" style="display:inline-block;padding:11px 22px;background:#1a1a2e;color:#ffffff;text-decoration:none;border-radius:999px;font-weight:600;font-size:14px;line-height:1;">View my orders</a>
+</div>

--- a/app/views/notification_mailer/status_changed.text.erb
+++ b/app/views/notification_mailer/status_changed.text.erb
@@ -1,0 +1,26 @@
+<% state = @notification.params["state"].to_s %>
+<% item = @record&.shop_item&.name %>
+<% headline = @notification.headline %>
+
+<% guidance_by_state = {
+  "awaiting_verification"      => "Send the required verification materials so we can release your order.",
+  "awaiting_verification_call" => "Schedule the verification call linked from your order page so we can release your order.",
+  "awaiting_periodical_fulfillment" => "We'll ship this in the next batch — no action needed from you.",
+  "fulfilled" => "Tracking and shipment details (where applicable) are on the order page.",
+  "rejected"  => "If you think this is a mistake, reply in the shop support thread."
+} %>
+<% guidance = guidance_by_state[state] %>
+
+Your order <%= headline %>
+
+<% if item.present? %>
+Your order for "<%= item %>" <%= headline %>.
+<% else %>
+Your shop order <%= headline %>.
+<% end %>
+
+<% if guidance %>
+<%= guidance %>
+
+<% end %>
+View my orders: <%= shop_my_orders_url %>

--- a/app/views/notification_mailer/submission_approved.html.erb
+++ b/app/views/notification_mailer/submission_approved.html.erb
@@ -1,0 +1,27 @@
+<% mission_name = @record&.mission&.name %>
+<% project_title = @record&.ship_event&.post&.project&.title %>
+<% reviewer = @record&.reviewed_by %>
+
+<h1 style="margin:0 0 12px;font-size:22px;font-weight:700;line-height:1.3;color:#1a1a2e;">Your submission was approved!</h1>
+
+<p style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#3a3a4a;">
+  Nice work.
+  <% if mission_name && project_title %>
+    Your submission for <strong><%= mission_name %></strong> on <strong><%= project_title %></strong> just passed review<% if reviewer %>, courtesy of <strong>@<%= reviewer.display_name %></strong><% end %>.
+  <% elsif mission_name %>
+    Your submission for <strong><%= mission_name %></strong> just passed review<% if reviewer %>, courtesy of <strong>@<%= reviewer.display_name %></strong><% end %>.
+  <% else %>
+    Your mission submission just passed review.
+  <% end %>
+</p>
+
+<p style="margin:0 0 24px;font-size:15px;line-height:1.55;color:#3a3a4a;">
+  Stardust is on the way to your balance. Cast any pending votes to unlock it.
+</p>
+
+<% if @record %>
+  <div style="margin:24px 0 4px;">
+    <a href="<%= mission_submission_url(@record) %>" style="display:inline-block;padding:11px 22px;background:#1a1a2e;color:#ffffff;text-decoration:none;border-radius:999px;font-weight:600;font-size:14px;line-height:1;">View submission</a>
+    <a href="<%= my_balance_url %>" style="display:inline-block;padding:11px 22px;background:#ffffff;color:#1a1a2e;text-decoration:none;border:1px solid #d9d5c5;border-radius:999px;font-weight:600;font-size:14px;line-height:1;margin-left:6px;">View balance</a>
+  </div>
+<% end %>

--- a/app/views/notification_mailer/submission_approved.text.erb
+++ b/app/views/notification_mailer/submission_approved.text.erb
@@ -1,0 +1,14 @@
+<% mission_name = @record&.mission&.name %>
+<% project_title = @record&.ship_event&.post&.project&.title %>
+<% reviewer = @record&.reviewed_by %>
+
+Your submission was approved!
+
+Nice work. <% if mission_name && project_title %>Your submission for "<%= mission_name %>" on "<%= project_title %>" just passed review<% if reviewer %>, courtesy of @<%= reviewer.display_name %><% end %>.<% elsif mission_name %>Your submission for "<%= mission_name %>" just passed review<% if reviewer %>, courtesy of @<%= reviewer.display_name %><% end %>.<% else %>Your mission submission just passed review.<% end %>
+
+Stardust is on the way to your balance. Cast any pending votes to unlock it.
+
+<% if @record %>
+View submission: <%= mission_submission_url(@record) %>
+View balance: <%= my_balance_url %>
+<% end %>

--- a/app/views/notification_mailer/submission_pending_for_reviewer.html.erb
+++ b/app/views/notification_mailer/submission_pending_for_reviewer.html.erb
@@ -1,0 +1,24 @@
+<% mission_name = @record&.mission&.name %>
+<% project_title = @record&.ship_event&.post&.project&.title %>
+<% builder = @actor || @record&.ship_event&.post&.user %>
+
+<h1 style="margin:0 0 12px;font-size:22px;font-weight:700;line-height:1.3;color:#1a1a2e;">
+  Ready for your review!
+</h1>
+
+<p style="margin:0 0 20px;font-size:15px;line-height:1.55;color:#3a3a4a;">
+  <% if builder && project_title.present? %>
+    <strong>@<%= builder.display_name %></strong> just submitted <strong><%= project_title %></strong><% if mission_name %> for <strong><%= mission_name %></strong><% end %> and needs a reviewer.
+  <% elsif builder %>
+    <strong>@<%= builder.display_name %></strong> just submitted a ship event<% if mission_name %> for <strong><%= mission_name %></strong><% end %> and needs a reviewer.
+  <% else %>
+    A new submission<% if mission_name %> for <strong><%= mission_name %></strong><% end %> is waiting for a reviewer.
+  <% end %>
+  Approve, request revisions, or reject — payout's on hold until you do.
+</p>
+
+<% if @record %>
+  <div style="margin:24px 0 4px;">
+    <a href="<%= mission_submission_url(@record) %>" style="display:inline-block;padding:11px 22px;background:#1a1a2e;color:#ffffff;text-decoration:none;border-radius:999px;font-weight:600;font-size:14px;line-height:1;">Review submission</a>
+  </div>
+<% end %>

--- a/app/views/notification_mailer/submission_pending_for_reviewer.text.erb
+++ b/app/views/notification_mailer/submission_pending_for_reviewer.text.erb
@@ -1,0 +1,13 @@
+<% mission_name = @record&.mission&.name %>
+<% project_title = @record&.ship_event&.post&.project&.title %>
+<% builder = @actor || @record&.ship_event&.post&.user %>
+
+Ready for your review!
+
+<% if builder && project_title.present? %>@<%= builder.display_name %> just submitted "<%= project_title %>"<% if mission_name %> for <%= mission_name %><% end %> and needs a reviewer.<% elsif builder %>@<%= builder.display_name %> just submitted a ship event<% if mission_name %> for <%= mission_name %><% end %> and needs a reviewer.<% else %>A new submission<% if mission_name %> for <%= mission_name %><% end %> is waiting for a reviewer.<% end %>
+
+Approve, request revisions, or reject — payout's on hold until you do.
+
+<% if @record %>
+Review submission: <%= mission_submission_url(@record) %>
+<% end %>

--- a/app/views/notification_mailer/submission_rejected.html.erb
+++ b/app/views/notification_mailer/submission_rejected.html.erb
@@ -1,0 +1,33 @@
+<% mission_name = @record&.mission&.name %>
+<% project_title = @record&.ship_event&.post&.project&.title %>
+<% reviewer = @record&.reviewed_by %>
+<% feedback = @record&.rejection_message %>
+
+<h1 style="margin:0 0 12px;font-size:22px;font-weight:700;line-height:1.3;color:#1a1a2e;">Your submission needs revisions</h1>
+
+<p style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#3a3a4a;">
+  <% if mission_name && project_title %>
+    Your submission for <strong><%= mission_name %></strong> on <strong><%= project_title %></strong> was sent back<% if reviewer %> by <strong>@<%= reviewer.display_name %></strong><% end %> for revisions.
+  <% elsif mission_name %>
+    Your submission for <strong><%= mission_name %></strong> was sent back<% if reviewer %> by <strong>@<%= reviewer.display_name %></strong><% end %> for revisions.
+  <% else %>
+    Your mission submission was sent back for revisions.
+  <% end %>
+</p>
+
+<% if feedback.present? %>
+  <p style="margin:0 0 8px;font-size:13px;font-weight:600;color:#6b6961;text-transform:uppercase;letter-spacing:0.06em;">Reviewer feedback</p>
+  <blockquote style="margin:0 0 24px;padding:14px 18px;background:#faf8ef;border-left:3px solid #d9d5c5;color:#3a3a4a;font-size:15px;line-height:1.55;border-radius:4px;">
+    <%= simple_format(feedback) %>
+  </blockquote>
+<% end %>
+
+<p style="margin:0 0 20px;font-size:15px;line-height:1.55;color:#3a3a4a;">
+  Address the feedback above and re-submit when you're ready.
+</p>
+
+<% if @record %>
+  <div style="margin:24px 0 4px;">
+    <a href="<%= mission_submission_url(@record) %>" style="display:inline-block;padding:11px 22px;background:#1a1a2e;color:#ffffff;text-decoration:none;border-radius:999px;font-weight:600;font-size:14px;line-height:1;">View submission</a>
+  </div>
+<% end %>

--- a/app/views/notification_mailer/submission_rejected.text.erb
+++ b/app/views/notification_mailer/submission_rejected.text.erb
@@ -1,0 +1,25 @@
+<% mission_name = @record&.mission&.name %>
+<% project_title = @record&.ship_event&.post&.project&.title %>
+<% reviewer = @record&.reviewed_by %>
+<% feedback = @record&.rejection_message %>
+
+Your submission needs revisions
+
+<% if mission_name && project_title %>
+Your submission for "<%= mission_name %>" on "<%= project_title %>" was sent back<% if reviewer %> by @<%= reviewer.display_name %><% end %> for revisions.
+<% elsif mission_name %>
+Your submission for "<%= mission_name %>" was sent back<% if reviewer %> by @<%= reviewer.display_name %><% end %> for revisions.
+<% else %>
+Your mission submission was sent back for revisions.
+<% end %>
+
+<% if feedback.present? %>
+Reviewer feedback:
+<%= feedback %>
+
+<% end %>
+Address the feedback above and re-submit when you're ready.
+
+<% if @record %>
+View submission: <%= mission_submission_url(@record) %>
+<% end %>

--- a/app/views/notification_mailer/super_star.html.erb
+++ b/app/views/notification_mailer/super_star.html.erb
@@ -1,0 +1,27 @@
+<% project_title = @record&.title %>
+
+<h1 style="margin:0 0 12px;font-size:22px;font-weight:700;line-height:1.3;color:#1a1a2e;">
+  <% if project_title.present? %>
+    <%= project_title %> is a Super Star!
+  <% else %>
+    Your project is a Super Star!
+  <% end %>
+</h1>
+
+<p style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#3a3a4a;">
+  <% if @actor && project_title.present? %>
+    <strong>@<%= @actor.display_name %></strong> marked <strong><%= project_title %></strong> as a Super Star — a recognition saved for projects with exceptional craft, polish, or ambition.
+  <% else %>
+    Your project was just marked a Super Star — a recognition saved for exceptional work.
+  <% end %>
+</p>
+
+<p style="margin:0 0 24px;font-size:15px;line-height:1.55;color:#3a3a4a;">
+  As thanks, a bonus prize is on its way to your shipping address.
+</p>
+
+<% if @record %>
+  <div style="margin:24px 0 4px;">
+    <a href="<%= project_url(@record) %>" style="display:inline-block;padding:11px 22px;background:#1a1a2e;color:#ffffff;text-decoration:none;border-radius:999px;font-weight:600;font-size:14px;line-height:1;">View project</a>
+  </div>
+<% end %>

--- a/app/views/notification_mailer/super_star.text.erb
+++ b/app/views/notification_mailer/super_star.text.erb
@@ -1,0 +1,15 @@
+<% project_title = @record&.title %>
+
+<% if project_title.present? %><%= project_title %> is a Super Star!<% else %>Your project is a Super Star!<% end %>
+
+<% if @actor && project_title.present? %>
+@<%= @actor.display_name %> marked "<%= project_title %>" as a Super Star — a recognition saved for projects with exceptional craft, polish, or ambition.
+<% else %>
+Your project was just marked a Super Star — a recognition saved for exceptional work.
+<% end %>
+
+As thanks, a bonus prize is on its way to your shipping address.
+
+<% if @record %>
+View project: <%= project_url(@record) %>
+<% end %>

--- a/app/views/notification_mailer/vote_deficit_blocked.html.erb
+++ b/app/views/notification_mailer/vote_deficit_blocked.html.erb
@@ -1,0 +1,29 @@
+<% votes_needed = @notification.params["votes_needed"].to_i %>
+<% project_title = @notification.params["project_title"] %>
+<% ship_date = @record.respond_to?(:post) ? @record.post&.created_at&.strftime("%b %-d, %Y") : nil %>
+
+<h1 style="margin:0 0 12px;font-size:22px;font-weight:700;line-height:1.3;color:#1a1a2e;">
+  Payout blocked — vote deficit
+</h1>
+
+<p style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#3a3a4a;">
+  Your payout for
+  <% if project_title.present? %><strong><%= project_title %></strong><% else %>your ship event<% end %><%= " (shipped #{ship_date})" if ship_date %>
+  is blocked because you're in a vote deficit.
+</p>
+
+<p style="margin:0 0 20px;font-size:15px;line-height:1.55;color:#3a3a4a;">
+  <% if votes_needed.positive? %>
+    You need to cast <strong><%= pluralize(votes_needed, "more vote") %></strong> before your payout will be issued.
+  <% else %>
+    Cast more votes to clear the deficit and unblock your payout.
+  <% end %>
+</p>
+
+<p style="margin:0 0 24px;font-size:14px;line-height:1.55;color:#6b6961;">
+  Every ship event you submit drops your vote balance by 15. Every vote you cast adds 1 back. Keep voting to maintain a positive balance.
+</p>
+
+<div style="margin:24px 0 4px;">
+  <a href="<%= new_vote_url %>" style="display:inline-block;padding:11px 22px;background:#1a1a2e;color:#ffffff;text-decoration:none;border-radius:999px;font-weight:600;font-size:14px;line-height:1;">Vote on projects</a>
+</div>

--- a/app/views/notification_mailer/vote_deficit_blocked.text.erb
+++ b/app/views/notification_mailer/vote_deficit_blocked.text.erb
@@ -1,0 +1,13 @@
+<% votes_needed = @notification.params["votes_needed"].to_i %>
+<% project_title = @notification.params["project_title"] %>
+<% ship_date = @record.respond_to?(:post) ? @record.post&.created_at&.strftime("%b %-d, %Y") : nil %>
+
+Payout blocked — vote deficit
+
+Your payout for <% if project_title.present? %>"<%= project_title %>"<% else %>your ship event<% end %><%= " (shipped #{ship_date})" if ship_date %> is blocked because you're in a vote deficit.
+
+<% if votes_needed.positive? %>You need to cast <%= pluralize(votes_needed, "more vote") %> before your payout will be issued.<% else %>Cast more votes to clear the deficit and unblock your payout.<% end %>
+
+Every ship event you submit drops your vote balance by 15. Every vote you cast adds 1 back. Keep voting to maintain a positive balance.
+
+Vote on projects: <%= new_vote_url %>

--- a/app/views/notifications/_inbox_row.html.erb
+++ b/app/views/notifications/_inbox_row.html.erb
@@ -1,0 +1,1 @@
+<%= render Notifications::ItemComponent.new(notification: notification) %>

--- a/app/views/notifications/inbox/_followed_devlog_created.html.erb
+++ b/app/views/notifications/inbox/_followed_devlog_created.html.erb
@@ -1,0 +1,11 @@
+<% if notification.actor %>
+  <%= link_to "@#{notification.actor.display_name}", user_path(notification.actor), class: "notifications-item__actor" %>
+<% else %>
+  <span class="notifications-item__actor">Someone</span>
+<% end %>
+<span class="notifications-item__verb"> posted a devlog</span>
+<% project = notification.record&.post&.project %>
+<% if project %>
+  <span class="notifications-item__verb">on</span>
+  <%= link_to project.title, project_path(project), class: "notifications-item__actor" %>
+<% end %>

--- a/app/views/notifications/inbox/_new_follower.html.erb
+++ b/app/views/notifications/inbox/_new_follower.html.erb
@@ -1,0 +1,10 @@
+<% if notification.actor %>
+  <%= link_to "@#{notification.actor.display_name}", user_path(notification.actor), class: "notifications-item__actor" %>
+<% else %>
+  <span class="notifications-item__actor">Someone</span>
+<% end %>
+<% others = notification.group_count.to_i - 1 %>
+<% if others > 0 %>
+  <span class="notifications-item__verb"> and</span> <strong><%= pluralize(others, "other") %></strong>
+<% end %>
+<span class="notifications-item__verb"> followed you</span>

--- a/app/views/notifications/inbox/_project_comment_received.html.erb
+++ b/app/views/notifications/inbox/_project_comment_received.html.erb
@@ -1,0 +1,16 @@
+<% if notification.actor %>
+  <%= link_to "@#{notification.actor.display_name}", user_path(notification.actor), class: "notifications-item__actor" %>
+<% else %>
+  <span class="notifications-item__actor">Someone</span>
+<% end %>
+<% others = notification.group_count.to_i - 1 %>
+<% if others > 0 %>
+  <span class="notifications-item__verb"> and</span> <strong><%= pluralize(others, "other") %></strong>
+<% end %>
+<span class="notifications-item__verb"> commented on</span>
+<% project = notification.record&.commentable.respond_to?(:post) ? notification.record.commentable.post&.project : nil %>
+<% if project %>
+  <%= link_to project.title, project_path(project), class: "notifications-item__actor" %>
+<% else %>
+  <span class="notifications-item__verb">your project</span>
+<% end %>

--- a/app/views/notifications/inbox/_project_followed.html.erb
+++ b/app/views/notifications/inbox/_project_followed.html.erb
@@ -1,0 +1,15 @@
+<% if notification.actor %>
+  <%= link_to "@#{notification.actor.display_name}", user_path(notification.actor), class: "notifications-item__actor" %>
+<% else %>
+  <span class="notifications-item__actor">Someone</span>
+<% end %>
+<% others = notification.group_count.to_i - 1 %>
+<% if others > 0 %>
+  <span class="notifications-item__verb"> and</span> <strong><%= pluralize(others, "other") %></strong>
+<% end %>
+<span class="notifications-item__verb"> started following</span>
+<% if notification.record %>
+  <%= link_to notification.record.title, project_path(notification.record), class: "notifications-item__actor" %>
+<% else %>
+  <span class="notifications-item__verb">a project</span>
+<% end %>

--- a/app/views/notifications/inbox/_ship_event_issued.html.erb
+++ b/app/views/notifications/inbox/_ship_event_issued.html.erb
@@ -1,0 +1,6 @@
+<span class="notifications-item__verb">Payout issued:</span>
+<strong><%= notification.params["stardust"] %> stardust</strong>
+<% if notification.params["project_title"].present? %>
+  <span class="notifications-item__verb">for</span>
+  <span class="notifications-item__actor"><%= notification.params["project_title"] %></span>
+<% end %>

--- a/app/views/notifications/inbox/_stardust_balance_changed.html.erb
+++ b/app/views/notifications/inbox/_stardust_balance_changed.html.erb
@@ -1,0 +1,10 @@
+<% amount = notification.params["amount"].to_i %>
+<% source = notification.params["source"] %>
+<% if amount.positive? %>
+  <span class="notifications-item__verb">You earned</span> <strong>+<%= amount %> stardust</strong>
+<% else %>
+  <strong><%= amount %> stardust</strong> <span class="notifications-item__verb">deducted</span>
+<% end %>
+<% if source.present? %>
+  <span class="notifications-item__verb">(<%= source %>)</span>
+<% end %>

--- a/app/views/notifications/inbox/_status_changed.html.erb
+++ b/app/views/notifications/inbox/_status_changed.html.erb
@@ -1,0 +1,8 @@
+<span class="notifications-item__verb">Your shop order</span>
+<strong><%= notification.headline %></strong>
+<% if notification.record %>
+  <span class="notifications-item__verb">—</span>
+  <%= link_to notification.record.shop_item&.name || "order ##{notification.record.id}",
+                 shop_my_orders_path,
+                 class: "notifications-item__actor" %>
+<% end %>

--- a/app/views/notifications/inbox/_submission_approved.html.erb
+++ b/app/views/notifications/inbox/_submission_approved.html.erb
@@ -1,0 +1,6 @@
+<span class="notifications-item__verb">Your mission submission was</span>
+<strong>approved</strong>
+<% if notification.record && notification.record.mission %>
+  <span class="notifications-item__verb">—</span>
+  <%= link_to notification.record.mission.name, mission_path(notification.record.mission), class: "notifications-item__actor" %>
+<% end %>

--- a/app/views/notifications/inbox/_submission_pending_for_reviewer.html.erb
+++ b/app/views/notifications/inbox/_submission_pending_for_reviewer.html.erb
@@ -1,0 +1,10 @@
+<% if notification.actor %>
+  <%= link_to "@#{notification.actor.display_name}", user_path(notification.actor), class: "notifications-item__actor" %>
+<% else %>
+  <span class="notifications-item__actor">A builder</span>
+<% end %>
+<span class="notifications-item__verb"> submitted a ship event for your review</span>
+<% if notification.record && notification.record.mission %>
+  <span class="notifications-item__verb">on</span>
+  <%= link_to notification.record.mission.name, mission_path(notification.record.mission), class: "notifications-item__actor" %>
+<% end %>

--- a/app/views/notifications/inbox/_submission_rejected.html.erb
+++ b/app/views/notifications/inbox/_submission_rejected.html.erb
@@ -1,0 +1,6 @@
+<span class="notifications-item__verb">Your mission submission</span>
+<strong>needs another look</strong>
+<% if notification.record && notification.record.mission %>
+  <span class="notifications-item__verb">—</span>
+  <%= link_to notification.record.mission.name, mission_path(notification.record.mission), class: "notifications-item__actor" %>
+<% end %>

--- a/app/views/notifications/inbox/_super_star.html.erb
+++ b/app/views/notifications/inbox/_super_star.html.erb
@@ -1,0 +1,6 @@
+<span class="notifications-item__verb">Your project</span>
+<% if notification.record %>
+  <%= link_to notification.record.title, project_path(notification.record), class: "notifications-item__actor" %>
+<% end %>
+<span class="notifications-item__verb">was marked a</span>
+<strong>Super Star</strong>

--- a/app/views/notifications/inbox/_vote_deficit_blocked.html.erb
+++ b/app/views/notifications/inbox/_vote_deficit_blocked.html.erb
@@ -1,0 +1,3 @@
+<span class="notifications-item__verb">Your ship event payout is on hold —</span>
+<span class="notifications-item__verb">cast</span> <strong><%= notification.params["votes_needed"] %> more votes</strong>
+<span class="notifications-item__verb">to unlock it</span>

--- a/app/views/notifications/payouts/vote_deficit_blocked.slack_message.slocks
+++ b/app/views/notifications/payouts/vote_deficit_blocked.slack_message.slocks
@@ -7,7 +7,7 @@ section "Your payout for #{ship_event_label}#{ship_date.present? ? " (shipped #{
 
 divider
 
-section "You need to vote *#{pluralize(votes_needed, 'more time')}* before your payouts will be issued.", markdown: true
+section "You need to cast *#{pluralize(votes_needed, 'more vote')}* before your payout will be issued.", markdown: true
 
 section "Remember: every time you ship a project, your vote balance decreases by 15. Every time you vote, it increases by 1. Keep voting to maintain a positive balance!", markdown: true
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -524,6 +524,17 @@ Rails.application.routes.draw do
     resource :balance, only: [ :show ]
     resource :settings, only: [ :update ]
     resources :dismissals, only: [ :create ]
+    resources :notifications, only: [ :index ] do
+      collection do
+        post :mark_all_seen
+        post :mark_all_read
+        delete :clear_all
+      end
+      member do
+        post :mark_read
+      end
+    end
+    resource :notification_settings, only: [ :show, :update ], controller: "notification_settings"
   end
   get "my/achievements", to: "achievements#index", as: :my_achievements
 

--- a/db/migrate/20260520040141_create_notifications.rb
+++ b/db/migrate/20260520040141_create_notifications.rb
@@ -1,0 +1,27 @@
+class CreateNotifications < ActiveRecord::Migration[8.1]
+  def change
+    create_table :notifications do |t|
+      t.references :recipient, null: false, foreign_key: { to_table: :users, on_delete: :cascade }
+      t.references :actor, foreign_key: { to_table: :users, on_delete: :nullify }
+      t.string :record_type
+      t.bigint :record_id
+      t.string :type, null: false
+      t.integer :priority, null: false, default: 0
+      t.jsonb :params, null: false, default: {}
+      t.string :group_key
+      t.integer :group_count, null: false, default: 1
+      t.datetime :seen_at
+      t.datetime :read_at
+      t.datetime :slack_delivered_at
+      t.datetime :email_delivered_at
+
+      t.timestamps
+    end
+
+    add_index :notifications, [ :recipient_id, :seen_at ]
+    add_index :notifications, [ :recipient_id, :created_at ]
+    add_index :notifications, [ :recipient_id, :group_key, :read_at ], where: "group_key IS NOT NULL"
+    add_index :notifications, [ :record_type, :record_id ]
+    add_index :notifications, [ :type, :created_at ]
+  end
+end

--- a/db/migrate/20260520043236_create_user_notification_preferences.rb
+++ b/db/migrate/20260520043236_create_user_notification_preferences.rb
@@ -1,0 +1,14 @@
+class CreateUserNotificationPreferences < ActiveRecord::Migration[8.1]
+  def change
+    create_table :user_notification_preferences do |t|
+      t.references :user, null: false, foreign_key: { on_delete: :cascade }
+      t.string :category, null: false
+      t.boolean :slack_enabled
+      t.boolean :email_enabled
+
+      t.timestamps
+    end
+
+    add_index :user_notification_preferences, [ :user_id, :category ], unique: true
+  end
+end

--- a/db/migrate/20260520044133_backfill_notification_preferences.rb
+++ b/db/migrate/20260520044133_backfill_notification_preferences.rb
@@ -1,0 +1,52 @@
+class BackfillNotificationPreferences < ActiveRecord::Migration[8.1]
+  # Backfill new user_notification_preferences rows from the legacy boolean
+  # columns on user_preferences (+ users.mission_review_notifications).
+  # Dead column user_preferences.send_notifications_for_followed_users is
+  # intentionally skipped — it has no readers.
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      execute(<<~SQL)
+        INSERT INTO user_notification_preferences (user_id, category, slack_enabled, email_enabled, created_at, updated_at)
+        SELECT user_id, 'new_follower', send_notifications_for_new_followers, NULL, NOW(), NOW()
+        FROM user_preferences
+        ON CONFLICT (user_id, category) DO NOTHING;
+      SQL
+
+      execute(<<~SQL)
+        INSERT INTO user_notification_preferences (user_id, category, slack_enabled, email_enabled, created_at, updated_at)
+        SELECT user_id, 'followed_devlog_created', send_notifications_for_followed_projects, NULL, NOW(), NOW()
+        FROM user_preferences
+        ON CONFLICT (user_id, category) DO NOTHING;
+      SQL
+
+      execute(<<~SQL)
+        INSERT INTO user_notification_preferences (user_id, category, slack_enabled, email_enabled, created_at, updated_at)
+        SELECT user_id, 'project_comment_received', send_notifications_for_new_comments, NULL, NOW(), NOW()
+        FROM user_preferences
+        ON CONFLICT (user_id, category) DO NOTHING;
+      SQL
+
+      execute(<<~SQL)
+        INSERT INTO user_notification_preferences (user_id, category, slack_enabled, email_enabled, created_at, updated_at)
+        SELECT user_id, 'stardust_balance_changed', stardust_balance_notifications, NULL, NOW(), NOW()
+        FROM user_preferences
+        ON CONFLICT (user_id, category) DO NOTHING;
+      SQL
+
+      execute(<<~SQL)
+        INSERT INTO user_notification_preferences (user_id, category, slack_enabled, email_enabled, created_at, updated_at)
+        SELECT id, 'mission_submission_pending_for_reviewer', mission_review_notifications, NULL, NOW(), NOW()
+        FROM users
+        ON CONFLICT (user_id, category) DO NOTHING;
+      SQL
+    end
+  end
+
+  def down
+    safety_assured do
+      execute("DELETE FROM user_notification_preferences WHERE category IN ('new_follower', 'followed_devlog_created', 'project_comment_received', 'stardust_balance_changed', 'mission_submission_pending_for_reviewer')")
+    end
+  end
+end

--- a/db/migrate/20260520045026_remove_legacy_notification_preference_columns.rb
+++ b/db/migrate/20260520045026_remove_legacy_notification_preference_columns.rb
@@ -1,0 +1,12 @@
+class RemoveLegacyNotificationPreferenceColumns < ActiveRecord::Migration[8.1]
+  def change
+    safety_assured do
+      remove_column :user_preferences, :send_notifications_for_new_followers,     :boolean, default: true, null: false
+      remove_column :user_preferences, :send_notifications_for_followed_projects, :boolean, default: true, null: false
+      remove_column :user_preferences, :send_notifications_for_new_comments,      :boolean, default: true, null: false
+      remove_column :user_preferences, :send_notifications_for_followed_users,    :boolean, default: true, null: false
+      remove_column :user_preferences, :stardust_balance_notifications,           :boolean, default: false, null: false
+      remove_column :users,            :mission_review_notifications,             :boolean, default: true, null: false
+    end
+  end
+end

--- a/db/migrate/20260520215816_backfill_project_followed_preferences.rb
+++ b/db/migrate/20260520215816_backfill_project_followed_preferences.rb
@@ -1,0 +1,26 @@
+class BackfillProjectFollowedPreferences < ActiveRecord::Migration[8.1]
+  # The original BackfillNotificationPreferences mapped the legacy
+  # send_notifications_for_new_followers boolean to the `new_follower`
+  # category only. But the same legacy boolean ALSO gated project-follow
+  # Slack DMs in projects_controller#follow. Without this migration,
+  # every existing user who had project-follow Slack DMs enabled silently
+  # loses them once the new preferences system goes live, because the
+  # project_followed category has slack:false in the priority defaults.
+  def up
+    safety_assured do
+      execute(<<~SQL)
+        INSERT INTO user_notification_preferences (user_id, category, slack_enabled, email_enabled, created_at, updated_at)
+        SELECT user_id, 'project_followed', slack_enabled, NULL, NOW(), NOW()
+        FROM user_notification_preferences
+        WHERE category = 'new_follower'
+        ON CONFLICT (user_id, category) DO NOTHING;
+      SQL
+    end
+  end
+
+  def down
+    safety_assured do
+      execute("DELETE FROM user_notification_preferences WHERE category = 'project_followed'")
+    end
+  end
+end

--- a/db/migrate/20260520215820_rename_slack_delivered_at_to_slack_enqueued_at.rb
+++ b/db/migrate/20260520215820_rename_slack_delivered_at_to_slack_enqueued_at.rb
@@ -1,0 +1,7 @@
+class RenameSlackDeliveredAtToSlackEnqueuedAt < ActiveRecord::Migration[8.1]
+  def change
+    safety_assured do
+      rename_column :notifications, :slack_delivered_at, :slack_enqueued_at
+    end
+  end
+end

--- a/db/migrate/20260520215823_add_unique_aggregation_index_to_notifications.rb
+++ b/db/migrate/20260520215823_add_unique_aggregation_index_to_notifications.rb
@@ -1,0 +1,17 @@
+class AddUniqueAggregationIndexToNotifications < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  # Belt-and-suspenders to Notification.aggregate_or_build: even with the
+  # pessimistic .lock, two concurrent notifies that both find no existing
+  # unread row would each insert a fresh row. This enforces dedupe at the
+  # DB level for aggregatable types; the model rescues RecordNotUnique
+  # and retries the lookup.
+  def change
+    add_index :notifications,
+              [ :recipient_id, :type, :group_key ],
+              unique: true,
+              where: "read_at IS NULL AND group_key IS NOT NULL",
+              algorithm: :concurrently,
+              name: "index_notifications_unique_unread_aggregate"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_19_100000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_20_215823) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
@@ -410,6 +410,32 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_100000) do
     t.index ["enabled"], name: "index_missions_on_enabled"
     t.index ["featured_at"], name: "index_missions_on_featured_at"
     t.index ["slug"], name: "index_missions_on_slug", unique: true
+  end
+
+  create_table "notifications", force: :cascade do |t|
+    t.bigint "actor_id"
+    t.datetime "created_at", null: false
+    t.datetime "email_delivered_at"
+    t.integer "group_count", default: 1, null: false
+    t.string "group_key"
+    t.jsonb "params", default: {}, null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "read_at"
+    t.bigint "recipient_id", null: false
+    t.bigint "record_id"
+    t.string "record_type"
+    t.datetime "seen_at"
+    t.datetime "slack_enqueued_at"
+    t.string "type", null: false
+    t.datetime "updated_at", null: false
+    t.index ["actor_id"], name: "index_notifications_on_actor_id"
+    t.index ["recipient_id", "created_at"], name: "index_notifications_on_recipient_id_and_created_at"
+    t.index ["recipient_id", "group_key", "read_at"], name: "index_notifications_on_recipient_id_and_group_key_and_read_at", where: "(group_key IS NOT NULL)"
+    t.index ["recipient_id", "seen_at"], name: "index_notifications_on_recipient_id_and_seen_at"
+    t.index ["recipient_id", "type", "group_key"], name: "index_notifications_unique_unread_aggregate", unique: true, where: "((read_at IS NULL) AND (group_key IS NOT NULL))"
+    t.index ["recipient_id"], name: "index_notifications_on_recipient_id"
+    t.index ["record_type", "record_id"], name: "index_notifications_on_record_type_and_record_id"
+    t.index ["type", "created_at"], name: "index_notifications_on_type_and_created_at"
   end
 
   create_table "post_devlogs", force: :cascade do |t|
@@ -881,16 +907,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_100000) do
     t.index ["user_id"], name: "index_user_identities_on_user_id"
   end
 
+  create_table "user_notification_preferences", force: :cascade do |t|
+    t.string "category", null: false
+    t.datetime "created_at", null: false
+    t.boolean "email_enabled"
+    t.boolean "slack_enabled"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id", "category"], name: "index_user_notification_preferences_on_user_id_and_category", unique: true
+    t.index ["user_id"], name: "index_user_notification_preferences_on_user_id"
+  end
+
   create_table "user_preferences", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.boolean "leaderboard_optin", default: false, null: false
     t.boolean "search_engine_indexing_off", default: false, null: false
-    t.boolean "send_notifications_for_followed_projects", default: true, null: false
-    t.boolean "send_notifications_for_followed_users", default: true, null: false
-    t.boolean "send_notifications_for_new_comments", default: true, null: false
-    t.boolean "send_notifications_for_new_followers", default: true, null: false
     t.boolean "send_votes_to_slack", default: false, null: false
-    t.boolean "stardust_balance_notifications", default: false, null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["leaderboard_optin"], name: "index_user_preferences_on_leaderboard_optin"
@@ -927,7 +959,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_100000) do
     t.text "internal_notes"
     t.string "last_name"
     t.boolean "manual_ysws_override"
-    t.boolean "mission_review_notifications", default: true, null: false
     t.datetime "onboarded_at"
     t.string "ref"
     t.string "regions", default: [], array: true
@@ -1030,6 +1061,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_100000) do
   add_foreign_key "mission_submissions", "post_ship_events", column: "ship_event_id"
   add_foreign_key "mission_submissions", "shop_orders"
   add_foreign_key "mission_submissions", "users", column: "reviewed_by_id"
+  add_foreign_key "notifications", "users", column: "actor_id", on_delete: :nullify
+  add_foreign_key "notifications", "users", column: "recipient_id", on_delete: :cascade
   add_foreign_key "posts", "projects"
   add_foreign_key "posts", "users"
   add_foreign_key "project_follows", "projects"
@@ -1069,6 +1102,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_100000) do
   add_foreign_key "user_hackatime_projects", "projects"
   add_foreign_key "user_hackatime_projects", "users"
   add_foreign_key "user_identities", "users"
+  add_foreign_key "user_notification_preferences", "users", on_delete: :cascade
   add_foreign_key "user_preferences", "users"
   add_foreign_key "user_vote_verdicts", "users"
   add_foreign_key "votes", "post_ship_events", column: "ship_event_id"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@fullstory/browser": "^2.0.6",
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.20",
+    "@rails/actioncable": "^8.1.300",
     "@rails/activestorage": "^8.1.100",
     "chart.js": "^4.5.1",
     "chartkick": "^5.0.1",

--- a/test/channels/notifications_channel_test.rb
+++ b/test/channels/notifications_channel_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class NotificationsChannelTest < ActionCable::Channel::TestCase
+  setup do
+    @alice = create_user(slack_id: "U_ALICE", display_name: "alice")
+    stub_connection current_user: @alice
+  end
+
+  test "subscribes and streams for the current user" do
+    subscribe
+    assert subscription.confirmed?
+    assert_has_stream_for @alice
+  end
+
+  test "rejects subscription when current_user is nil (anonymous connection)" do
+    stub_connection current_user: nil
+    subscribe
+    assert subscription.rejected?
+  end
+
+  test "broadcast_unseen_count pushes the unseen count to the user stream" do
+    Notifications::NewFollower.create!(recipient: @alice, actor: create_user(slack_id: "U_BOB", display_name: "bob"))
+
+    assert_broadcasts(NotificationsChannel.broadcasting_for(@alice), 1) do
+      NotificationsChannel.broadcast_unseen_count(@alice)
+    end
+  end
+end

--- a/test/controllers/my/notifications_controller_test.rb
+++ b/test/controllers/my/notifications_controller_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+
+class My::NotificationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @alice = create_user(slack_id: "U_ALICE", display_name: "alice")
+    @bob   = create_user(slack_id: "U_BOB",   display_name: "bob")
+    sign_in(@alice)
+  end
+
+  test "index renders and marks loaded unseen rows as seen" do
+    notification = Notifications::NewFollower.notify(recipient: @alice, actor: @bob)
+
+    get my_notifications_path
+    assert_response :success
+
+    assert_not_nil notification.reload.seen_at
+  end
+
+  test "index hides notifications with destroyed polymorphic record" do
+    Notification.create!(
+      recipient: @alice,
+      type: "Notifications::NewFollower",
+      record_type: "Project",
+      record_id: 999_999_999,
+      params: {}
+    )
+    visible = Notifications::NewFollower.notify(recipient: @alice, actor: @bob)
+
+    get my_notifications_path
+    assert_response :success
+    assert_select "li.notifications-item", count: 1
+    assert visible.reload.seen_at.present?
+  end
+
+  test "mark_read marks the row read and redirects to the deep link" do
+    notification = Notifications::NewFollower.notify(recipient: @alice, actor: @bob)
+
+    post mark_read_my_notification_path(notification)
+    assert_response :redirect
+    assert_redirected_to user_path(@bob)
+    assert_not_nil notification.reload.read_at
+  end
+
+  test "mark_all_seen clears unseen across all rows" do
+    3.times { Notifications::NewFollower.notify(recipient: @alice, actor: @bob) }
+
+    assert_difference -> { @alice.notifications.unseen.count }, -1 do
+      post mark_all_seen_my_notifications_path
+    end
+  end
+
+  test "mark_all_read flips every row to read" do
+    Notifications::NewFollower.notify(recipient: @alice, actor: @bob)
+
+    post mark_all_read_my_notifications_path
+
+    assert_equal 0, @alice.notifications.unread.count
+  end
+
+  test "logged out users are bounced" do
+    delete logout_path
+    get my_notifications_path
+    assert_response :redirect
+  end
+end

--- a/test/controllers/my_controller_test.rb
+++ b/test/controllers/my_controller_test.rb
@@ -9,9 +9,6 @@ class MyResourcesTest < ActionDispatch::IntegrationTest
       hcb_email: "grants@example.test",
       send_votes_to_slack: "1",
       leaderboard_optin: "1",
-      stardust_balance_notifications: "0",
-      send_notifications_for_followed_projects: "1",
-      send_notifications_for_new_followers: "1",
       search_engine_indexing_off: "1"
     }
 
@@ -21,10 +18,6 @@ class MyResourcesTest < ActionDispatch::IntegrationTest
     preference = user.preference.reload
     assert preference.send_votes_to_slack
     assert preference.leaderboard_optin
-    assert_not preference.stardust_balance_notifications
-    assert preference.send_notifications_for_followed_projects
-    assert preference.send_notifications_for_new_followers
-    assert_not preference.send_notifications_for_new_comments
     assert preference.search_engine_indexing_off
   end
 

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -1,0 +1,67 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                 :bigint           not null, primary key
+#  email_delivered_at :datetime
+#  group_count        :integer          default(1), not null
+#  group_key          :string
+#  params             :jsonb            not null
+#  priority           :integer          default("low"), not null
+#  read_at            :datetime
+#  record_type        :string
+#  seen_at            :datetime
+#  slack_enqueued_at  :datetime
+#  type               :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  actor_id           :bigint
+#  recipient_id       :bigint           not null
+#  record_id          :bigint
+#
+# Indexes
+#
+#  index_notifications_on_actor_id                                (actor_id)
+#  index_notifications_on_recipient_id                            (recipient_id)
+#  index_notifications_on_recipient_id_and_created_at             (recipient_id,created_at)
+#  index_notifications_on_recipient_id_and_group_key_and_read_at  (recipient_id,group_key,read_at) WHERE (group_key IS NOT NULL)
+#  index_notifications_on_recipient_id_and_seen_at                (recipient_id,seen_at)
+#  index_notifications_on_record_type_and_record_id               (record_type,record_id)
+#  index_notifications_on_type_and_created_at                     (type,created_at)
+#  index_notifications_unique_unread_aggregate                    (recipient_id,type,group_key) UNIQUE WHERE ((read_at IS NULL) AND (group_key IS NOT NULL))
+#
+# Foreign Keys
+#
+#  fk_rails_...  (actor_id => users.id) ON DELETE => nullify
+#  fk_rails_...  (recipient_id => users.id) ON DELETE => cascade
+#
+unseen_new_follower:
+  recipient: one
+  actor: two
+  type: Notifications::NewFollower
+  priority: 0
+  params: {}
+  group_key: "user_followed:<%= ActiveRecord::FixtureSet.identify(:one) %>"
+  group_count: 1
+
+read_new_follower:
+  recipient: two
+  actor: one
+  type: Notifications::NewFollower
+  priority: 0
+  params: {}
+  group_key: "user_followed:<%= ActiveRecord::FixtureSet.identify(:two) %>"
+  group_count: 1
+  seen_at: 2026-01-01 00:00:00
+  read_at: 2026-01-01 00:00:01
+
+orphaned_notification:
+  recipient: one
+  type: Notifications::NewFollower
+  priority: 0
+  params: {}
+  record_type: Project
+  record_id: 999999999
+  group_count: 1

--- a/test/fixtures/user/preferences.yml
+++ b/test/fixtures/user/preferences.yml
@@ -4,18 +4,13 @@
 #
 # Table name: user_preferences
 #
-#  id                                       :bigint           not null, primary key
-#  leaderboard_optin                        :boolean          default(FALSE), not null
-#  search_engine_indexing_off               :boolean          default(FALSE), not null
-#  send_notifications_for_followed_projects :boolean          default(TRUE), not null
-#  send_notifications_for_followed_users    :boolean          default(TRUE), not null
-#  send_notifications_for_new_comments      :boolean          default(TRUE), not null
-#  send_notifications_for_new_followers     :boolean          default(TRUE), not null
-#  send_votes_to_slack                      :boolean          default(FALSE), not null
-#  stardust_balance_notifications           :boolean          default(FALSE), not null
-#  created_at                               :datetime         not null
-#  updated_at                               :datetime         not null
-#  user_id                                  :bigint           not null
+#  id                         :bigint           not null, primary key
+#  leaderboard_optin          :boolean          default(FALSE), not null
+#  search_engine_indexing_off :boolean          default(FALSE), not null
+#  send_votes_to_slack        :boolean          default(FALSE), not null
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  user_id                    :bigint           not null
 #
 # Indexes
 #

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,42 +4,41 @@
 #
 # Table name: users
 #
-#  id                           :bigint           not null, primary key
-#  age_attestation              :string
-#  banned                       :boolean          default(FALSE), not null
-#  banned_at                    :datetime
-#  banned_reason                :text
-#  bio                          :text
-#  display_name                 :string
-#  email                        :string
-#  enriched_ref                 :string
-#  experience_level             :string
-#  first_name                   :string
-#  granted_roles                :string           default([]), not null, is an Array
-#  has_gotten_free_stickers     :boolean          default(FALSE)
-#  has_pending_achievements     :boolean          default(FALSE), not null
-#  hcb_email                    :string
-#  interests                    :string           default([]), is an Array
-#  internal_notes               :text
-#  last_name                    :string
-#  manual_ysws_override         :boolean
-#  mission_review_notifications :boolean          default(TRUE), not null
-#  onboarded_at                 :datetime
-#  ref                          :string
-#  regions                      :string           default([]), is an Array
-#  session_token                :string
-#  shop_region                  :enum
-#  synced_at                    :datetime
-#  things_dismissed             :string           default([]), not null, is an Array
-#  tutorial_steps_completed     :string           default([]), is an Array
-#  verification_status          :string           default("needs_submission"), not null
-#  vote_balance                 :integer          default(0), not null
-#  votes_count                  :integer
-#  voting_locked                :boolean          default(FALSE), not null
-#  ysws_eligible                :boolean          default(FALSE), not null
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
-#  slack_id                     :string
+#  id                       :bigint           not null, primary key
+#  age_attestation          :string
+#  banned                   :boolean          default(FALSE), not null
+#  banned_at                :datetime
+#  banned_reason            :text
+#  bio                      :text
+#  display_name             :string
+#  email                    :string
+#  enriched_ref             :string
+#  experience_level         :string
+#  first_name               :string
+#  granted_roles            :string           default([]), not null, is an Array
+#  has_gotten_free_stickers :boolean          default(FALSE)
+#  has_pending_achievements :boolean          default(FALSE), not null
+#  hcb_email                :string
+#  interests                :string           default([]), is an Array
+#  internal_notes           :text
+#  last_name                :string
+#  manual_ysws_override     :boolean
+#  onboarded_at             :datetime
+#  ref                      :string
+#  regions                  :string           default([]), is an Array
+#  session_token            :string
+#  shop_region              :enum
+#  synced_at                :datetime
+#  things_dismissed         :string           default([]), not null, is an Array
+#  tutorial_steps_completed :string           default([]), is an Array
+#  verification_status      :string           default("needs_submission"), not null
+#  vote_balance             :integer          default(0), not null
+#  votes_count              :integer
+#  voting_locked            :boolean          default(FALSE), not null
+#  ysws_eligible            :boolean          default(FALSE), not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  slack_id                 :string
 #
 # Indexes
 #

--- a/test/jobs/notification_delivery_job_test.rb
+++ b/test/jobs/notification_delivery_job_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class NotificationDeliveryJobTest < ActiveJob::TestCase
+  setup do
+    @alice = create_user(slack_id: "U_ALICE", display_name: "alice")
+    @bob   = create_user(slack_id: "U_BOB",   display_name: "bob")
+    @notification = Notifications::NewFollower.create!(recipient: @bob, actor: @alice)
+  end
+
+  test "slack channel enqueues SendSlackDmJob and stamps slack_enqueued_at" do
+    assert_enqueued_with(job: SendSlackDmJob, args: [
+      @bob.slack_id,
+      "✨ <@#{@alice.slack_id}> just started following you on Stardance!",
+      { blocks_path: nil, locals: {} }
+    ]) do
+      NotificationDeliveryJob.perform_now(@notification.id, "slack")
+    end
+
+    assert_not_nil @notification.reload.slack_enqueued_at
+  end
+
+  test "slack channel no-ops when recipient has no slack_id" do
+    @bob.update!(slack_id: nil)
+
+    assert_no_enqueued_jobs(only: SendSlackDmJob) do
+      NotificationDeliveryJob.perform_now(@notification.id, "slack")
+    end
+
+    assert_nil @notification.reload.slack_enqueued_at
+  end
+
+  test "unknown channel logs and exits cleanly" do
+    assert_nothing_raised do
+      NotificationDeliveryJob.perform_now(@notification.id, "carrier_pigeon")
+    end
+  end
+
+  test "missing notification id is a no-op" do
+    assert_nothing_raised do
+      NotificationDeliveryJob.perform_now(999_999_999, "slack")
+    end
+  end
+end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class NotificationMailerTest < ActionMailer::TestCase
+  setup do
+    @alice = create_user(slack_id: "U_ALICE", display_name: "alice")
+    @bob   = create_user(slack_id: "U_BOB",   display_name: "bob")
+  end
+
+  test "renders new follower email" do
+    notification = Notifications::NewFollower.create!(recipient: @bob, actor: @alice)
+    mail = NotificationMailer.notification(notification.id)
+
+    assert_equal [ @bob.email ], mail.to
+    assert_equal "@alice started following you on Stardance", mail.subject
+    assert_match "@alice", mail.body.encoded
+  end
+
+  test "no-ops when recipient has no email" do
+    @bob.update!(email: nil)
+    notification = Notifications::NewFollower.create!(recipient: @bob, actor: @alice)
+    mail = NotificationMailer.notification(notification.id)
+
+    assert_nil mail.message_id
+  end
+
+  test "no-ops when notification missing" do
+    mail = NotificationMailer.notification(999_999_999)
+    assert_nil mail.message_id
+  end
+end

--- a/test/models/follow_test.rb
+++ b/test/models/follow_test.rb
@@ -47,17 +47,13 @@ class FollowTest < ActiveSupport::TestCase
     assert_includes follow.errors[:followed_id], "can't follow yourself"
   end
 
-  test "fires Slack DM to followed user when notifications enabled" do
-    @bob.preference.update!(send_notifications_for_new_followers: true)
-    assert_enqueued_with(job: SendSlackDmJob) do
+  test "creates an in-app notification for the followed user" do
+    assert_difference -> { @bob.notifications.count }, 1 do
       Follow.create!(follower: @alice, followed: @bob)
     end
-  end
 
-  test "does not fire Slack DM if followed user opted out" do
-    @bob.preference.update!(send_notifications_for_new_followers: false)
-    assert_no_enqueued_jobs(only: SendSlackDmJob) do
-      Follow.create!(follower: @alice, followed: @bob)
-    end
+    notification = @bob.notifications.last
+    assert_instance_of Notifications::NewFollower, notification
+    assert_equal @alice, notification.actor
   end
 end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -1,0 +1,119 @@
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                 :bigint           not null, primary key
+#  email_delivered_at :datetime
+#  group_count        :integer          default(1), not null
+#  group_key          :string
+#  params             :jsonb            not null
+#  priority           :integer          default("low"), not null
+#  read_at            :datetime
+#  record_type        :string
+#  seen_at            :datetime
+#  slack_enqueued_at  :datetime
+#  type               :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  actor_id           :bigint
+#  recipient_id       :bigint           not null
+#  record_id          :bigint
+#
+# Indexes
+#
+#  index_notifications_on_actor_id                                (actor_id)
+#  index_notifications_on_recipient_id                            (recipient_id)
+#  index_notifications_on_recipient_id_and_created_at             (recipient_id,created_at)
+#  index_notifications_on_recipient_id_and_group_key_and_read_at  (recipient_id,group_key,read_at) WHERE (group_key IS NOT NULL)
+#  index_notifications_on_recipient_id_and_seen_at                (recipient_id,seen_at)
+#  index_notifications_on_record_type_and_record_id               (record_type,record_id)
+#  index_notifications_on_type_and_created_at                     (type,created_at)
+#  index_notifications_unique_unread_aggregate                    (recipient_id,type,group_key) UNIQUE WHERE ((read_at IS NULL) AND (group_key IS NOT NULL))
+#
+# Foreign Keys
+#
+#  fk_rails_...  (actor_id => users.id) ON DELETE => nullify
+#  fk_rails_...  (recipient_id => users.id) ON DELETE => cascade
+#
+require "test_helper"
+
+class NotificationTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @alice = create_user(slack_id: "U_ALICE", display_name: "alice")
+    @bob   = create_user(slack_id: "U_BOB",   display_name: "bob")
+    @carol = create_user(slack_id: "U_CAROL", display_name: "carol")
+  end
+
+  test "notify inserts a notification row for the recipient" do
+    assert_difference "Notification.count", 1 do
+      Notifications::NewFollower.notify(recipient: @bob, actor: @alice)
+    end
+
+    notification = @bob.notifications.last
+    assert_equal "Notifications::NewFollower", notification.type
+    assert_equal @alice, notification.actor
+    assert_equal "low", notification.priority
+  end
+
+  test "notify skips self-notify by default" do
+    assert_no_difference "Notification.count" do
+      Notifications::NewFollower.notify(recipient: @alice, actor: @alice)
+    end
+  end
+
+  test "notify aggregates into existing unread row with matching group_key" do
+    Notifications::NewFollower.notify(recipient: @bob, actor: @alice)
+
+    assert_no_difference "Notification.count" do
+      Notifications::NewFollower.notify(recipient: @bob, actor: @carol)
+    end
+
+    notification = @bob.notifications.last
+    assert_equal 2, notification.group_count
+    assert_equal @carol, notification.actor
+  end
+
+  test "notify starts a fresh row once the previous one is read" do
+    first = Notifications::NewFollower.notify(recipient: @bob, actor: @alice)
+    first.mark_read!
+
+    assert_difference "Notification.count", 1 do
+      Notifications::NewFollower.notify(recipient: @bob, actor: @carol)
+    end
+  end
+
+  test "low priority enqueues no delivery jobs by default" do
+    assert_no_enqueued_jobs(only: NotificationDeliveryJob) do
+      Notifications::NewFollower.notify(recipient: @bob, actor: @alice)
+    end
+  end
+
+  test "orphaned? returns true when the polymorphic record is missing" do
+    orphan = notifications(:orphaned_notification)
+    assert orphan.orphaned?
+  end
+
+  test "mark_seen! and mark_read! are idempotent" do
+    notification = Notifications::NewFollower.notify(recipient: @bob, actor: @alice)
+    notification.mark_seen!
+    seen_at = notification.reload.seen_at
+    notification.mark_seen!
+    assert_equal seen_at, notification.reload.seen_at
+
+    notification.mark_read!
+    read_at = notification.reload.read_at
+    notification.mark_read!
+    assert_equal read_at, notification.reload.read_at
+  end
+
+  test "aggregation re-surfaces seen rows by clearing seen_at" do
+    first = Notifications::NewFollower.notify(recipient: @bob, actor: @alice)
+    first.mark_seen!
+    assert_not_nil first.reload.seen_at
+
+    Notifications::NewFollower.notify(recipient: @bob, actor: @carol)
+    assert_nil first.reload.seen_at
+  end
+end

--- a/test/models/notifications/new_follower_test.rb
+++ b/test/models/notifications/new_follower_test.rb
@@ -1,0 +1,71 @@
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                 :bigint           not null, primary key
+#  email_delivered_at :datetime
+#  group_count        :integer          default(1), not null
+#  group_key          :string
+#  params             :jsonb            not null
+#  priority           :integer          default("low"), not null
+#  read_at            :datetime
+#  record_type        :string
+#  seen_at            :datetime
+#  slack_enqueued_at  :datetime
+#  type               :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  actor_id           :bigint
+#  recipient_id       :bigint           not null
+#  record_id          :bigint
+#
+# Indexes
+#
+#  index_notifications_on_actor_id                                (actor_id)
+#  index_notifications_on_recipient_id                            (recipient_id)
+#  index_notifications_on_recipient_id_and_created_at             (recipient_id,created_at)
+#  index_notifications_on_recipient_id_and_group_key_and_read_at  (recipient_id,group_key,read_at) WHERE (group_key IS NOT NULL)
+#  index_notifications_on_recipient_id_and_seen_at                (recipient_id,seen_at)
+#  index_notifications_on_record_type_and_record_id               (record_type,record_id)
+#  index_notifications_on_type_and_created_at                     (type,created_at)
+#  index_notifications_unique_unread_aggregate                    (recipient_id,type,group_key) UNIQUE WHERE ((read_at IS NULL) AND (group_key IS NOT NULL))
+#
+# Foreign Keys
+#
+#  fk_rails_...  (actor_id => users.id) ON DELETE => nullify
+#  fk_rails_...  (recipient_id => users.id) ON DELETE => cascade
+#
+require "test_helper"
+
+module Notifications
+  class NewFollowerTest < ActiveSupport::TestCase
+    setup do
+      @alice = create_user(slack_id: "U_ALICE", display_name: "alice")
+      @bob   = create_user(slack_id: "U_BOB",   display_name: "bob")
+    end
+
+    test "is low priority by default" do
+      assert_equal :low, Notifications::NewFollower.default_priority
+    end
+
+    test "is aggregatable" do
+      assert Notifications::NewFollower.aggregatable
+    end
+
+    test "builds a per-recipient group_key" do
+      key = Notifications::NewFollower.build_group_key(recipient: @bob, actor: @alice, record: nil, params: {})
+      assert_equal "user_followed:#{@bob.id}", key
+    end
+
+    test "slack_message renders with actor slack_id" do
+      notification = Notifications::NewFollower.new(recipient: @bob, actor: @alice)
+      assert_equal "✨ <@U_ALICE> just started following you on Stardance!", notification.slack_message
+    end
+
+    test "slack_message is nil when actor has no slack_id" do
+      slackless = create_user(slack_id: nil, display_name: "ghost")
+      notification = Notifications::NewFollower.new(recipient: @bob, actor: slackless)
+      assert_nil notification.slack_message
+    end
+  end
+end

--- a/test/models/user/preference_test.rb
+++ b/test/models/user/preference_test.rb
@@ -2,18 +2,13 @@
 #
 # Table name: user_preferences
 #
-#  id                                       :bigint           not null, primary key
-#  leaderboard_optin                        :boolean          default(FALSE), not null
-#  search_engine_indexing_off               :boolean          default(FALSE), not null
-#  send_notifications_for_followed_projects :boolean          default(TRUE), not null
-#  send_notifications_for_followed_users    :boolean          default(TRUE), not null
-#  send_notifications_for_new_comments      :boolean          default(TRUE), not null
-#  send_notifications_for_new_followers     :boolean          default(TRUE), not null
-#  send_votes_to_slack                      :boolean          default(FALSE), not null
-#  stardust_balance_notifications           :boolean          default(FALSE), not null
-#  created_at                               :datetime         not null
-#  updated_at                               :datetime         not null
-#  user_id                                  :bigint           not null
+#  id                         :bigint           not null, primary key
+#  leaderboard_optin          :boolean          default(FALSE), not null
+#  search_engine_indexing_off :boolean          default(FALSE), not null
+#  send_votes_to_slack        :boolean          default(FALSE), not null
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  user_id                    :bigint           not null
 #
 # Indexes
 #
@@ -33,11 +28,6 @@ class User::PreferenceTest < ActiveSupport::TestCase
     assert user.preference
     assert_not user.preference.send_votes_to_slack
     assert_not user.preference.leaderboard_optin
-    assert_not user.preference.stardust_balance_notifications
-    assert user.preference.send_notifications_for_followed_projects
-    assert user.preference.send_notifications_for_followed_users
-    assert user.preference.send_notifications_for_new_followers
-    assert user.preference.send_notifications_for_new_comments
     assert_not user.preference.search_engine_indexing_off
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,42 +2,41 @@
 #
 # Table name: users
 #
-#  id                           :bigint           not null, primary key
-#  age_attestation              :string
-#  banned                       :boolean          default(FALSE), not null
-#  banned_at                    :datetime
-#  banned_reason                :text
-#  bio                          :text
-#  display_name                 :string
-#  email                        :string
-#  enriched_ref                 :string
-#  experience_level             :string
-#  first_name                   :string
-#  granted_roles                :string           default([]), not null, is an Array
-#  has_gotten_free_stickers     :boolean          default(FALSE)
-#  has_pending_achievements     :boolean          default(FALSE), not null
-#  hcb_email                    :string
-#  interests                    :string           default([]), is an Array
-#  internal_notes               :text
-#  last_name                    :string
-#  manual_ysws_override         :boolean
-#  mission_review_notifications :boolean          default(TRUE), not null
-#  onboarded_at                 :datetime
-#  ref                          :string
-#  regions                      :string           default([]), is an Array
-#  session_token                :string
-#  shop_region                  :enum
-#  synced_at                    :datetime
-#  things_dismissed             :string           default([]), not null, is an Array
-#  tutorial_steps_completed     :string           default([]), is an Array
-#  verification_status          :string           default("needs_submission"), not null
-#  vote_balance                 :integer          default(0), not null
-#  votes_count                  :integer
-#  voting_locked                :boolean          default(FALSE), not null
-#  ysws_eligible                :boolean          default(FALSE), not null
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
-#  slack_id                     :string
+#  id                       :bigint           not null, primary key
+#  age_attestation          :string
+#  banned                   :boolean          default(FALSE), not null
+#  banned_at                :datetime
+#  banned_reason            :text
+#  bio                      :text
+#  display_name             :string
+#  email                    :string
+#  enriched_ref             :string
+#  experience_level         :string
+#  first_name               :string
+#  granted_roles            :string           default([]), not null, is an Array
+#  has_gotten_free_stickers :boolean          default(FALSE)
+#  has_pending_achievements :boolean          default(FALSE), not null
+#  hcb_email                :string
+#  interests                :string           default([]), is an Array
+#  internal_notes           :text
+#  last_name                :string
+#  manual_ysws_override     :boolean
+#  onboarded_at             :datetime
+#  ref                      :string
+#  regions                  :string           default([]), is an Array
+#  session_token            :string
+#  shop_region              :enum
+#  synced_at                :datetime
+#  things_dismissed         :string           default([]), not null, is an Array
+#  tutorial_steps_completed :string           default([]), is an Array
+#  verification_status      :string           default("needs_submission"), not null
+#  vote_balance             :integer          default(0), not null
+#  votes_count              :integer
+#  voting_locked            :boolean          default(FALSE), not null
+#  ysws_eligible            :boolean          default(FALSE), not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  slack_id                 :string
 #
 # Indexes
 #

--- a/yarn.lock
+++ b/yarn.lock
@@ -177,6 +177,11 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-8.1.100.tgz#b1f85f3482425fb91e5eba1deb55152ee0bb2f85"
   integrity sha512-j4vJQqz51CDVYv2UafKRu4jiZi5/gTnm7NkyL+VMIgEw3s8jtVtmzu9uItUaZccUg9NJ6o05yVyBAHxNfTuCRA==
 
+"@rails/actioncable@^8.1.300":
+  version "8.1.300"
+  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-8.1.300.tgz#bfd50813be0225a0403bddb11e8ba9a00b1fb135"
+  integrity sha512-zOENQsq3NM2jyBY6Z2qtZa3V/R/6OEqA+LGKixQbBMl7kk/J3FXDRcszPe74LsHNgB01jCl/DXu/xA8sHt4I/g==
+
 "@rails/activestorage@^8.1.100":
   version "8.1.100"
   resolved "https://registry.yarnpkg.com/@rails/activestorage/-/activestorage-8.1.100.tgz#8814545349eaf824ea7a528b33f7bae0867584c9"


### PR DESCRIPTION
Change notifications from being a slack-message-only system to having a first class notifications page, slack dms, and email support for more notification categories.

- In-app inbox at /my/notifications with realtime ActionCable updates and sidebar badge
- Per-user prefs page- Slack/email toggles grouped by category
- 12 typed notifications (follows, comments, devlogs, mission reviews, payouts, shop orders, etc.) wired through existing Slack call sites
- Priority channels- critical always-on, high is on by default, medium and low are off by default
- Aggregation (10 likes → 1 row) + digest delay so there isn't spam
- Branded HTML emails with per-type CTAs and unsubscribe footer
- Legacy preference columns backfilled and dropped