### PR TITLE
feat(faq): add an faq page and allow admins and helpers to manage it

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -71,3 +71,4 @@
 @use "pages/guides";
 @use "pages/admin/_super_mega_dashboard";
 @use "pages/admin/_voting_dashboard";
+@use "pages/faq/index" as faq_index;

--- a/app/assets/stylesheets/pages/faq/_index.scss
+++ b/app/assets/stylesheets/pages/faq/_index.scss
@@ -1,0 +1,151 @@
+body.page-faq &,
+body.page-faq {
+  color: transparent;
+  padding: 0;
+}
+
+.page-faq {
+  margin: 0;
+  padding: clamp(2rem, 5vw, 4.5rem) clamp(1rem, 4vw, 2.5rem) 5rem;
+  color: var(--color-body-text);
+  font-family: "Exo 2", sans-serif;
+  text-align: center;
+  background:
+    radial-gradient(
+      circle at top left,
+      rgba(129, 255, 255, 0.12),
+      transparent 28%
+    ),
+    radial-gradient(
+      circle at top right,
+      rgba(235, 183, 255, 0.1),
+      transparent 24%
+    ),
+    linear-gradient(180deg, #0e0810 0%, #100a14 42%, #08061e 100%);
+  position: relative;
+  overflow-x: hidden;
+
+  &::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background-image:
+      linear-gradient(rgba(255, 255, 255, 0.03) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+    background-size: 72px 72px;
+    mask-image: radial-gradient(circle at center, black 55%, transparent 100%);
+    opacity: 0.35;
+  }
+
+  h1,
+  h2,
+  .faq-entry {
+    position: relative;
+    z-index: 1;
+  }
+
+  h1 {
+    max-width: 12ch;
+    margin: 0 auto 0.35em;
+    font-size: clamp(2.6rem, 7vw, 4.8rem);
+    line-height: 0.92;
+    font-weight: 700;
+    letter-spacing: -0.04em;
+    color: #fefdfb;
+    text-wrap: balance;
+  }
+
+  h2 {
+    max-width: 42rem;
+    margin: 0 auto 3rem;
+    font-family: "Playfair Display", serif;
+    font-style: italic;
+    font-size: clamp(1.2rem, 2.5vw, 1.8rem);
+    font-weight: 700;
+    line-height: 1.45;
+    color: var(--color-brand-cream);
+    text-wrap: balance;
+
+    span {
+      color: var(--color-brand-yellow);
+      text-decoration: underline;
+      text-underline-offset: 0.14em;
+
+      a {
+        color: inherit;
+        text-decoration: inherit;
+
+        &:hover {
+          color: #fff;
+        }
+      }
+    }
+  }
+
+  h2 a {
+    color: var(--color-brand-mint);
+    text-decoration: underline;
+    text-underline-offset: 0.14em;
+
+    &:hover {
+      color: #fff;
+    }
+  }
+
+  .faq-entry {
+    width: min(100%, 46rem);
+    margin: 0 auto;
+    padding: 1.5rem 0;
+    text-align: left;
+
+    & + .faq-entry {
+      border-top: 1px solid rgba(255, 255, 255, 0.12);
+    }
+
+    h2 {
+      margin: 0 0 0.55rem;
+      font-family: "Exo 2", sans-serif;
+      font-size: clamp(1.25rem, 2vw, 1.7rem);
+      font-weight: 700;
+      color: #fefdfb;
+      letter-spacing: -0.02em;
+    }
+
+    p {
+      margin: 0;
+      font-size: clamp(1rem, 1.5vw, 1.1rem);
+      line-height: 1.7;
+      color: rgba(255, 255, 255, 0.82);
+
+      a {
+        color: var(--color-brand-yellow);
+        text-decoration: underline;
+        text-underline-offset: 0.14em;
+
+        &:hover {
+          color: #fff;
+        }
+      }
+    }
+  }
+
+  @media (max-width: 900px) {
+    .page-faq {
+      padding: 2.5em;
+
+      h1 {
+        max-width: initial;
+        margin: 0;
+        font-size: 2.5rem;
+      }
+
+      h2 {
+        max-width: 100%;
+        margin-top: 0.75em;
+        font-size: 1.1rem;
+        margin-bottom: 0;
+      }
+    }
+  }
+}

--- a/app/controllers/admin/faq_entries_controller.rb
+++ b/app/controllers/admin/faq_entries_controller.rb
@@ -1,0 +1,53 @@
+module Admin
+    class FaqEntriesController < Admin::ApplicationController
+        before_action :set_faq_entry, only: %i[edit update destroy]
+
+        def index
+            authorize :admin, :manage_faq?
+            @faq_entries = FaqEntry.order(:id)
+            @faq_entry = FaqEntry.new
+        end
+
+        def create
+            authorize :admin, :manage_faq?
+            @faq_entry = FaqEntry.new(faq_entry_params)
+
+            if @faq_entry.save
+                redirect_to admin_faq_entries_path, notice: "Successfully created."
+            else
+                @faq_entries = FaqEntry.order(:id)
+                render :index, status: :unprocessable_entity
+            end
+        end
+
+        def edit
+            authorize :admin, :manage_faq?
+        end
+
+        def update
+            authorize :admin, :manage_faq?
+
+            if @faq_entry.update(faq_entry_params)
+                redirect_to admin_faq_entries_path, notice: "Successfully updated."
+            else
+                render :edit, status: :unprocessable_entity
+            end
+        end
+
+        def destroy
+            authorize :admin, :manage_faq?
+            @faq_entry.destroy
+            redirect_to admin_faq_entries_path, notice: "Successfully deleted."
+        end
+
+        private
+
+        def set_faq_entry
+            @faq_entry = FaqEntry.find(params[:id])
+        end
+
+        def faq_entry_params
+            params.require(:faq_entry).permit(:question, :answer)
+        end
+    end
+end

--- a/app/controllers/faq_controller.rb
+++ b/app/controllers/faq_controller.rb
@@ -1,0 +1,6 @@
+class FaqController < ApplicationController
+  def index
+    @faq_entries = FaqEntry.order(:id)
+    @body_class = "page-faq"
+  end
+end

--- a/app/controllers/helper/faq_entries_controller.rb
+++ b/app/controllers/helper/faq_entries_controller.rb
@@ -1,0 +1,53 @@
+module Helper
+    class FaqEntriesController < ApplicationController
+        before_action :set_faq_entry, only: %i[edit update destroy]
+
+        def index
+            authorize :helper, :manage_faq?
+            @faq_entries = FaqEntry.order(:id)
+            @faq_entry = FaqEntry.new
+        end
+
+        def create
+            authorize :helper, :manage_faq?
+            @faq_entry = FaqEntry.new(faq_entry_params)
+
+            if @faq_entry.save
+                redirect_to helper_faq_entries_path, notice: "Successfully created."
+            else
+                @faq_entries = FaqEntry.order(:id)
+                render :index, status: :unprocessable_entity
+            end
+        end
+
+        def edit
+            authorize :helper, :manage_faq?
+        end
+
+        def update
+            authorize :helper, :manage_faq?
+
+            if @faq_entry.update(faq_entry_params)
+                redirect_to helper_faq_entries_path, notice: "Successfully updated."
+            else
+                render :edit, status: :unprocessable_entity
+            end
+        end
+
+        def destroy
+            authorize :helper, :manage_faq?
+            @faq_entry.destroy
+            redirect_to helper_faq_entries_path, notice: "Successfully deleted."
+        end
+
+        private
+
+        def set_faq_entry
+            @faq_entry = FaqEntry.find(params[:id])
+        end
+
+        def faq_entry_params
+            params.require(:faq_entry).permit(:question, :answer)
+        end
+    end
+end

--- a/app/models/faq_entry.rb
+++ b/app/models/faq_entry.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: faq_entries
+#
+#  id         :bigint           not null, primary key
+#  answer     :text             not null
+#  question   :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class FaqEntry < ApplicationRecord
+  has_paper_trail
+
+  validates :question, presence: true
+  validates :answer, presence: true
+end

--- a/app/policies/admin_policy.rb
+++ b/app/policies/admin_policy.rb
@@ -138,4 +138,8 @@ class AdminPolicy < ApplicationPolicy
   def access_flavortime_dashboard?
     user.admin? || user.flavortime?
   end
+
+  def manage_faq?
+    user.admin?
+  end
 end

--- a/app/policies/helper_policy.rb
+++ b/app/policies/helper_policy.rb
@@ -26,4 +26,8 @@ class HelperPolicy < ApplicationPolicy
   def view_support_vibes?
     access?
   end
+
+  def manage_faq?
+    access?
+  end
 end

--- a/app/views/admin/application/index.html.erb
+++ b/app/views/admin/application/index.html.erb
@@ -136,4 +136,7 @@
   <% if policy(:admin).access_flavortime_dashboard? %>
     <%= link_to "Flavortime Dashboard", admin_flavortime_dashboard_path, class: button_class %>
   <% end %>
+  <% if policy(:admin).manage_faq? %>
+    <%= link_to "FAQ", admin_faq_entries_path, class: button_class %>
+  <% end %>
 </div>

--- a/app/views/admin/faq_entries/_form.html.erb
+++ b/app/views/admin/faq_entries/_form.html.erb
@@ -1,0 +1,46 @@
+<%= form_with model: [:admin, faq_entry] do |f| %>
+  <div>
+    <%= f.label :question %>
+    <%= f.text_field :question %>
+  </div>
+
+  <div>
+    <%= f.label :answer %>
+    <%= f.text_area :answer, rows: 4 %>
+  </div>
+
+  <%= f.submit %>
+<% end %>
+
+<style>
+  form {
+    margin-top: 1.5em;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5em;
+
+    label {
+      font-weight: bold;
+      font-size: 1.25rem;
+    }
+
+    input[type="text"],
+    textarea {
+      width: 100%;
+      padding: 0.5em;
+      border-radius: 4px;
+      border: none;
+      font-size: 1.25rem;
+    }
+
+    input[type="submit"] {
+      background: var(--color-green-500);
+      color: white;
+      border: none;
+      padding: 0.5em 1em;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 1.25rem;
+    }
+  }
+</style>

--- a/app/views/admin/faq_entries/edit.html.erb
+++ b/app/views/admin/faq_entries/edit.html.erb
@@ -1,0 +1,3 @@
+<%= render HeadingComponent.new(title: "Edit FAQ Entry", tone: :red) %>
+
+<%= render "form", faq_entry: @faq_entry %>

--- a/app/views/admin/faq_entries/index.html.erb
+++ b/app/views/admin/faq_entries/index.html.erb
@@ -1,0 +1,69 @@
+<%= render HeadingComponent.new(title: "FAQ Entries", tone: :blue) %>
+
+<%= render "form", faq_entry: @faq_entry %>
+
+<table class="table-data">
+  <thead>
+    <tr>
+      <th>Question</th>
+      <th>Answer</th>
+      <th></th>
+      <th></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @faq_entries.each do |entry| %>
+      <tr>
+        <td><%= entry.question %></td>
+        <td><%= md(entry.answer) %></td>
+        <td>
+          <%= link_to "Edit", edit_admin_faq_entry_path(entry), class: "edit-btn" %>
+        </td>
+        <td>
+          <%= button_to "Delete", admin_faq_entry_path(entry), method: :delete, class: "delete-btn" %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<style>
+  table.table-data {
+    color: black;
+    margin-top: 1.5em;
+    width: 100%;
+  }
+
+  table.table-data td form {
+    display: inline;
+    margin: 0;
+    padding: 0;
+  }
+
+  a.edit-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    background: var(--color-blue-500);
+    color: white;
+    border-radius: 4px;
+    padding: 0.25rem 0.5rem;
+    text-decoration: none;
+    font-size: 1rem;
+  }
+
+  .delete-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    vertical-align: middle;
+    background: var(--color-red-500);
+    color: white;
+    border: none;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    font-size: 1rem;
+    cursor: pointer;
+  }
+</style>

--- a/app/views/faq/index.html.erb
+++ b/app/views/faq/index.html.erb
@@ -1,0 +1,11 @@
+<div class="page-faq">
+  <h1>Frequently Asked Questions</h1>
+  <h2>Got more questions? Email us at <%= mail_to "stardance@hackclub.com" %> and we'll try to respond within two days!</h2>
+
+  <% @faq_entries.each do |entry| %>
+    <div class="faq-entry">
+      <h2><%= entry.question %></h2>
+      <p><%= md(entry.answer) %></p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/helper/application/index.html.erb
+++ b/app/views/helper/application/index.html.erb
@@ -9,6 +9,7 @@
       <%= link_to "see what they are making", helper_projects_path, class: "btn-primary" %>
       <%= link_to "see what they are buying", helper_shop_orders_path, class: "btn-primary" %>
       <%= link_to "see what the vibes are", helper_support_vibes_path, class: "btn-primary" %>
+      <%= link_to "manage the faq", helper_faq_entries_path, class: "btn-primary" %>
     </div>
   </div>
 </div>

--- a/app/views/helper/faq_entries/_form.html.erb
+++ b/app/views/helper/faq_entries/_form.html.erb
@@ -1,0 +1,46 @@
+<%= form_with model: [:helper, faq_entry] do |f| %>
+  <div>
+    <%= f.label :question %>
+    <%= f.text_field :question %>
+  </div>
+
+  <div>
+    <%= f.label :answer %>
+    <%= f.text_area :answer, rows: 4 %>
+  </div>
+
+  <%= f.submit %>
+<% end %>
+
+<style>
+  form {
+    margin-top: 1.5em;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5em;
+
+    label {
+      font-weight: bold;
+      font-size: 1.25rem;
+    }
+
+    input[type="text"],
+    textarea {
+      width: 100%;
+      padding: 0.5em;
+      border-radius: 4px;
+      border: none;
+      font-size: 1.25rem;
+    }
+
+    input[type="submit"] {
+      background: var(--color-green-500);
+      color: white;
+      border: none;
+      padding: 0.5em 1em;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 1.25rem;
+    }
+  }
+</style>

--- a/app/views/helper/faq_entries/edit.html.erb
+++ b/app/views/helper/faq_entries/edit.html.erb
@@ -1,0 +1,3 @@
+<%= render HeadingComponent.new(title: "Edit FAQ Entry", tone: :red) %>
+
+<%= render "form", faq_entry: @faq_entry %>

--- a/app/views/helper/faq_entries/index.html.erb
+++ b/app/views/helper/faq_entries/index.html.erb
@@ -1,0 +1,69 @@
+<%= render HeadingComponent.new(title: "FAQ Entries", tone: :blue) %>
+
+<%= render "form", faq_entry: @faq_entry %>
+
+<table class="table-data">
+  <thead>
+    <tr>
+      <th>Question</th>
+      <th>Answer</th>
+      <th></th>
+      <th></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @faq_entries.each do |entry| %>
+      <tr>
+        <td><%= entry.question %></td>
+        <td><%= md(entry.answer) %></td>
+        <td>
+          <%= link_to "Edit", edit_helper_faq_entry_path(entry), class: "edit-btn" %>
+        </td>
+        <td>
+          <%= button_to "Delete", helper_faq_entry_path(entry), method: :delete, class: "delete-btn" %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<style>
+  table.table-data {
+    color: black;
+    margin-top: 1.5em;
+    width: 100%;
+  }
+
+  table.table-data td form {
+    display: inline;
+    margin: 0;
+    padding: 0;
+  }
+
+  a.edit-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    background: var(--color-blue-500);
+    color: white;
+    border-radius: 4px;
+    padding: 0.25rem 0.5rem;
+    text-decoration: none;
+    font-size: 1rem;
+  }
+
+  .delete-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    vertical-align: middle;
+    background: var(--color-red-500);
+    color: white;
+    border: none;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    font-size: 1rem;
+    cursor: pointer;
+  }
+</style>

--- a/app/views/landing/edu.erb
+++ b/app/views/landing/edu.erb
@@ -20,7 +20,7 @@
       </h1>
       <p class="educator-toolkit__subtitle">
         Everything you need to spread the word about Stardance Challenge.
-        Show the video, get free posters, and request an Artemis mission patch.
+        Show the video, get free posters, and request a NASA mission patch.
       </p>
       <div class="educator-toolkit__nasa-attribution">
         <p class="educator-toolkit__nasa-attribution-label">Featured on NASA.gov</p>

--- a/app/views/landing/sections/_faq.html.erb
+++ b/app/views/landing/sections/_faq.html.erb
@@ -50,7 +50,7 @@
       <span class="faq-section__question">I&rsquo;ve got more questions...</span>
       <svg class="faq-section__arrow" data-faq-accordion-target="arrow" viewBox="0 0 12 12" aria-hidden="true" focusable="false"><path d="M3 1.5 9 6 3 10.5Z" fill="currentColor" /></svg>
       <div class="faq-section__answer" data-faq-accordion-target="answer">
-        You can email us at <%= mail_to "stardance@hackclub.com" %>! We&rsquo;ll try and respond to everything within two days :)
+        View the complete FAQ <a href="/faq">here</a>. You can also email us at <%= mail_to "stardance@hackclub.com" %>! We&rsquo;ll try and respond to everything within two days :)
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -505,6 +505,7 @@ Rails.application.routes.draw do
     end
     resources :shop_orders, only: [ :index, :show ]
     resources :support_vibes, only: [ :index ]
+    resources :faq_entries, path: "faq_entries", only: %i[index create edit update destroy]
   end
 
   # admin shallow routing

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -692,5 +692,12 @@ Rails.application.routes.draw do
   # Guides
   resources :guides, only: [ :index, :show ]
 
+  # FAQs
+  resources :faq, to: "faq#index"
+
+  namespace :admin, constraints: AdminConstraint do
+    resources :faq_entries, path: "faq_entries", only: %i[index create edit update destroy]
+  end
+
   get "/:ref", to: "landing#index", constraints: { ref: /[a-z0-9][a-z0-9_-]{0,63}/ }
 end

--- a/db/migrate/20260525034348_create_faq_entries.rb
+++ b/db/migrate/20260525034348_create_faq_entries.rb
@@ -1,0 +1,10 @@
+class CreateFaqEntries < ActiveRecord::Migration[8.1]
+  def change
+    create_table :faq_entries do |t|
+      t.string :question, null: false
+      t.text :answer, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260525190236_seed_faq_entries.rb
+++ b/db/migrate/20260525190236_seed_faq_entries.rb
@@ -1,0 +1,35 @@
+class SeedFaqEntries < ActiveRecord::Migration[8.1]
+  FAQ_ENTRIES = [
+    {
+      question: "Who is eligible?",
+      answer: "Stardance is for highschoolers! You need to be 13-18 years old to participate."
+    },
+    {
+      question: "How much does it cost?",
+      answer: "100% free* - all the prizes are donated to us or paid for by us! (*customs might occur outside of the US)"
+    },
+    {
+      question: "What types of projects count?",
+      answer: "All kinds of technical projects as long as it’s open-source!"
+    },
+    {
+      question: "How many projects can I build?",
+      answer: "There’s no limit! Dance as much as you can!"
+    },
+    {
+      question: "Is this legit?",
+      answer: "Yup. We’re Hack Club, a nonprofit that’s been running programs like this for years.\nPast rounds: Arcade, High Seas, Summer of Making, and Flavortown. Teens build projects, we send out real prizes. Stardance is this summer’s round."
+    }
+  ].freeze
+
+  def up
+    FAQ_ENTRIES.each do |attrs|
+      FaqEntry.find_or_create_by!(question: attrs[:question]) do |entry|
+        entry.answer = attrs[:answer]
+      end
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_19_091148) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_25_190236) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
@@ -188,6 +188,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_091148) do
     t.datetime "updated_at", null: false
     t.index ["item_type", "item_id"], name: "index_disco_recommendations_on_item"
     t.index ["subject_type", "subject_id"], name: "index_disco_recommendations_on_subject"
+  end
+
+  create_table "faq_entries", force: :cascade do |t|
+    t.text "answer", null: false
+    t.datetime "created_at", null: false
+    t.string "question", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "flavortime_sessions", force: :cascade do |t|


### PR DESCRIPTION
Adds a new page at `/faq` that simply lists frequently asked questions and their answers. Also adds an `faq_entries` table that stores the questions and answers, so new PRs are not needed each time the FAQ needs to be updated, and any admin or helper can do it from their respective dash (paper trail-ed). FAQ answers can also have markdown! Requested by @MMK21Hub 
<img width="900" alt="image" src="https://github.com/user-attachments/assets/ea620614-f765-4214-add4-eaa8b15d5c0e" />
<img width="800" alt="image" src="https://github.com/user-attachments/assets/ad0c81fc-93a3-4ce7-bfa5-41a6f86ee963" />
<img width="700" alt="image" src="https://github.com/user-attachments/assets/b60ca2f4-352a-45f2-b917-50aea48ccf7a" />
