### PR TITLE
part 1/5 — feat(idv): verify badge, popup, and profile alert

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -40,6 +40,7 @@
 @use "components/command_palette";
 
 @use "components/streamer_mode";
+@use "components/idv_setup_card";
 
 // Pages
 @use "pages/onboarding" as onboarding_pages;

--- a/app/assets/stylesheets/components/_feed.scss
+++ b/app/assets/stylesheets/components/_feed.scss
@@ -275,6 +275,13 @@
     gap: var(--space-xxs);
   }
 
+  // Unverified `!` warning sits just left of the Post button.
+  &__submit-group {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+  }
+
   &__tool-btn {
     display: grid;
     place-items: center;

--- a/app/assets/stylesheets/components/_idv_setup_card.scss
+++ b/app/assets/stylesheets/components/_idv_setup_card.scss
@@ -1,0 +1,235 @@
+// Profile-level IDV CTA card and the small `!` badges that surface on the
+// user's own posts/profile when their identity isn't verified yet.
+//
+// Both live on set 1 surfaces (`#08061E`). The card pairs cream typography on
+// a lifted set-3 background so it feels like an alert, not part of the feed.
+// The badge uses salmon (`--color-brand-salmon`) since it's signalling the
+// user that something needs attention.
+
+.idv-setup-card {
+  background: var(--color-set-3-bg, #606684);
+  border: 2px solid var(--color-brand-highlight);
+  border-radius: 8px;
+  color: var(--color-brand-cream);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+  padding: 1.5rem 1.5rem 1.25rem;
+
+  &__eyebrow {
+    color: var(--color-brand-yellow);
+    font-size: var(--font-size-s);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    margin: 0;
+    text-transform: uppercase;
+  }
+
+  &__title {
+    color: var(--color-brand-cream);
+    font-family: "Playfair Display", serif;
+    font-size: var(--font-size-xl, 1.75rem);
+    font-style: italic;
+    font-weight: 700;
+    margin: 0;
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin: 0;
+  }
+
+  &__lede {
+    color: var(--color-brand-off-white);
+    font-size: var(--font-size-m);
+    line-height: 1.5;
+    margin: 0;
+  }
+
+  &__cta {
+    align-self: flex-start;
+    margin-top: 0.5rem;
+  }
+
+  &__footer {
+    border-top: 1px solid rgba(255, 255, 255, 0.18);
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin-top: 0.5rem;
+    padding-top: 0.75rem;
+  }
+
+  &__footer-line {
+    color: var(--color-brand-off-white);
+    font-size: var(--font-size-s);
+    margin: 0;
+    opacity: 0.85;
+  }
+
+  &__footer-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    margin: 0;
+  }
+
+  &__footer-link {
+    color: var(--color-brand-off-white);
+    font-size: var(--font-size-s);
+    text-decoration: underline;
+
+    &:hover,
+    &:focus-visible {
+      color: var(--color-brand-highlight);
+    }
+  }
+}
+
+// Round `!` warning shown to the owner on their own unverified profile,
+// devlogs, and the devlog composer. Opens the verify popup on click; a custom
+// tooltip explains the "private until verified" state on hover.
+.idv-badge {
+  appearance: none;
+  align-items: center;
+  background: var(--color-brand-salmon);
+  border: 0;
+  border-radius: 999px;
+  color: var(--color-space-bg);
+  cursor: pointer;
+  display: inline-flex;
+  font-family: "Exo 2", sans-serif;
+  font-weight: 700;
+  height: 1.25rem;
+  justify-content: center;
+  line-height: 1;
+  margin-left: 0.4rem;
+  min-width: 1.25rem;
+  padding: 0 0.4rem;
+  text-decoration: none;
+  vertical-align: middle;
+
+  &:hover,
+  &:focus-visible {
+    background: var(--color-brand-yellow);
+    color: var(--color-space-bg);
+    outline: none;
+    transform: translateY(-1px);
+  }
+
+  &__icon {
+    font-size: 0.9rem;
+    font-weight: 900;
+    line-height: 1;
+  }
+
+  // Status variants (mirrors Flavortown's id_verification_ui_for). Base is the
+  // salmon "danger" look; pending swaps to an amber "under review" tone.
+  &--warning {
+    background: var(--color-brand-yellow);
+
+    &:hover,
+    &:focus-visible {
+      background: var(--color-brand-peach, var(--color-brand-yellow));
+    }
+  }
+}
+
+// Verify-identity popup — same dialog shell + card treatment as the
+// "create new project" popup (see pages/projects/_new.scss).
+.idv-modal {
+  position: fixed;
+  inset: 0;
+  margin: auto;
+  width: min(560px, calc(100vw - 48px));
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+
+  &::backdrop {
+    background: rgba(8, 6, 30, 0.75);
+    backdrop-filter: blur(4px);
+  }
+
+  &__close {
+    position: absolute;
+    top: var(--space-m);
+    right: var(--space-m);
+    z-index: 10;
+    width: 36px;
+    height: 36px;
+    display: grid;
+    place-items: center;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--color-space-text);
+    font-size: 1.25rem;
+    line-height: 1;
+    cursor: pointer;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.18);
+    }
+  }
+
+  &__card {
+    background: rgba(8, 6, 30, 0.6);
+    border: 2px solid #5e6687;
+    border-radius: 8px;
+    color: var(--color-space-text);
+    padding: var(--space-l) var(--space-l) var(--space-xl);
+  }
+
+  // The setup card sits inside the modal's own card: drop its standalone
+  // chrome, center everything, and use set-1 text colors with a Title-2 style
+  // heading (Exo 2, per the style guide / the create-project popup).
+  .idv-setup-card {
+    align-items: center;
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+    margin: 0;
+    padding: 0;
+    text-align: center;
+
+    &__eyebrow {
+      color: var(--color-space-text-muted);
+    }
+
+    &__title {
+      color: var(--color-space-text);
+      font-family: var(--font-family-text);
+      font-size: clamp(2rem, 4vw, 3rem);
+      font-style: normal;
+      line-height: var(--line-height-headers);
+    }
+
+    &__body {
+      align-items: center;
+    }
+
+    &__lede {
+      color: var(--color-space-text);
+    }
+
+    &__cta {
+      align-self: center;
+    }
+
+    &__footer {
+      align-items: center;
+      text-align: center;
+    }
+
+    &__footer-links {
+      justify-content: center;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/_idv_setup_card.scss
+++ b/app/assets/stylesheets/components/_idv_setup_card.scss
@@ -54,6 +54,29 @@
     margin-top: 0.5rem;
   }
 
+  // Wraps the button_to "Check verification status" — keep it inline so it
+  // sits where the card's alignment puts it (centered inside the popup).
+  &__cta-form {
+    display: flex;
+    margin: 0;
+  }
+
+  &__checked {
+    color: var(--color-space-text-muted);
+    font-size: var(--font-size-s);
+    margin: 0.25rem 0 0;
+  }
+
+  &__dev-cta {
+    align-self: flex-start;
+    margin-top: 0.5rem;
+    opacity: 0.85;
+  }
+
+  &__dev-form {
+    margin: 0;
+  }
+
   &__footer {
     border-top: 1px solid rgba(255, 255, 255, 0.18);
     display: flex;
@@ -219,7 +242,8 @@
       color: var(--color-space-text);
     }
 
-    &__cta {
+    &__cta,
+    &__dev-cta {
       align-self: center;
     }
 

--- a/app/assets/stylesheets/pages/user/_show.scss
+++ b/app/assets/stylesheets/pages/user/_show.scss
@@ -290,6 +290,41 @@ turbo-frame#profile_tabs {
   font-style: italic;
 }
 
+// Owner-only IDV status line under the bio, with the second clause as an
+// underlined trigger for the verify popup. Colour reflects the status:
+// danger (not verified / failed) vs warning (under review).
+.profile__idv-alert {
+  font-size: var(--font-size-s);
+  font-weight: 600;
+  margin: 0.5rem 0 0;
+
+  &--danger {
+    color: var(--color-brand-salmon);
+  }
+
+  &--warning {
+    color: var(--color-brand-yellow);
+  }
+}
+
+.profile__idv-alert-link {
+  appearance: none;
+  background: none;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+
+  &:hover,
+  &:focus-visible {
+    color: var(--color-brand-yellow);
+    outline: none;
+  }
+}
+
 .bio-link {
   color: var(--color-space-text);
   text-decoration: underline;

--- a/app/components/idv_badge_component.html.erb
+++ b/app/components/idv_badge_component.html.erb
@@ -1,0 +1,9 @@
+<button type="button"
+        class="idv-badge idv-badge--<%= context %> idv-badge--<%= variant %>"
+        aria-label="<%= tooltip %>"
+        data-controller="tooltip"
+        data-tooltip-message-value="<%= tooltip %>"
+        data-tooltip-position-value="top"
+        onclick="document.getElementById('idv-verify-modal')?.showModal()">
+  <span class="idv-badge__icon" aria-hidden="true">!</span>
+</button>

--- a/app/components/idv_badge_component.rb
+++ b/app/components/idv_badge_component.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Small `!` badge shown only to the owner on their own posts/profile when their
+# identity isn't verified yet. The label is the hover text and explains that
+# the surrounding content is hidden from other users until verification is
+# done. Linking back to the profile IDV card means one place to act on it.
+class IdvBadgeComponent < ViewComponent::Base
+  attr_reader :user, :context
+
+  CONTEXTS = %i[profile devlog post comment].freeze
+
+  def initialize(user:, context: :devlog)
+    @user = user
+    @context = CONTEXTS.include?(context) ? context : :devlog
+  end
+
+  def render?
+    user.present? && !user.identity_verified?
+  end
+
+  # Pending = under review (warning/amber); needs_submission or ineligible
+  # (rejected/poor quality) = action needed (danger/red). Mirrors Flavortown's
+  # id_verification_ui_for variants.
+  def variant
+    user.verification_pending? ? "warning" : "danger"
+  end
+
+  def tooltip
+    noun = "your #{context}"
+    if user.verification_pending?
+      "Your identity is under review — #{noun} becomes public once it's approved."
+    elsif user.verification_ineligible?
+      "Your identity verification didn't go through — #{noun} stays private until it's sorted out."
+    else
+      "Only you and Hack Club admins can see #{noun} until you verify your identity."
+    end
+  end
+end

--- a/app/components/idv_setup_card_component.html.erb
+++ b/app/components/idv_setup_card_component.html.erb
@@ -1,0 +1,32 @@
+<section class="idv-setup-card" id="<%= dom_id %>" data-controller="idv-setup">
+  <p class="idv-setup-card__eyebrow"><%= status_eyebrow %></p>
+  <h2 class="idv-setup-card__title"><%= title %></h2>
+
+  <div class="idv-setup-card__body">
+    <% if pending? %>
+      <p class="idv-setup-card__lede">Your verification is in the queue. As soon as it's approved, your profile and devlogs become visible to other builders. We'll email you when it's done.</p>
+    <% elsif ineligible? %>
+      <p class="idv-setup-card__lede">Your last verification attempt didn't go through. Open the Hack Club portal to see what happened or contact support if you're stuck.</p>
+    <% else %>
+      <p class="idv-setup-card__lede">Right now, only you (and Hack Club admins) can see your profile and devlogs. Verify your identity through Hack Club to make your work public — it takes a minute and you'll come right back here.</p>
+      <p class="idv-setup-card__lede">Stardance is run by Hack Club, a 501(c)(3) nonprofit. Verification is part of how we keep the program safe and meet the recordkeeping rules nonprofits have to follow.</p>
+    <% end %>
+  </div>
+
+  <%= render ActionButtonComponent.new(
+        text: pending? ? "Check on Hack Club" : (ineligible? ? "Re-open Hack Club verification" : "Verify your identity"),
+        href: verify_url,
+        variant: :primary,
+        size: :large,
+        class: "idv-setup-card__cta",
+        data: { turbo: false }
+      ) %>
+
+  <footer class="idv-setup-card__footer">
+    <p class="idv-setup-card__footer-line">501(c)(3) nonprofit · We don't sell data or run ads</p>
+    <p class="idv-setup-card__footer-links">
+      <%= link_to "Why we ask for your info →", guide_path("why_we_ask"), target: "_blank", rel: "noopener", class: "idv-setup-card__footer-link" %>
+      <%= link_to "Privacy policy →", "https://hackclub.com/privacy", target: "_blank", rel: "noopener", class: "idv-setup-card__footer-link" %>
+    </p>
+  </footer>
+</section>

--- a/app/components/idv_setup_card_component.html.erb
+++ b/app/components/idv_setup_card_component.html.erb
@@ -13,14 +13,34 @@
     <% end %>
   </div>
 
-  <%= render ActionButtonComponent.new(
-        text: pending? ? "Check on Hack Club" : (ineligible? ? "Re-open Hack Club verification" : "Verify your identity"),
-        href: verify_url,
-        variant: :primary,
-        size: :large,
-        class: "idv-setup-card__cta",
-        data: { turbo: false }
-      ) %>
+  <% if pending? %>
+    <%= button_to "Check verification status",
+                  my_verification_refresh_path,
+                  method: :post,
+                  class: "action-btn action-btn--large action-btn--primary idv-setup-card__cta",
+                  form: { class: "idv-setup-card__cta-form" } %>
+  <% else %>
+    <%= render ActionButtonComponent.new(
+          text: ineligible? ? "Re-open Hack Club verification" : "Verify your identity",
+          href: verify_url,
+          variant: :primary,
+          size: :large,
+          class: "idv-setup-card__cta",
+          data: { turbo: false }
+        ) %>
+  <% end %>
+
+  <% if user.verification_checked_at.present? %>
+    <p class="idv-setup-card__checked">Last checked <%= helpers.time_ago_in_words(user.verification_checked_at) %> ago</p>
+  <% end %>
+
+  <% if Rails.env.development? %>
+    <%= button_to "Pretend IDV is verified (dev)",
+                  my_pretend_idv_dev_path,
+                  method: :post,
+                  class: "action-btn action-btn--small action-btn--secondary idv-setup-card__dev-cta",
+                  form: { class: "idv-setup-card__dev-form" } %>
+  <% end %>
 
   <footer class="idv-setup-card__footer">
     <p class="idv-setup-card__footer-line">501(c)(3) nonprofit · We don't sell data or run ads</p>

--- a/app/components/idv_setup_card_component.rb
+++ b/app/components/idv_setup_card_component.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Body of the "verify your identity" popup (shared/_idv_verify_modal), opened
+# from the IDV badge/alert when the user hasn't completed identity verification.
+# Tone matches the link-account screen — reassure, explain why, and link to
+# authoritative resources.
+class IdvSetupCardComponent < ViewComponent::Base
+  attr_reader :user, :return_to, :dom_id
+
+  def initialize(user:, return_to: nil, dom_id: "idv-setup")
+    @user = user
+    @return_to = return_to
+    @dom_id = dom_id
+  end
+
+  def render?
+    user.present? && !user.identity_verified?
+  end
+
+  def status_eyebrow
+    case user.verification_status
+    when "pending"     then "we're reviewing"
+    when "ineligible"  then "something went wrong"
+    else                    "your work isn't public yet"
+    end
+  end
+
+  def title
+    case user.verification_status
+    when "pending"     then "Hold tight — we're verifying your identity."
+    when "ineligible"  then "We couldn't verify your identity."
+    else                    "Verify your identity to share your work."
+    end
+  end
+
+  def pending?     = user.verification_pending?
+  def ineligible?  = user.verification_ineligible?
+
+  def verify_url
+    HCAService.verify_portal_url(return_to: return_to.presence || helpers.request.original_url)
+  end
+end

--- a/app/components/posts/composer_component.html.erb
+++ b/app/components/posts/composer_component.html.erb
@@ -95,15 +95,18 @@
           </div>
         </div>
 
-        <%= render ActionButtonComponent.new(
-              text: "Post",
-              size: :small,
-              type: :submit,
-              disable_with: "Posting...",
-              disabled: true,
-              class: "feed-composer__submit",
-              data: { composer_target: "submit" }
-            ) %>
+        <div class="feed-composer__submit-group">
+          <%= render IdvBadgeComponent.new(user: current_user, context: :devlog) %>
+          <%= render ActionButtonComponent.new(
+                text: "Post",
+                size: :small,
+                type: :submit,
+                disable_with: "Posting...",
+                disabled: true,
+                class: "feed-composer__submit",
+                data: { composer_target: "submit" }
+              ) %>
+        </div>
       </div>
     <% end %>
   </section>

--- a/app/controllers/my/dev_tools_controller.rb
+++ b/app/controllers/my/dev_tools_controller.rb
@@ -1,0 +1,17 @@
+class My::DevToolsController < ApplicationController
+  # Convenience endpoints for local development only — never reachable in
+  # production. Each action 404s outside of dev to keep the surface area tight.
+
+  def pretend_idv
+    return head :not_found unless Rails.env.development?
+    return head :unauthorized unless current_user
+
+    current_user.apply_hca_verification_payload!(
+      { "verification_status" => "verified", "ysws_eligible" => true },
+      persist_with_callbacks: false
+    )
+
+    redirect_back fallback_location: user_path(current_user),
+                  notice: "Dev override: pretending identity is verified."
+  end
+end

--- a/app/controllers/my/verifications_controller.rb
+++ b/app/controllers/my/verifications_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class My::VerificationsController < ApplicationController
+  # User-initiated "check my verification status" — re-pulls the latest from
+  # Hack Club Auth and applies it (same effect as the portal-return refresh),
+  # so a pending user can self-check without re-logging in or waiting for the
+  # background sweep.
+  def refresh
+    return head :unauthorized unless current_user
+
+    identity = current_user.hack_club_identity
+    if identity&.access_token.present?
+      payload = HCAService.identity(identity.access_token)
+      current_user.apply_hca_verification_payload!(payload) if payload.present?
+    end
+
+    redirect_back fallback_location: user_path(current_user), notice: status_message
+  rescue StandardError => e
+    Rails.logger.warn("Verification refresh failed: #{e.class}: #{e.message}")
+    Sentry.capture_exception(e, extra: { user_id: current_user&.id })
+    redirect_back fallback_location: user_path(current_user),
+                  alert: "Couldn't check your verification status right now — try again in a moment."
+  end
+
+  private
+
+  def status_message
+    current_user.reload
+    if current_user.identity_verified?
+      "You're verified — your work is now public."
+    elsif current_user.verification_pending?
+      "Still under review. We'll update this the moment Hack Club approves it."
+    elsif current_user.verification_ineligible?
+      "Your identity verification didn't go through. Open it to see what to do next."
+    else
+      "You haven't verified your identity yet."
+    end
+  end
+end

--- a/app/helpers/idv_helper.rb
+++ b/app/helpers/idv_helper.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module IdvHelper
+  # Ported from Flavortown's HomeHelper#id_verification_ui_for — maps a user's
+  # verification status to how the owner-facing IDV indicators present it.
+  #
+  # Statuses (User#verification_status enum): needs_submission, pending,
+  # verified, ineligible (ineligible == rejected / poor quality).
+  #
+  # Returns nil when there's nothing to flag (no user, or already verified).
+  #   variant – :warning (pending / under review) or :danger (action needed)
+  #   line    – the owner-facing "why your stuff is private" sentence
+  #   cta     – label for the link that opens the verify popup
+  def idv_status_for(user)
+    return nil if user.nil? || user.identity_verified?
+
+    if user.verification_pending?
+      { variant: :warning,
+        line: "We're reviewing your identity — your profile stays private until it's approved.",
+        cta: "Check status" }
+    elsif user.verification_ineligible?
+      { variant: :danger,
+        line: "Your identity verification didn't go through, so your profile is private.",
+        cta: "See what happened" }
+    else # needs_submission
+      { variant: :danger,
+        line: "Your profile is private.",
+        cta: "Verify your identity now" }
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,7 @@
 #  shop_region                  :enum
 #  synced_at                    :datetime
 #  things_dismissed             :string           default([]), not null, is an Array
+#  verification_checked_at      :datetime
 #  verification_status          :string           default("needs_submission"), not null
 #  vote_balance                 :integer          default(0), not null
 #  votes_count                  :integer

--- a/app/models/user/verification.rb
+++ b/app/models/user/verification.rb
@@ -32,6 +32,10 @@ module User::Verification
     status = payload["verification_status"].to_s
     return :invalid_status unless self.class.verification_statuses.key?(status)
 
+    # Record when we last pulled a status from HCA — drives the "last checked"
+    # line on the verify popup — regardless of whether anything changed.
+    update_columns(verification_checked_at: Time.current)
+
     fatal_rejection = payload["fatal_rejection"] == true
     return :ignored_ineligible if status == "ineligible" && !fatal_rejection
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -89,6 +89,7 @@
     <div id="flash-region"><%= render "shared/flash" %></div>
     <%= render Onboarding::GuestBannerComponent.new %>
     <%= yield %>
+    <%= render "shared/idv_verify_modal" %>
     <% unless @hide_footer %>
       <footer class="dev-footer">
         <p>

--- a/app/views/shared/_idv_verify_modal.html.erb
+++ b/app/views/shared/_idv_verify_modal.html.erb
@@ -1,0 +1,11 @@
+<%# Shared "verify your identity" popup, opened by the IDV alert badge from any
+    page (profile, feed, shop). Mounted once in the layout for unverified users.
+    Uses the same dialog/card treatment as the "create new project" popup. %>
+<% if current_user && !current_user.identity_verified? %>
+  <dialog id="idv-verify-modal" class="idv-modal" data-controller="modal" aria-label="Verify your identity">
+    <button type="button" class="idv-modal__close" aria-label="Close" onclick="this.closest('dialog').close()">&times;</button>
+    <div class="idv-modal__card">
+      <%= render IdvSetupCardComponent.new(user: current_user, dom_id: "idv-setup-modal") %>
+    </div>
+  </dialog>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -55,7 +55,7 @@
           </div>
 
           <div class="profile__identity-text">
-            <h1 class="profile__handle">@<%= @user.display_name %></h1>
+            <h1 class="profile__handle">@<%= @user.display_name %><% if own_profile %><%= render IdvBadgeComponent.new(user: @user, context: :profile) %><% end %></h1>
             <% if own_profile %>
               <div class="profile__handle-edit"
                    data-controller="username-availability"
@@ -118,6 +118,13 @@
                hidden></div>
           <p class="profile__bio-hint">Type <kbd>@</kbd> to mention a user, <kbd>$</kbd> to link a project.</p>
         </div>
+      <% end %>
+
+      <% if own_profile && (idv = idv_status_for(@user)) %>
+        <p class="profile__idv-alert profile__idv-alert--<%= idv[:variant] %>">
+          <%= idv[:line] %>
+          <button type="button" class="profile__idv-alert-link" onclick="document.getElementById('idv-verify-modal')?.showModal()"><%= idv[:cta] %></button>
+        </p>
       <% end %>
 
       <div class="profile__footer">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -487,6 +487,8 @@ Rails.application.routes.draw do
       post :streamer_mode, on: :member, action: :toggle_streamer_mode
     end
     resources :dismissals, only: [ :create ]
+    post "verification/refresh", to: "verifications#refresh", as: :verification_refresh
+    post "dev/pretend_idv", to: "dev_tools#pretend_idv", as: :pretend_idv_dev
   end
   get "my/achievements", to: "achievements#index", as: :my_achievements
 

--- a/db/migrate/20260529133839_add_verification_checked_at_to_users.rb
+++ b/db/migrate/20260529133839_add_verification_checked_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddVerificationCheckedAtToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :verification_checked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_28_132028) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_29_133839) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
@@ -1049,6 +1049,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_132028) do
     t.datetime "synced_at"
     t.string "things_dismissed", default: [], null: false, array: true
     t.datetime "updated_at", null: false
+    t.datetime "verification_checked_at"
     t.string "verification_status", default: "needs_submission", null: false
     t.integer "vote_balance", default: 0, null: false
     t.integer "votes_count"


### PR DESCRIPTION
visual implementations of idv stuff
- owner-only idv badge on profile handle, posts, post composing popup
- idv verify popup that asks you to idv - links to hca portal
- maps verification_status to badges and tooltip

pretty sure hca callback is working too

<img width="1125" height="760" alt="image" src="https://github.com/user-attachments/assets/5f9701dd-6db2-4447-b05f-17a8deb5fc6e" />
<img width="423" height="201" alt="image" src="https://github.com/user-attachments/assets/e9dcbf39-072e-474b-a7b5-af7b7fa4e706" />
<img width="754" height="661" alt="image" src="https://github.com/user-attachments/assets/0f150613-33b5-4c09-972d-c1e366edfd60" />