### PR TITLE
fix(onboading): onboarding wizard persistence

### DIFF
--- a/app/assets/stylesheets/pages/_onboarding.scss
+++ b/app/assets/stylesheets/pages/_onboarding.scss
@@ -6,6 +6,36 @@
   min-height: 100vh;
 }
 
+// "ada@example.com · Log out" strip pinned to the bottom-left corner so users
+// aren't trapped in the wizard. Subtle enough not to distract.
+.onboarding-escape {
+  bottom: 1rem;
+  color: rgba(255, 255, 255, 0.45);
+  font-family: "Exo 2", sans-serif;
+  font-size: 0.8rem;
+  left: 1.25rem;
+  position: fixed;
+  z-index: 10;
+
+  &__email {
+    font-weight: 500;
+  }
+
+  &__sep {
+    margin: 0 0.3em;
+  }
+
+  &__link {
+    color: rgba(255, 255, 255, 0.55);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+
+    &:hover {
+      color: rgba(255, 255, 255, 0.85);
+    }
+  }
+}
+
 // Shared animated background rendered by the onboarding layout. Lives behind
 // every wizard step except welcome + complete, which have their own elaborate
 // planet-based backgrounds.

--- a/app/controllers/concerns/onboarding_resumable.rb
+++ b/app/controllers/concerns/onboarding_resumable.rb
@@ -1,0 +1,48 @@
+# Shared logic for resuming or expiring an interrupted signup-wizard session.
+#
+# A "mid-onboarding" user is a guest who entered the wizard but never reached
+# the final name step (onboarded_at still nil). The freshness window is anchored
+# on when they started the wizard (created_at).
+#
+# Gated on the :new_onboarding flag: only when it's on is the wizard the sole
+# way to become an onboarded_at-nil guest, so the signal can't be confused with
+# project-setup / link-gate guests from the old flow.
+module OnboardingResumable
+  extend ActiveSupport::Concern
+
+  ONBOARDING_WINDOW = 7.days
+
+  private
+
+  def onboarding_in_progress?(user)
+    return false unless Flipper.enabled?(:new_onboarding)
+
+    user&.guest? && user.onboarded_at.nil?
+  end
+
+  # Within the active window, anchored on when they first started onboarding.
+  def onboarding_fresh?(user)
+    user.created_at >= ONBOARDING_WINDOW.ago
+  end
+
+  # The first wizard step the user hasn't answered yet.
+  def onboarding_resume_path(user)
+    return onboarding_birthday_path   if user.age_attestation.blank?
+    return onboarding_experience_path if user.experience_level.blank?
+    return onboarding_interests_path  if user.interests.blank?
+
+    onboarding_name_path
+  end
+
+  # Wipe wizard answers so the flow starts over from the top. The email and
+  # placeholder name are kept (email is unique, and the name is still a
+  # placeholder because they never finished the name step).
+  def restart_onboarding!(user)
+    user.update!(
+      age_attestation: nil,
+      experience_level: nil,
+      interests: [],
+      onboarded_at: nil
+    )
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,8 @@
 class HomeController < ApplicationController
+  include OnboardingResumable
+
+  before_action :resume_or_expire_onboarding!, only: :index
+
   def index
     authorize :home
     @body_class = "app-layout-page"
@@ -13,6 +17,21 @@ class HomeController < ApplicationController
   end
 
   private
+
+  # A guest who bailed mid-wizard and lands on /home: bring them back to where
+  # they left off if they started within the window, otherwise treat the
+  # placeholder account as expired and drop them on the landing page.
+  def resume_or_expire_onboarding!
+    user = current_user
+    return unless onboarding_in_progress?(user)
+
+    if onboarding_fresh?(user)
+      redirect_to onboarding_resume_path(user)
+    else
+      reset_session
+      redirect_to root_path
+    end
+  end
 
   def load_feed
     devlogs = Post.of_devlogs(join: true)

--- a/app/controllers/onboarding/wizard_controller.rb
+++ b/app/controllers/onboarding/wizard_controller.rb
@@ -1,4 +1,6 @@
 class Onboarding::WizardController < ApplicationController
+  include OnboardingResumable
+
   layout "onboarding"
 
   before_action :require_onboarding_guest!,  only: %i[welcome birthday submit_birthday
@@ -10,7 +12,8 @@ class Onboarding::WizardController < ApplicationController
                                                       name submit_name]
 
   def start
-    if current_user.present?
+    # A fully-linked member has nothing left to onboard.
+    if current_user&.hca_linked?
       redirect_to home_path and return
     end
 
@@ -31,6 +34,19 @@ class Onboarding::WizardController < ApplicationController
 
     if existing
       session[:user_id] = existing.id
+
+      if onboarding_in_progress?(existing)
+        if onboarding_fresh?(existing)
+          # Started within the window — drop them back where they left off.
+          redirect_to onboarding_resume_path(existing) and return
+        else
+          # Stale placeholder account — wipe progress and start over.
+          restart_onboarding!(existing)
+          redirect_to onboarding_welcome_path and return
+        end
+      end
+
+      # Guest who already finished the wizard (still needs to link HCA later).
       redirect_to home_path and return
     end
 
@@ -130,7 +146,7 @@ class Onboarding::WizardController < ApplicationController
 
   def create_guest!(email)
     5.times do
-      user = User.new(email: email, display_name: User.random_funny_display_name)
+      user = User.new(email: email, display_name: User.placeholder_display_name_from_email(email))
       return user if user.save
       # Email collision means the user already exists — hand back the existing
       # record. For any other error (most likely a display_name collision in

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -186,6 +186,20 @@ class User < ApplicationRecord
     "#{KERBAL_FIRST_NAMES.sample}_Kerman_#{rand(1000..9999)}"
   end
 
+  # Auto-assigned placeholder name for a guest who hasn't picked one yet: the
+  # email's local part plus a random number (e.g. "ada_lovelace_4821"). Trimmed
+  # to fit MAX_DISPLAY_NAME_LENGTH and the USERNAME_FORMAT; falls back to a
+  # Kerbal name when the local part has no usable characters.
+  def self.placeholder_display_name_from_email(email)
+    local = email.to_s.split("@").first.to_s
+                 .gsub(/[^a-zA-Z0-9_-]/, "_")
+                 .gsub(/_{2,}/, "_")
+                 .delete_prefix("_").delete_suffix("_")
+    return random_funny_display_name if local.blank?
+
+    "#{local.first(MAX_DISPLAY_NAME_LENGTH - 5)}_#{rand(1000..9999)}"
+  end
+
   def active_project_for_mission(mission)
     return nil if mission.nil?
     projects

--- a/app/views/layouts/onboarding.html.erb
+++ b/app/views/layouts/onboarding.html.erb
@@ -22,5 +22,12 @@
     </div>
     <div id="flash-region"><%= render "shared/flash" %></div>
     <%= yield %>
+    <% if current_user %>
+      <div class="onboarding-escape">
+        <span class="onboarding-escape__email"><%= current_user.email %></span>
+        <span class="onboarding-escape__sep">&middot;</span>
+        <%= link_to "Log out", logout_path, data: { turbo_method: :delete }, class: "onboarding-escape__link" %>
+      </div>
+    <% end %>
   </body>
 </html>

--- a/test/controllers/onboarding/resume_test.rb
+++ b/test/controllers/onboarding/resume_test.rb
@@ -1,0 +1,96 @@
+require "test_helper"
+
+# Behavior for interrupted signup-wizard sessions: resuming a fresh guest,
+# restarting a stale one, and expiring a stale guest who lands on /home.
+# All of this is gated on the :new_onboarding flag.
+class Onboarding::ResumeTest < ActionDispatch::IntegrationTest
+  setup do
+    Flipper.enable(:new_onboarding)
+  end
+
+  teardown do
+    Flipper.disable(:new_onboarding)
+  end
+
+  # A guest part-way through the wizard (no project, onboarded_at nil).
+  def in_progress_guest(email: "resume_me@example.com", **attrs)
+    User.create!(email: email, display_name: User.placeholder_display_name_from_email(email), **attrs)
+  end
+
+  test "placeholder display name is derived from the email plus a number" do
+    post onboarding_start_path, params: { email: "ada.lovelace@example.com" }
+
+    user = User.find_by(email: "ada.lovelace@example.com")
+    assert_match(/\Aada_lovelace_\d+\z/, user.display_name)
+  end
+
+  test "submitting email for a fresh in-progress guest resumes at the next unanswered step" do
+    guest = in_progress_guest(age_attestation: "teen_13_18") # answered birthday only
+
+    post onboarding_start_path, params: { email: guest.email }
+
+    assert_redirected_to onboarding_experience_path
+    assert_equal guest.id, session[:user_id]
+  end
+
+  test "fresh guest with no answers resumes at the birthday step" do
+    guest = in_progress_guest
+
+    post onboarding_start_path, params: { email: guest.email }
+
+    assert_redirected_to onboarding_birthday_path
+  end
+
+  test "submitting email for a stale in-progress guest restarts the wizard" do
+    guest = in_progress_guest(age_attestation: "teen_13_18", experience_level: "some", interests: %w[web_dev])
+    guest.update_column(:created_at, 8.days.ago)
+
+    post onboarding_start_path, params: { email: guest.email }
+
+    assert_redirected_to onboarding_welcome_path
+    guest.reload
+    assert_nil guest.age_attestation
+    assert_nil guest.experience_level
+    assert_empty guest.interests
+    assert_nil guest.onboarded_at
+  end
+
+  test "fresh in-progress guest visiting /home is sent back to where they left off" do
+    guest = in_progress_guest(age_attestation: "teen_13_18", experience_level: "some")
+    sign_in guest
+
+    get home_path
+
+    assert_redirected_to onboarding_interests_path
+  end
+
+  test "stale in-progress guest visiting /home is logged out and sent to the landing page" do
+    guest = in_progress_guest(age_attestation: "teen_13_18")
+    guest.update_column(:created_at, 8.days.ago)
+    sign_in guest
+
+    get home_path
+
+    assert_redirected_to root_path
+    assert_nil session[:user_id]
+  end
+
+  test "a guest who finished the wizard is not pulled back into onboarding from /home" do
+    guest = in_progress_guest(age_attestation: "teen_13_18", onboarded_at: Time.current)
+    sign_in guest
+
+    get home_path
+
+    assert_response :success
+  end
+
+  test "with the flag off an in-progress guest on /home is left alone" do
+    Flipper.disable(:new_onboarding)
+    guest = in_progress_guest(age_attestation: "teen_13_18")
+    sign_in guest
+
+    get home_path
+
+    assert_response :success
+  end
+end


### PR DESCRIPTION
if you start onboarding and close your tab, you can return to onboarding instead of being thrown into the platform. yay!!!!!!

+ if it's been >7d since you last touched the website, it sends you to the landing page and you sign up again.

+ a small log out button at the bottom left so you're not trapped in whatever email you had