### PR TITLE
fix(missions): permissions thingies (it was working on my machine :()

### DIFF
--- a/app/controllers/admin/missions/base_controller.rb
+++ b/app/controllers/admin/missions/base_controller.rb
@@ -17,10 +17,13 @@ module Admin
         @mission = Mission.find_by!(slug: slug)
       end
 
-      # Plain (non-namespaced) MissionPolicy so non-admin mission owners can
-      # reach these admin-URL'd sub-resource controllers.
+      # Non-admin mission owners can reach these admin-URL'd sub-resource
+      # controllers. Use the top-level ::MissionPolicy explicitly — bare
+      # `MissionPolicy` would resolve to the admin-namespaced policy here.
+      # skip_authorization satisfies the controller's `verify_authorized`.
       def authorize_mission_management
-        authorize @mission, :manage?, policy_class: MissionPolicy
+        raise Pundit::NotAuthorizedError unless ::MissionPolicy.new(current_user, @mission).manage?
+        skip_authorization
       end
     end
   end

--- a/app/controllers/admin/missions_controller.rb
+++ b/app/controllers/admin/missions_controller.rb
@@ -58,15 +58,12 @@ module Admin
     end
 
     def edit
-      # /admin/missions/:slug/edit is shared with non-admin mission owners
-      # via MissionPolicy#manage? — use the plain (non-namespaced) policy so
-      # owners pass; the rest of the actions stay admin-only via Admin::MissionPolicy.
-      authorize @mission, :manage?, policy_class: MissionPolicy
+      authorize_mission_management
       load_edit_locals
     end
 
     def update
-      authorize @mission, :manage?, policy_class: MissionPolicy
+      authorize_mission_management
       if @mission.update(mission_params)
         redirect_to edit_admin_mission_path(@mission.slug), notice: "Mission updated."
       else
@@ -97,6 +94,16 @@ module Admin
       @mission = Mission.with_deleted.find_by!(slug: params[:slug])
     end
 
+    # /admin/missions/:slug/edit is shared with non-admin mission owners via
+    # MissionPolicy#manage?. Use the top-level ::MissionPolicy explicitly —
+    # bare `MissionPolicy` would resolve to Admin::MissionPolicy under the
+    # Admin namespace, whose `manage?` is private and admin-only.
+    # skip_authorization satisfies the controller's `verify_authorized`.
+    def authorize_mission_management
+      raise Pundit::NotAuthorizedError unless ::MissionPolicy.new(current_user, @mission).manage?
+      skip_authorization
+    end
+
     def load_edit_locals
       @current_language    = @mission.resolve_storage_language(params[:language].presence)
       @available_languages = @mission.available_languages
@@ -109,8 +116,10 @@ module Admin
       @unlocks     = @mission.shop_unlocks.includes(:shop_item)
 
       # Admin-only sections (slug / owner CRUD / danger zone) render on the
-      # same edit page. Preload the owner list when the viewer can see them.
-      if policy(@mission).manage_owners?
+      # same edit page. Use ::MissionPolicy explicitly — `policy(@mission)`
+      # under the Admin namespace returns an Admin::MissionPolicy, which
+      # doesn't define `manage_owners?`.
+      if ::MissionPolicy.new(current_user, @mission).manage_owners?
         @owners = @mission.memberships
                           .where(role: Mission::Membership.roles[:owner])
                           .includes(:user)
@@ -148,7 +157,7 @@ module Admin
         :estimated_completion_minutes,
         :default_project_title, :default_project_description
       ]
-      permitted << :slug if policy(@mission).manage_owners?
+      permitted << :slug if ::MissionPolicy.new(current_user, @mission).manage_owners?
       params.require(:mission).permit(*permitted)
     end
   end

--- a/app/views/admin/missions/edit.html.erb
+++ b/app/views/admin/missions/edit.html.erb
@@ -5,7 +5,7 @@
     <header class="admin-mission-edit__header">
       <p class="admin-mission-edit__breadcrumb">
         <%= link_to "Mission", mission_path(@mission.slug) %>
-        <% if policy(@mission).manage_owners? %>
+        <% if ::MissionPolicy.new(current_user, @mission).manage_owners? %>
           <span aria-hidden="true">·</span>
           <%= link_to "Admin", admin_mission_path(@mission.slug) %>
         <% end %>
@@ -126,7 +126,7 @@
     <%= render "admin/missions/shop_unlocks_frame",
           mission: @mission, unlocks: @unlocks %>
 
-    <% if policy(@mission).manage_owners? %>
+    <% if ::MissionPolicy.new(current_user, @mission).manage_owners? %>
       <%# Admin-only sections — slug rename, owner add/remove, danger zone.
           Non-admin mission owners can't see any of this; they manage the
           mission content above and stop there. %>


### PR DESCRIPTION
there was an error with the way that the user perms were being routed to allow non-admin mission owners to access the specific admin page for their mission. it was for some reason working on my machine but not prod. Now fixed!