### PR TITLE
part 3/5 — feat(idv): hide unverified users' content until they verify

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -56,6 +56,7 @@
 @use "pages/shop/my_orders";
 @use "pages/shop/admin_order_show";
 @use "pages/user/show" as users_show;
+@use "pages/profile_placeholder";
 @use "pages/errors/not_authorized";
 @use "pages/errors/error" as errors_error;
 @use "pages/guides";

--- a/app/assets/stylesheets/pages/_profile_placeholder.scss
+++ b/app/assets/stylesheets/pages/_profile_placeholder.scss
@@ -1,0 +1,45 @@
+// Shown to non-admin, non-self viewers who land on a user profile before that
+// user has finished identity verification. Quiet, terse, non-stigmatizing — we
+// don't want to spotlight that the user is unverified, just explain why the
+// profile is empty.
+.profile-placeholder {
+  align-items: center;
+  background: var(--color-set-2-bg, #343651);
+  border-radius: 8px;
+  color: var(--color-brand-cream);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  margin: 0 auto;
+  max-width: 480px;
+  padding: 2.5rem 1.5rem 2rem;
+  text-align: center;
+
+  &__avatar-wrap {
+    border-radius: 999px;
+    overflow: hidden;
+    width: 88px;
+    height: 88px;
+  }
+
+  &__avatar {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  &__handle {
+    font-family: "Playfair Display", serif;
+    font-size: var(--font-size-xl, 1.75rem);
+    font-style: italic;
+    font-weight: 700;
+    margin: 0;
+  }
+
+  &__lede {
+    color: var(--color-brand-off-white);
+    font-size: var(--font-size-m);
+    line-height: 1.5;
+    margin: 0;
+  }
+}

--- a/app/components/posts/card_component.html.erb
+++ b/app/components/posts/card_component.html.erb
@@ -24,6 +24,10 @@
         <time class="feed-post-card__time" datetime="<%= post.created_at.iso8601 %>" title="<%= l(post.created_at, format: :long) %>">
           · <%= time_ago_in_words(post.created_at) %>
         </time>
+
+        <% if show_idv_badge? %>
+          <%= render IdvBadgeComponent.new(user: current_user, context: devlog? ? :devlog : :post) %>
+        <% end %>
       </p>
 
       <% if devlog? && postable.respond_to?(:duration_seconds) && postable.duration_seconds.present? %>

--- a/app/components/posts/card_component.rb
+++ b/app/components/posts/card_component.rb
@@ -71,5 +71,15 @@ module Posts
     def likeable
       postable if devlog?
     end
+
+    # When the current user is the post's author and they haven't yet verified
+    # their identity, surface a small badge in the card header to remind them
+    # that this content is hidden from everyone except admins.
+    def show_idv_badge?
+      current_user.present? &&
+        author.present? &&
+        current_user.id == author.id &&
+        !current_user.identity_verified?
+    end
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -16,6 +16,7 @@ class HomeController < ApplicationController
 
   def load_feed
     devlogs = Post.of_devlogs(join: true)
+                  .visible_to(current_user)
                   .where(post_devlogs: { deleted_at: nil })
                   .where(project_id: Project.not_deleted)
                   .includes(:user, :project)
@@ -24,6 +25,7 @@ class HomeController < ApplicationController
                   .limit(20)
 
     ship_events = Post.of_ship_events(join: true)
+                      .visible_to(current_user)
                       .where.not(post_ship_events: { certification_status: "rejected" })
                       .where(project_id: Project.not_deleted)
                       .includes(:user, :project, :postable)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -67,6 +67,7 @@ class ProjectsController < ApplicationController
 
     load_posts = -> {
       @project.posts
+               .visible_to(current_user)
                .includes(postable: [ :attachments_attachments ])
                .order(created_at: :desc)
                .select { |post| post.postable.present? }

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -8,6 +8,7 @@ class SearchController < ApplicationController
     q = params[:q].to_s.strip.delete_prefix("@")
 
     scope = User.discoverable.where.not(display_name: [ nil, "" ])
+    scope = scope.where(verification_status: "verified") unless current_user&.admin?
     scope = scope.where("LOWER(display_name) LIKE ?", "#{q.downcase}%") if q.present?
 
     results = scope

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,11 @@ class UsersController < ApplicationController
   ALLOWED_TABS = %w[feed devlogs replies projects].freeze
 
   def show
+    if profile_hidden_from_viewer?
+      render "users/unverified_placeholder", layout: "application"
+      return
+    end
+
     tab = params[:tab].presence_in(ALLOWED_TABS) || "feed"
     load_profile(tab)
   end
@@ -75,6 +80,7 @@ class UsersController < ApplicationController
   def profile_activity
     scope = Post.joins(:project)
                 .merge(Project.not_deleted)
+                .visible_to(current_user)
                 .where(user_id: @user.id)
                 .preload(:project, :user, postable: [ { attachments_attachments: :blob } ])
                 .order(created_at: :desc)
@@ -106,5 +112,14 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:bio, :banner, :display_name)
+  end
+
+  # Non-admin, non-self viewers see a placeholder until the user verifies.
+  def profile_hidden_from_viewer?
+    return false if @user.identity_verified?
+    return false if current_user&.admin?
+    return false if current_user&.id == @user.id
+
+    true
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -63,6 +63,30 @@ class Post < ApplicationRecord
                  optional: true
     end
 
+    # Restrict to posts whose author has finished identity verification.
+    # System posts (user_id IS NULL) are always allowed through — they aren't
+    # user-authored. The viewer-aware variant additionally lets a logged-in
+    # user see their own posts even before they verify, and short-circuits to
+    # `all` for admins (who can see everything).
+    scope :authored_by_verified, -> {
+      left_outer_joins(:user)
+        .where("posts.user_id IS NULL OR users.verification_status = 'verified'")
+    }
+
+    def self.visible_to(viewer)
+      return all if viewer&.admin?
+
+      scope = left_outer_joins(:user)
+      if viewer.present?
+        scope.where(
+          "posts.user_id IS NULL OR posts.user_id = ? OR users.verification_status = 'verified'",
+          viewer.id
+        )
+      else
+        scope.where("posts.user_id IS NULL OR users.verification_status = 'verified'")
+      end
+    end
+
     # For multiple types, use .with to create a CTE with UNION ALL:
     #   Post.with(
     #     available_posts: [

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -60,4 +60,11 @@ class ApplicationPolicy
   def signed_in_any?
     user.present?
   end
+
+  # True once the user has finished IDV. Used on actions that produce content
+  # visible to other users — comments, etc. — to make sure unverified users
+  # can't interact with the platform until verification is done.
+  def verified?
+    user.present? && user.identity_verified?
+  end
 end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -1,6 +1,6 @@
 class CommentPolicy < ApplicationPolicy
   def create?
-    logged_in?
+    logged_in? && verified?
   end
 
   def destroy?

--- a/app/views/users/unverified_placeholder.html.erb
+++ b/app/views/users/unverified_placeholder.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, "Verifying…" %>
+<% @body_class = "app-layout-page" %>
+
+<div class="app-layout">
+  <div class="app-layout__main">
+    <section class="profile-placeholder" aria-live="polite">
+      <div class="profile-placeholder__avatar-wrap">
+        <%= image_tag @user.avatar, alt: "", class: "profile-placeholder__avatar" %>
+      </div>
+
+      <h1 class="profile-placeholder__handle">@<%= @user.display_name.presence || "stardancer" %></h1>
+      <p class="profile-placeholder__lede">This stardancer is still verifying their identity. Check back soon — their profile and devlogs will show up once they're done.</p>
+    </section>
+  </div>
+
+  <%= render DiscoverRailComponent.new %>
+</div>

--- a/test/models/post_visibility_test.rb
+++ b/test/models/post_visibility_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class PostVisibilityTest < ActiveSupport::TestCase
+  setup do
+    @verified   = create_user(slack_id: "U_POST_VER", display_name: "pver")
+    @verified.update!(verification_status: "verified")
+
+    @unverified = create_user(slack_id: "U_POST_UNV", display_name: "punv")
+    @unverified.update!(verification_status: "needs_submission")
+
+    @admin = create_user(slack_id: "U_POST_ADMIN", display_name: "padmin")
+    @admin.update!(granted_roles: [ "admin" ])
+
+    @project = Project.create!(title: "vp", description: "d")
+    @project.memberships.create!(user: @verified, role: :owner)
+    @project.memberships.create!(user: @unverified, role: :contributor)
+
+    @verified_fire   = Post::FireEvent.create!(body: "ver fire")
+    @verified_post   = Post.create!(project: @project, user: @verified, postable: @verified_fire)
+
+    @unverified_fire = Post::FireEvent.create!(body: "unv fire")
+    @unverified_post = Post.create!(project: @project, user: @unverified, postable: @unverified_fire)
+  end
+
+  test "logged-out viewer only sees verified-author posts" do
+    visible_ids = Post.visible_to(nil).pluck(:id)
+    assert_includes visible_ids, @verified_post.id
+    refute_includes visible_ids, @unverified_post.id
+  end
+
+  test "non-admin viewer doesn't see unverified-author posts" do
+    other = create_user(slack_id: "U_POST_OTHER", display_name: "pother")
+    other.update!(verification_status: "verified")
+
+    visible_ids = Post.visible_to(other).pluck(:id)
+    assert_includes visible_ids, @verified_post.id
+    refute_includes visible_ids, @unverified_post.id
+  end
+
+  test "unverified viewer still sees their own posts" do
+    visible_ids = Post.visible_to(@unverified).pluck(:id)
+    assert_includes visible_ids, @unverified_post.id
+  end
+
+  test "admin sees every post regardless of verification" do
+    visible_ids = Post.visible_to(@admin).pluck(:id)
+    assert_includes visible_ids, @verified_post.id
+    assert_includes visible_ids, @unverified_post.id
+  end
+end

--- a/test/policies/comment_policy_test.rb
+++ b/test/policies/comment_policy_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class CommentPolicyTest < ActiveSupport::TestCase
+  setup do
+    @author    = create_user(slack_id: "U_COMMENT_AUTHOR", display_name: "ca")
+    @commenter = create_user(slack_id: "U_COMMENT_USER",   display_name: "cu")
+    @comment = Comment.new(user: @commenter)
+  end
+
+  test "create? is false for nil user" do
+    refute CommentPolicy.new(nil, @comment).create?
+  end
+
+  test "create? is false for a logged-in but unverified user" do
+    @commenter.update!(verification_status: "needs_submission")
+    refute CommentPolicy.new(@commenter, @comment).create?
+  end
+
+  test "create? is true once the user is verified" do
+    @commenter.update!(verification_status: "verified")
+    assert CommentPolicy.new(@commenter, @comment).create?
+  end
+
+  test "destroy? still allowed for owner regardless of verification" do
+    @commenter.update!(verification_status: "needs_submission")
+    assert CommentPolicy.new(@commenter, @comment).destroy?
+  end
+end


### PR DESCRIPTION
if you're unverified, posts show pending or needs IDV badges
<img width="721" height="464" alt="image" src="https://github.com/user-attachments/assets/8ce606a1-a018-43f8-a3a8-d675ab018c89" />

and if you're unverified, your posts only show to yourself and admins — other people can't see your post, and you also can't comment. (this part needs more testing)
<img width="679" height="480" alt="image" src="https://github.com/user-attachments/assets/06f5a6da-67b6-4538-a734-f76e6b23f064" />
