### PR TITLE
fix(idv): idv edge cases fixes

### DIFF
--- a/app/assets/stylesheets/components/_idv_setup_card.scss
+++ b/app/assets/stylesheets/components/_idv_setup_card.scss
@@ -140,7 +140,6 @@
     background: var(--color-brand-yellow);
     color: var(--color-space-bg);
     outline: none;
-    transform: translateY(-1px);
   }
 
   &__icon {

--- a/app/assets/stylesheets/pages/user/_show.scss
+++ b/app/assets/stylesheets/pages/user/_show.scss
@@ -294,6 +294,9 @@ turbo-frame#profile_tabs {
 // underlined trigger for the verify popup. Colour reflects the status:
 // danger (not verified / failed) vs warning (under review).
 .profile__idv-alert {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
   font-size: var(--font-size-s);
   font-weight: 600;
   margin: 0.5rem 0 0;
@@ -304,6 +307,26 @@ turbo-frame#profile_tabs {
 
   &--warning {
     color: var(--color-brand-yellow);
+  }
+
+  &--success {
+    color: var(--color-brand-green, #4ade80);
+  }
+}
+
+.profile__idv-alert-dismiss {
+  appearance: none;
+  background: none;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1.1em;
+  line-height: 1;
+  opacity: 0.7;
+  padding: 0;
+
+  &:hover {
+    opacity: 1;
   }
 }
 

--- a/app/components/idv_badge_component.rb
+++ b/app/components/idv_badge_component.rb
@@ -26,12 +26,13 @@ class IdvBadgeComponent < ViewComponent::Base
   end
 
   def tooltip
+    subject = context == :profile ? "Your account" : "This #{context}"
     if user.verification_pending?
-      "Your identity is under review. Your posts will not be visible to the public until it's approved."
+      "Your identity is under review. #{subject} will not be visible to the public until it's approved."
     elsif user.verification_ineligible?
-      "Your identity verification didn't go through. Your posts will stay private until it's sorted out."
+      "Your identity verification didn't go through. #{subject} will stay private until it's sorted out."
     else
-      "Your posts are only visible to you and Hack Club admins until you verify your identity."
+      "#{subject} is only visible to you and Hack Club admins until you verify your identity."
     end
   end
 end

--- a/app/components/idv_badge_component.rb
+++ b/app/components/idv_badge_component.rb
@@ -26,13 +26,12 @@ class IdvBadgeComponent < ViewComponent::Base
   end
 
   def tooltip
-    noun = "your #{context}"
     if user.verification_pending?
-      "Your identity is under review — #{noun} becomes public once it's approved."
+      "Your identity is under review. Your posts will not be visible to the public until it's approved."
     elsif user.verification_ineligible?
-      "Your identity verification didn't go through — #{noun} stays private until it's sorted out."
+      "Your identity verification didn't go through. Your posts will stay private until it's sorted out."
     else
-      "Only you and Hack Club admins can see #{noun} until you verify your identity."
+      "Your posts are only visible to you and Hack Club admins until you verify your identity."
     end
   end
 end

--- a/app/components/idv_setup_card_component.html.erb
+++ b/app/components/idv_setup_card_component.html.erb
@@ -3,7 +3,9 @@
   <h2 class="idv-setup-card__title"><%= title %></h2>
 
   <div class="idv-setup-card__body">
-    <% if pending? %>
+    <% if ysws_ineligible? %>
+      <p class="idv-setup-card__lede">Your identity is verified and your work is public, but you're not yet eligible for YSWS prizes. Open the Hack Club portal for details or contact support.</p>
+    <% elsif pending? %>
       <p class="idv-setup-card__lede">Your verification is in the queue. As soon as it's approved, your profile and devlogs become visible to other builders. We'll email you when it's done.</p>
     <% elsif ineligible? %>
       <p class="idv-setup-card__lede">Your last verification attempt didn't go through. Open the Hack Club portal to see what happened or contact support if you're stuck.</p>
@@ -13,7 +15,16 @@
     <% end %>
   </div>
 
-  <% if pending? %>
+  <% if ysws_ineligible? %>
+    <%= render ActionButtonComponent.new(
+          text: "Open Hack Club portal",
+          href: verify_url,
+          variant: :primary,
+          size: :large,
+          class: "idv-setup-card__cta",
+          data: { turbo: false }
+        ) %>
+  <% elsif pending? %>
     <%= button_to "Check verification status",
                   my_verification_refresh_path,
                   method: :post,

--- a/app/components/idv_setup_card_component.rb
+++ b/app/components/idv_setup_card_component.rb
@@ -14,10 +14,12 @@ class IdvSetupCardComponent < ViewComponent::Base
   end
 
   def render?
-    user.present? && !user.identity_verified?
+    user.present? && (!user.identity_verified? || ysws_ineligible?)
   end
 
   def status_eyebrow
+    return "not eligible for prizes" if ysws_ineligible?
+
     case user.verification_status
     when "pending"     then "we're reviewing"
     when "ineligible"  then "something went wrong"
@@ -26,6 +28,8 @@ class IdvSetupCardComponent < ViewComponent::Base
   end
 
   def title
+    return "You're verified, but not eligible for YSWS yet." if ysws_ineligible?
+
     case user.verification_status
     when "pending"     then "Hold tight — we're verifying your identity."
     when "ineligible"  then "We couldn't verify your identity."
@@ -33,8 +37,9 @@ class IdvSetupCardComponent < ViewComponent::Base
     end
   end
 
-  def pending?     = user.verification_pending?
-  def ineligible?  = user.verification_ineligible?
+  def pending?          = user.verification_pending?
+  def ineligible?       = user.verification_ineligible?
+  def ysws_ineligible?  = user.identity_verified? && !user.ysws_eligible?
 
   def verify_url
     HCAService.verify_portal_url(return_to: return_to.presence || helpers.request.original_url)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -259,6 +259,13 @@ class ApplicationController < ActionController::Base
     return if identity_payload.blank?
 
     current_user.apply_hca_verification_payload!(identity_payload)
+    current_user.reload
+
+    if current_user.identity_verified?
+      redirect_to user_path(current_user), notice: "You're verified — your work is now public!" and return
+    else
+      redirect_to user_path(current_user, idv_check: 1) and return
+    end
   rescue StandardError => e
     Rails.logger.warn("Portal return identity refresh failed: #{e.class}: #{e.message}")
   end

--- a/app/helpers/idv_helper.rb
+++ b/app/helpers/idv_helper.rb
@@ -12,9 +12,14 @@ module IdvHelper
   #   line    – the owner-facing "why your stuff is private" sentence
   #   cta     – label for the link that opens the verify popup
   def idv_status_for(user)
-    return nil if user.nil? || user.identity_verified?
+    return nil if user.nil?
+    return nil if user.identity_verified? && user.ysws_eligible?
 
-    if user.verification_pending?
+    if user.identity_verified? && !user.ysws_eligible?
+      { variant: :warning,
+        line: "Your identity is verified, but you're not eligible for YSWS prizes yet.",
+        cta: "Learn more" }
+    elsif user.verification_pending?
       { variant: :warning,
         line: "We're reviewing your identity — your profile stays private until it's approved.",
         cta: "Check status" }

--- a/app/javascript/controllers/dismissable_controller.js
+++ b/app/javascript/controllers/dismissable_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static values = { cookie: String };
+
+  dismiss() {
+    if (this.cookieValue) {
+      document.cookie = `${this.cookieValue}=1; path=/; max-age=${60 * 60 * 24 * 365}`;
+    }
+    this.element.remove();
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -70,6 +70,9 @@ application.register("customs-warning", CustomsWarningController);
 import DecisionTreeController from "./decision_tree_controller";
 application.register("decision-tree", DecisionTreeController);
 
+import DismissableController from "./dismissable_controller";
+application.register("dismissable", DismissableController);
+
 import EmojiPickerController from "./emoji_picker_controller";
 application.register("emoji-picker", EmojiPickerController);
 

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -29,6 +29,7 @@ export default class extends Controller {
     }
 
     this.openSettingsModalFromQueryParam();
+    this.openIdvModalFromQueryParam();
   }
 
   disconnect() {
@@ -105,6 +106,24 @@ export default class extends Controller {
     }
 
     params.delete("settings");
+    const query = params.toString();
+    const nextUrl = `${window.location.pathname}${query ? `?${query}` : ""}${
+      window.location.hash
+    }`;
+    window.history.replaceState(window.history.state, "", nextUrl);
+  }
+
+  openIdvModalFromQueryParam() {
+    if (this.element.id !== "idv-verify-modal") return;
+
+    const params = new URLSearchParams(window.location.search);
+    if (!params.has("idv_check")) return;
+
+    if (!this.element.open) {
+      this.element.showModal();
+    }
+
+    params.delete("idv_check");
     const query = params.toString();
     const nextUrl = `${window.location.pathname}${query ? `?${query}` : ""}${
       window.location.hash

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -66,7 +66,7 @@ export default class extends Controller {
     }
     this.popover.appendChild(document.createTextNode(this.messageValue));
 
-    document.body.appendChild(this.popover);
+    this.#container().appendChild(this.popover);
 
     this.reposition();
 
@@ -126,6 +126,13 @@ export default class extends Controller {
         break;
     }
 
+    const container = this.#container();
+    if (container !== document.body) {
+      const cr = container.getBoundingClientRect();
+      top -= cr.top;
+      left -= cr.left;
+    }
+
     this.popover.style.top = `${Math.max(8, top)}px`;
     this.popover.style.left = `${Math.max(8, left)}px`;
   }
@@ -138,5 +145,10 @@ export default class extends Controller {
 
   handleKey(event) {
     if (event.key === "Escape") this.hide();
+  }
+
+  #container() {
+    const dialog = this.element.closest("dialog[open]");
+    return dialog || document.body;
   }
 }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -362,6 +362,13 @@ class Project < ApplicationRecord
         passed: memberships.owner.first&.user&.identity_verified?
       },
       {
+        key: :ysws_eligible,
+        label: "You're eligible for YSWS prizes",
+        fail_label: "You're not eligible for YSWS prizes yet — check the Hack Club portal",
+        tooltip: "Your identity is verified, but YSWS eligibility is still pending. Open the Hack Club portal for details.",
+        passed: memberships.owner.first&.user&.ysws_eligible?
+      },
+      {
         key: :shop_tutorial,
         label: "Pick stickers or nothing in the shop once",
         fail_label: "Visit the shop and pick stickers (or nothing) to get started",

--- a/app/views/shared/_idv_verify_modal.html.erb
+++ b/app/views/shared/_idv_verify_modal.html.erb
@@ -1,7 +1,7 @@
 <%# Shared "verify your identity" popup, opened by the IDV alert badge from any
     page (profile, feed, shop). Mounted once in the layout for unverified users.
     Uses the same dialog/card treatment as the "create new project" popup. %>
-<% if current_user && !current_user.identity_verified? %>
+<% if current_user && (!current_user.identity_verified? || !current_user.ysws_eligible?) %>
   <dialog id="idv-verify-modal" class="idv-modal" data-controller="modal" aria-label="Verify your identity">
     <button type="button" class="idv-modal__close" aria-label="Close" onclick="this.closest('dialog').close()">&times;</button>
     <div class="idv-modal__card">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -120,6 +120,14 @@
         </div>
       <% end %>
 
+      <% if own_profile && @user.identity_verified? && !cookies[:idv_approved_dismissed] %>
+        <p class="profile__idv-alert profile__idv-alert--success"
+           data-controller="dismissable"
+           data-dismissable-cookie-value="idv_approved_dismissed">
+          You're verified — your work is now public!
+          <button type="button" class="profile__idv-alert-dismiss" data-action="click->dismissable#dismiss" aria-label="Dismiss">&times;</button>
+        </p>
+      <% end %>
       <% if own_profile && (idv = idv_status_for(@user)) %>
         <p class="profile__idv-alert profile__idv-alert--<%= idv[:variant] %>">
           <%= idv[:line] %>


### PR DESCRIPTION
1. add tooltip to writing devlog, it was broken before
<img width="690" height="235" alt="image" src="https://github.com/user-attachments/assets/f8d1185c-4f90-451e-8509-1aa628cd22de" />

2. shows that you're ineligible if you are not ysws eligible, in consistency with flavortown's changes

3. after idv-ing, redirect to 'pending' popup in profile page

4. verified banner after u get idv verified that is dismissable