### PR TITLE
Make CI run on main branch too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
   merge_group:
+  push:
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
This will help flag up merged PRs that have failing checks + commits pushed directly to `main`.