### PR TITLE
fix(auth): only validate display_name format when changed

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -147,8 +147,13 @@ class User < ApplicationRecord
 
   validates :display_name, presence: true
   validates :display_name, uniqueness: { case_sensitive: false }
-  validates :display_name, length: { maximum: MAX_DISPLAY_NAME_LENGTH }
-  validates :display_name, format: { with: USERNAME_FORMAT, message: "can only contain letters, numbers, hyphens, and underscores" }
+  # Length/format only apply when the name is actually being set or changed
+  # (onboarding name step, profile rename). Existing/HCA accounts can carry
+  # legacy names with spaces or other characters — enforcing the new format on
+  # every save would block them from logging in (user.save! in the HCA login
+  # flow would raise RecordInvalid → "Unable to save your account").
+  validates :display_name, length: { maximum: MAX_DISPLAY_NAME_LENGTH }, if: :display_name_changed?
+  validates :display_name, format: { with: USERNAME_FORMAT, message: "can only contain letters, numbers, hyphens, and underscores" }, if: :display_name_changed?
   validates :hcb_email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
 
   include User::Notifications


### PR DESCRIPTION
remove error of 'unable to save your account' when legacy usernames violate the new username restraints