### PR TITLE
feat(shop): restyle and clarity

### DIFF
--- a/app/assets/stylesheets/components/_discover_rail.scss
+++ b/app/assets/stylesheets/components/_discover_rail.scss
@@ -71,3 +71,73 @@
     height: 238px;
   }
 }
+
+.discover-rail__placeholder-text {
+  background: rgba(217, 217, 217, 0.08);
+  border-radius: 8px;
+  color: var(--color-brand-off-white);
+  font-size: 0.9rem;
+  margin: 0;
+  opacity: 0.75;
+  padding: 0.7rem 0.9rem;
+}
+
+.discover-rail__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.discover-rail__card {
+  background: rgba(217, 217, 217, 0.18);
+  border-radius: 8px;
+  color: var(--color-space-text);
+  min-height: 48px;
+  padding: 0.6rem 0.75rem;
+}
+
+.discover-rail__card-title {
+  font-size: 0.85rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.discover-rail__card-body {
+  color: var(--color-brand-off-white);
+  font-size: 0.8rem;
+  margin: 0.15rem 0 0;
+  opacity: 0.85;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.discover-rail__link {
+  align-self: flex-end;
+  color: var(--color-space-text);
+  font-size: 0.85rem;
+  text-decoration: underline;
+
+  &:hover,
+  &:focus-visible {
+    color: var(--color-brand-highlight);
+  }
+}
+
+.discover-rail__section--wishlist {
+  .shop-goals__container {
+    background: transparent;
+    border: 0;
+    margin: 0;
+    padding: 0;
+  }
+
+  .shop-goals__items {
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+  }
+}

--- a/app/assets/stylesheets/components/_dropdown.scss
+++ b/app/assets/stylesheets/components/_dropdown.scss
@@ -45,4 +45,41 @@
       }
     }
   }
+
+  // Dark-on-dark variant for the space theme (shop pages, etc.)
+  &--space {
+    .dropdown__label {
+      color: var(--color-space-text-muted);
+      font-family: "Exo 2", sans-serif;
+      font-size: 0.8rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .dropdown__select {
+      background-color: var(--color-space-surface-faint);
+      border-color: var(--color-space-border);
+      border-radius: 8px;
+      color: var(--color-space-text);
+      font-family: "Exo 2", sans-serif;
+      font-weight: 600;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='white' stroke-width='2' fill='none'/%3E%3C/svg%3E");
+      transition: border-color 160ms ease, background-color 160ms ease;
+
+      &:hover {
+        background-color: var(--color-space-surface-soft);
+      }
+
+      &:focus {
+        border-color: var(--color-brand-highlight);
+        outline: 2px solid var(--color-brand-highlight-soft);
+        outline-offset: 1px;
+      }
+
+      option {
+        background: var(--color-space-bg-2);
+        color: var(--color-space-text);
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/components/_dropdown.scss
+++ b/app/assets/stylesheets/components/_dropdown.scss
@@ -64,7 +64,9 @@
       font-family: "Exo 2", sans-serif;
       font-weight: 600;
       background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='white' stroke-width='2' fill='none'/%3E%3C/svg%3E");
-      transition: border-color 160ms ease, background-color 160ms ease;
+      transition:
+        border-color 160ms ease,
+        background-color 160ms ease;
 
       &:hover {
         background-color: var(--color-space-surface-soft);

--- a/app/assets/stylesheets/pages/shop/_hub.scss
+++ b/app/assets/stylesheets/pages/shop/_hub.scss
@@ -5,7 +5,6 @@
 
 .shop-hub {
   --shop-hub-gutter: 2.5rem;
-  --shop-hub-rail-width: 22rem;
 
   color: var(--color-space-text);
   padding: 1.5rem clamp(1.5rem, 4vw, 3rem) 4rem;
@@ -41,7 +40,7 @@
     display: grid;
     column-gap: var(--shop-hub-gutter);
     row-gap: 2rem;
-    grid-template-columns: minmax(0, 1fr) var(--shop-hub-rail-width);
+    grid-template-columns: minmax(0, 1fr) 264px;
     grid-template-areas:
       "topbar topbar"
       "main   rail"
@@ -56,6 +55,21 @@
         "new"
         "popular"
         "rail";
+    }
+  }
+
+  &__rail {
+    grid-area: rail;
+
+    .discover-rail {
+      position: static;
+      width: 100%;
+      max-height: none;
+      overflow: visible;
+    }
+
+    .discover-rail__search {
+      display: none;
     }
   }
 
@@ -453,99 +467,6 @@
     &:focus-visible {
       filter: brightness(1.05);
       outline: none;
-    }
-  }
-
-  &__sidebar {
-    display: flex;
-    flex-direction: column;
-    gap: 1.75rem;
-    grid-area: rail;
-  }
-
-  &__sidebar-block {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-  }
-
-  &__sidebar-title {
-    color: var(--color-space-text);
-    font-family: "Exo 2", sans-serif;
-    font-size: 1rem;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    margin: 0;
-  }
-
-  &__sidebar-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.55rem;
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  &__sidebar-card {
-    background: rgba(217, 217, 217, 0.18);
-    border-radius: 8px;
-    color: var(--color-space-text);
-    min-height: 64px;
-    padding: 0.75rem 0.9rem;
-  }
-
-  &__sidebar-card-title {
-    font-size: 0.95rem;
-    font-weight: 700;
-    margin: 0;
-    text-decoration: underline;
-  }
-
-  &__sidebar-card-body {
-    color: var(--color-brand-off-white);
-    font-size: 0.85rem;
-    margin: 0.2rem 0 0;
-    opacity: 0.85;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  &__sidebar-empty {
-    background: rgba(217, 217, 217, 0.08);
-    border-radius: 8px;
-    color: var(--color-brand-off-white);
-    font-size: 0.9rem;
-    margin: 0;
-    opacity: 0.75;
-    padding: 0.7rem 0.9rem;
-  }
-
-  &__sidebar-link {
-    align-self: flex-end;
-    color: var(--color-space-text);
-    font-size: 0.95rem;
-    text-decoration: underline;
-
-    &:hover,
-    &:focus-visible {
-      color: var(--color-brand-highlight);
-    }
-  }
-
-  &__sidebar-block--wishlist {
-    .shop-goals__container {
-      background: transparent;
-      border: 0;
-      margin: 0;
-      padding: 0;
-    }
-
-    .shop-goals__items {
-      display: flex;
-      flex-direction: column;
-      gap: 0.55rem;
     }
   }
 

--- a/app/assets/stylesheets/pages/shop/_hub.scss
+++ b/app/assets/stylesheets/pages/shop/_hub.scss
@@ -1,6 +1,7 @@
-// Stardance shop hub — category tiles + Discover row on the left, YOUR
-// ORDERS / SHOP UPDATES / WISHLIST rail on the right. The sidebar comes from
-// the application layout; this file only styles the hub content area.
+// Stardance shop hub — tutorial above everything, then category tiles +
+// sidebar rail, then random-item sections (New, Popular) full-width below.
+// The sidebar comes from the application layout; this file only styles the
+// hub content area.
 
 .shop-hub {
   --shop-hub-gutter: 2.5rem;
@@ -8,6 +9,33 @@
 
   color: var(--color-space-text);
   padding: 1.5rem clamp(1.5rem, 4vw, 3rem) 4rem;
+
+  &__tutorial-card {
+    background: rgba(217, 217, 217, 0.1);
+    border: 2px solid var(--color-brand-highlight);
+    border-radius: 16px;
+    margin: 0 0 2.5rem;
+    padding: 1.75rem 2rem 1rem;
+  }
+
+  &__tutorial-card-header {
+    margin-bottom: 1.25rem;
+  }
+
+  &__tutorial-card-title {
+    color: var(--color-brand-highlight);
+    font-family: "Exo 2", sans-serif;
+    font-size: 1.35rem;
+    font-weight: 800;
+    margin: 0 0 0.35rem;
+  }
+
+  &__tutorial-card-subtitle {
+    color: var(--color-space-text);
+    font-size: 1rem;
+    margin: 0;
+    opacity: 0.8;
+  }
 
   &__layout {
     display: grid;
@@ -17,14 +45,16 @@
     grid-template-areas:
       "topbar topbar"
       "main   rail"
-      "items  items";
+      "new    new"
+      "popular popular";
 
     @media (max-width: 1100px) {
       grid-template-columns: 1fr;
       grid-template-areas:
         "topbar"
         "main"
-        "items"
+        "new"
+        "popular"
         "rail";
     }
   }
@@ -224,12 +254,20 @@
     margin: 0 0 1rem;
   }
 
-  // "Discover" — the full-width item grid below the categories + sidebar. Uses
-  // the same card component and grid sizing as the category subpages so an item
-  // looks identical here and inside its category.
+  // Full-width item rows ("New", "Popular") below the categories + sidebar.
+  // Use the same card component and grid sizing as the category subpages so
+  // an item looks identical here and inside its category.
   &__items {
-    grid-area: items;
     min-width: 0;
+    overflow: visible;
+  }
+
+  &__items--new {
+    grid-area: new;
+  }
+
+  &__items--popular {
+    grid-area: popular;
   }
 
   &__items-header {
@@ -258,26 +296,87 @@
     }
   }
 
-  // Discover is a 2-row preview: extra rows fall into 0-height implicit rows
-  // and get clipped, so the grid is always at most two cards tall.
-  &__items-grid {
-    display: grid;
-    gap: 1.5rem;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    grid-template-rows: repeat(2, auto);
-    grid-auto-rows: 0;
-    list-style: none;
-    margin: 0;
-    overflow: hidden;
-    padding: 0;
+  &__items-scroll {
+    overflow: visible;
+    position: relative;
   }
 
-  // Flex column so the card stretches to the (grid-stretched) cell height —
-  // that's what keeps every card in a row the same height.
+  &__items-grid {
+    display: flex;
+    gap: 1.5rem;
+    list-style: none;
+    margin: 0;
+    overflow-x: auto;
+    padding: 0 0 0.5rem;
+    scroll-behavior: smooth;
+    scroll-snap-type: x proximity;
+    -webkit-overflow-scrolling: touch;
+
+    scrollbar-width: none;
+    &::-webkit-scrollbar { display: none; }
+
+    -webkit-mask-image: linear-gradient(
+      to right,
+      black calc(100% - 56px),
+      transparent 100%
+    );
+    mask-image: linear-gradient(
+      to right,
+      black calc(100% - 56px),
+      transparent 100%
+    );
+  }
+
+  &__scroll-arrow {
+    align-items: center;
+    appearance: none;
+    background: rgba(0, 0, 0, 0.55);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 50%;
+    color: var(--color-space-text);
+    cursor: pointer;
+    display: flex;
+    height: 36px;
+    justify-content: center;
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    transition: opacity 160ms ease;
+    width: 36px;
+    z-index: 2;
+
+    &[data-visible="true"] {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.75);
+    }
+
+    &--left {
+      left: -12px;
+    }
+
+    &--right {
+      right: -12px;
+    }
+
+    svg {
+      height: 16px;
+      width: 16px;
+    }
+  }
+
   &__items-card {
     display: flex;
+    flex: 0 0 280px;
     flex-direction: column;
     min-width: 0;
+    overflow: visible;
+    scroll-snap-align: start;
   }
 
   // Stickers + nothing get their own leading row, sharing the items grid's

--- a/app/assets/stylesheets/pages/shop/_hub.scss
+++ b/app/assets/stylesheets/pages/shop/_hub.scss
@@ -296,25 +296,11 @@
     }
   }
 
+  // Fade lives on the wrapper so it doesn't clip stars/badges that overflow
+  // the card bounds. The JS controller updates the mask dynamically.
   &__items-scroll {
     overflow: visible;
     position: relative;
-  }
-
-  &__items-grid {
-    display: flex;
-    gap: 1.5rem;
-    list-style: none;
-    margin: 0;
-    overflow-x: auto;
-    padding: 0 0 0.5rem;
-    scroll-behavior: smooth;
-    scroll-snap-type: x proximity;
-    -webkit-overflow-scrolling: touch;
-
-    scrollbar-width: none;
-    &::-webkit-scrollbar { display: none; }
-
     -webkit-mask-image: linear-gradient(
       to right,
       black calc(100% - 56px),
@@ -325,6 +311,22 @@
       black calc(100% - 56px),
       transparent 100%
     );
+  }
+
+  &__items-grid {
+    display: flex;
+    gap: 1.5rem;
+    list-style: none;
+    margin: 0;
+    overflow-x: auto;
+    overflow-y: visible;
+    padding: 14px 14px 0.5rem 0;
+    scroll-behavior: smooth;
+    scroll-snap-type: x proximity;
+    -webkit-overflow-scrolling: touch;
+
+    scrollbar-width: none;
+    &::-webkit-scrollbar { display: none; }
   }
 
   &__scroll-arrow {

--- a/app/assets/stylesheets/pages/shop/_hub.scss
+++ b/app/assets/stylesheets/pages/shop/_hub.scss
@@ -340,7 +340,9 @@
     -webkit-overflow-scrolling: touch;
 
     scrollbar-width: none;
-    &::-webkit-scrollbar { display: none; }
+    &::-webkit-scrollbar {
+      display: none;
+    }
   }
 
   &__scroll-arrow {

--- a/app/components/discover_rail/shop_orders_widget.html.erb
+++ b/app/components/discover_rail/shop_orders_widget.html.erb
@@ -1,0 +1,16 @@
+<section class="discover-rail__section" aria-label="Your orders">
+  <h3 class="discover-rail__heading">YOUR ORDERS</h3>
+  <% if orders.any? %>
+    <ul class="discover-rail__list">
+      <% orders.each do |order| %>
+        <li class="discover-rail__card">
+          <p class="discover-rail__card-title">Order (ID: <%= order.id %>) <%= order.aasm_state&.humanize&.downcase %></p>
+          <p class="discover-rail__card-body"><%= helpers.truncate(order.shop_item&.name.to_s, length: 60) %></p>
+        </li>
+      <% end %>
+    </ul>
+    <%= helpers.link_to "see more →", helpers.shop_my_orders_path, class: "discover-rail__link" %>
+  <% else %>
+    <p class="discover-rail__placeholder-text">No orders yet.</p>
+  <% end %>
+</section>

--- a/app/components/discover_rail/shop_orders_widget.rb
+++ b/app/components/discover_rail/shop_orders_widget.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DiscoverRail
+  class ShopOrdersWidget < BaseWidget
+    register_as :shop_orders
+
+    def orders
+      context[:sidebar_orders] || []
+    end
+
+    def render?
+      user.present?
+    end
+  end
+end

--- a/app/components/discover_rail/shop_updates_widget.html.erb
+++ b/app/components/discover_rail/shop_updates_widget.html.erb
@@ -1,0 +1,4 @@
+<section class="discover-rail__section" aria-label="Shop updates">
+  <h3 class="discover-rail__heading">SHOP UPDATES</h3>
+  <p class="discover-rail__placeholder-text">No updates right now.</p>
+</section>

--- a/app/components/discover_rail/shop_updates_widget.rb
+++ b/app/components/discover_rail/shop_updates_widget.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module DiscoverRail
+  class ShopUpdatesWidget < BaseWidget
+    register_as :shop_updates
+
+    def render?
+      true
+    end
+  end
+end

--- a/app/components/discover_rail/shop_wishlist_widget.html.erb
+++ b/app/components/discover_rail/shop_wishlist_widget.html.erb
@@ -1,0 +1,23 @@
+<section class="discover-rail__section discover-rail__section--wishlist" aria-label="Wishlist">
+  <h3 class="discover-rail__heading">WISHLIST</h3>
+  <div class="shop-goals"
+       data-controller="shop-goals"
+       data-shop-goals-balance-value="<%= balance %>"
+       data-shop-goals-stardust-icon-url-value="<%= helpers.image_path('icons/stardust.png') %>">
+    <div class="shop-goals__container" data-shop-goals-target="container" style="display: none;">
+      <div class="shop-goals__items" data-shop-goals-target="items"></div>
+    </div>
+    <p class="discover-rail__placeholder-text" data-shop-goals-empty>
+      Tap the star on any item to add it here.
+    </p>
+    <script>
+      try {
+        var w = JSON.parse(localStorage.getItem("shop_wishlist"));
+        if (w && Object.keys(w).length) {
+          document.currentScript.previousElementSibling.style.display = "none";
+          document.currentScript.previousElementSibling.previousElementSibling.style.display = "block";
+        }
+      } catch (e) {}
+    </script>
+  </div>
+</section>

--- a/app/components/discover_rail/shop_wishlist_widget.rb
+++ b/app/components/discover_rail/shop_wishlist_widget.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DiscoverRail
+  class ShopWishlistWidget < BaseWidget
+    register_as :shop_wishlist
+
+    def balance
+      context[:user_balance] || 0
+    end
+
+    def render?
+      true
+    end
+  end
+end

--- a/app/components/shop_item_card_component.html.erb
+++ b/app/components/shop_item_card_component.html.erb
@@ -57,7 +57,8 @@
             data-shop-wishlist-target="starButton"
             data-action="click->shop-wishlist#toggle"
             aria-label="Add to wishlist"
-            aria-pressed="false">
+            aria-pressed="false"
+            title="Add to wishlist to track progress">
       <%= helpers.inline_svg_tag "icons/star_fill.svg" %>
     </button>
   <% end %>
@@ -75,20 +76,20 @@
 
     <div class="shop-item-card__details">
       <span class="shop-item-card__hours">> <%= hours %> hours</span>
-      <span class="shop-item-card__price">
-        <%= helpers.stardust_icon %>
-        <% if on_sale && original_price %>
+      <% if on_sale && original_price %>
+        <span class="shop-item-card__price shop-item-card__price--strike">
+          <%= helpers.stardust_icon %>
           <span class="shop-item-card__original-price"><%= number_to_currency(original_price, precision: 0).delete('$') %></span>
-        <% end %>
-        <%= number_to_currency(display_price, precision: 0).delete('$') %>
-      </span>
+        </span>
+      <% end %>
     </div>
 
     <% case cta_mode %>
     <% when :tutorial_buy %>
       <% if logged_in %>
         <%= render ActionButtonComponent.new(
-              text: "Buy now",
+              text: cta_price_label,
+              leading_icon: cta_price_icon,
               href: order_url,
               size: :large,
               variant: :primary,
@@ -100,7 +101,10 @@
       <% if logged_in %>
         <button type="button"
                 class="action-btn action-btn--large action-btn--primary shop-item-card__order-cta"
-                onclick="document.getElementById('idv-verify-modal')?.showModal()">Buy now</button>
+                onclick="document.getElementById('idv-verify-modal')?.showModal()">
+          <% if cta_price_icon %><%= image_tag cta_price_icon, class: "action-btn__icon action-btn__icon--leading", "aria-hidden": true %><% end %>
+          <span class="action-btn__label"><%= cta_price_label %></span>
+        </button>
       <% end %>
     <% when :tutorial_locked %>
       <span class="action-btn action-btn--large action-btn--primary action-btn--disabled shop-item-card__order-cta shop-item-card__order-cta--locked" aria-disabled="true">Not enough Stardust</span>
@@ -108,20 +112,21 @@
       <span class="action-btn action-btn--large action-btn--secondary action-btn--disabled shop-item-card__order-cta shop-item-card__order-cta--locked" aria-disabled="true">Create a project to earn Stardust</span>
     <% else %>
       <% if logged_in && interactive %>
-        <% if balance >= display_price %>
-          <%= render ActionButtonComponent.new(
-                text: "Order now",
-                href: order_url,
-                size: :large,
-                variant: :primary,
-                class: "shop-item-card__order-cta",
-                data: { turbo_frame: "_top" }
-              ) %>
-        <% else %>
-          <p class="action-btn action-btn--large action-btn--primary action-btn--disabled shop-item-card__order-cta"><%= helpers.stardust_icon %> <%= number_to_currency(display_price - balance, precision: 0).delete('$') %> more needed</p>
-        <% end %>
+        <%= render ActionButtonComponent.new(
+              text: cta_price_label,
+              leading_icon: cta_price_icon,
+              href: order_url,
+              size: :large,
+              variant: :primary,
+              class: "shop-item-card__order-cta",
+              disabled: balance < display_price,
+              data: { turbo_frame: "_top" }
+            ) %>
       <% elsif logged_in %>
-        <span class="action-btn action-btn--large action-btn--secondary shop-item-card__order-cta shop-item-card__order-cta--locked" aria-disabled="true">Order now</span>
+        <span class="action-btn action-btn--large action-btn--secondary shop-item-card__order-cta shop-item-card__order-cta--locked" aria-disabled="true">
+          <% if cta_price_icon %><%= image_tag cta_price_icon, class: "action-btn__icon action-btn__icon--leading", "aria-hidden": true %><% end %>
+          <span class="action-btn__label"><%= cta_price_label %></span>
+        </span>
       <% end %>
     <% end %>
   </div>

--- a/app/components/shop_item_card_component.rb
+++ b/app/components/shop_item_card_component.rb
@@ -109,4 +109,17 @@ class ShopItemCardComponent < ViewComponent::Base
   def show_stock_indicator?
     limited && remaining_stock.present? && remaining_stock <= 10
   end
+
+  # CTA buttons now show the item's Stardust cost in place of "Buy now" /
+  # "Order now". Free items read "Free" and skip the icon so the button isn't
+  # an awkward "✦ 0".
+  def cta_price_label
+    return "Free" if display_price.to_i.zero?
+    helpers.number_to_currency(display_price, precision: 0).delete("$")
+  end
+
+  def cta_price_icon
+    return nil if display_price.to_i.zero?
+    "icons/stardust.png"
+  end
 end

--- a/app/controllers/shop_controller.rb
+++ b/app/controllers/shop_controller.rb
@@ -1,6 +1,9 @@
 class ShopController < ApplicationController
   skip_before_action :refresh_identity_on_portal_return, only: [ :index, :category ]
 
+  discover_rail_widgets :shop_orders, :shop_updates, :shop_wishlist,
+    context: -> { { sidebar_orders: @sidebar_orders || [], user_balance: @user_balance || 0 } }
+
   def index
     prepare_shop_chrome
     load_shop_items

--- a/app/controllers/shop_controller.rb
+++ b/app/controllers/shop_controller.rb
@@ -4,7 +4,7 @@ class ShopController < ApplicationController
   def index
     prepare_shop_chrome
     load_shop_items
-    load_random_items
+    load_hub_sections
     load_orders_sidebar
   end
 
@@ -312,24 +312,29 @@ class ShopController < ApplicationController
     @categories = Shop::Categorization.all
   end
 
-  # Picks a small randomised subset of the catalogue for the hub's "Discover"
-  # row. Excludes unlisted/tutorial items and anything in a region the viewer
-  # can't actually order from.
-  def load_random_items
-    return @random_items = [] if @shop_items.blank?
+  # Picks two randomised subsets of the catalogue for the hub's "New" and
+  # "Popular" sections. Excludes unlisted/tutorial items and anything in a
+  # region the viewer can't actually order from. Both sections show random
+  # items today; the names are just visual sectioning hints for the user.
+  def load_hub_sections
+    @new_items = []
+    @popular_items = []
+    return if @shop_items.blank?
 
     pool = @shop_items.select { |item| item.image.attached? && item.enabled_in_region?(@user_region) }
 
     # In tutorial mode the stickers/nothing picks get their own leading row, so
-    # keep them out of the Discover grid below.
+    # keep them out of the random sections below.
     if @shop_mode == :tutorial && @tutorial_items
       pick_ids = @tutorial_items.values.compact.map(&:id).to_set
       pool = pool.reject { |item| pick_ids.include?(item.id) }
     end
 
-    # Discover is a 2-row preview clipped in CSS; "See all" leads to the full
-    # listing. Cap the pool so we don't ship a giant hidden grid.
-    @random_items = pool.shuffle.first(12)
+    # Split the pool into two non-overlapping random subsets so a single item
+    # doesn't appear in both sections at once.
+    shuffled = pool.shuffle
+    @new_items     = shuffled.first(8)
+    @popular_items = shuffled.drop(8).first(8)
   end
 
   # Latest non-cancelled orders for the hub sidebar — keep it tiny.

--- a/app/javascript/controllers/horizontal_scroll_controller.js
+++ b/app/javascript/controllers/horizontal_scroll_controller.js
@@ -51,7 +51,9 @@ export default class extends Controller {
       mask =
         "linear-gradient(to right, transparent 0%, black 56px, black calc(100% - 56px), transparent 100%)";
     }
-    el.style.maskImage = mask;
-    el.style.webkitMaskImage = mask;
+    // Apply mask to the wrapper (this.element) so it doesn't clip
+    // stars/badges that overflow the card bounds.
+    this.element.style.maskImage = mask;
+    this.element.style.webkitMaskImage = mask;
   }
 }

--- a/app/javascript/controllers/horizontal_scroll_controller.js
+++ b/app/javascript/controllers/horizontal_scroll_controller.js
@@ -1,0 +1,57 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["track", "left", "right"];
+
+  connect() {
+    this._onScroll = this._updateArrows.bind(this);
+    this.trackTarget.addEventListener("scroll", this._onScroll, {
+      passive: true,
+    });
+    this._ro = new ResizeObserver(() => this._updateArrows());
+    this._ro.observe(this.trackTarget);
+    this._updateArrows();
+    // Re-check after images settle
+    requestAnimationFrame(() => this._updateArrows());
+  }
+
+  disconnect() {
+    this.trackTarget.removeEventListener("scroll", this._onScroll);
+    this._ro.disconnect();
+  }
+
+  scrollLeft() {
+    this.trackTarget.scrollBy({ left: -300, behavior: "smooth" });
+  }
+
+  scrollRight() {
+    this.trackTarget.scrollBy({ left: 300, behavior: "smooth" });
+  }
+
+  _updateArrows() {
+    const el = this.trackTarget;
+    const atStart = el.scrollLeft <= 1;
+    const atEnd = el.scrollLeft + el.clientWidth >= el.scrollWidth - 1;
+
+    if (this.hasLeftTarget) {
+      this.leftTarget.dataset.visible = String(!atStart);
+    }
+    if (this.hasRightTarget) {
+      this.rightTarget.dataset.visible = String(!atEnd);
+    }
+
+    let mask;
+    if (atStart && atEnd) {
+      mask = "none";
+    } else if (atStart) {
+      mask = "linear-gradient(to right, black calc(100% - 56px), transparent 100%)";
+    } else if (atEnd) {
+      mask = "linear-gradient(to left, black calc(100% - 56px), transparent 100%)";
+    } else {
+      mask =
+        "linear-gradient(to right, transparent 0%, black 56px, black calc(100% - 56px), transparent 100%)";
+    }
+    el.style.maskImage = mask;
+    el.style.webkitMaskImage = mask;
+  }
+}

--- a/app/javascript/controllers/horizontal_scroll_controller.js
+++ b/app/javascript/controllers/horizontal_scroll_controller.js
@@ -44,9 +44,11 @@ export default class extends Controller {
     if (atStart && atEnd) {
       mask = "none";
     } else if (atStart) {
-      mask = "linear-gradient(to right, black calc(100% - 56px), transparent 100%)";
+      mask =
+        "linear-gradient(to right, black calc(100% - 56px), transparent 100%)";
     } else if (atEnd) {
-      mask = "linear-gradient(to left, black calc(100% - 56px), transparent 100%)";
+      mask =
+        "linear-gradient(to left, black calc(100% - 56px), transparent 100%)";
     } else {
       mask =
         "linear-gradient(to right, transparent 0%, black 56px, black calc(100% - 56px), transparent 100%)";

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -76,6 +76,9 @@ application.register("emoji-picker", EmojiPickerController);
 import FallingStarController from "./falling_star_controller";
 application.register("falling-star", FallingStarController);
 
+import HorizontalScrollController from "./horizontal_scroll_controller";
+application.register("horizontal-scroll", HorizontalScrollController);
+
 import FaqAccordionController from "./faq_accordion_controller";
 application.register("faq-accordion", FaqAccordionController);
 

--- a/app/views/shop/category.html.erb
+++ b/app/views/shop/category.html.erb
@@ -44,28 +44,28 @@
                 { label: "> 1000", value: "1000+" }
               ],
               selected_option: "None",
-              color: :pink,
+              color: :space,
               action: "change->shop#filter"
             ) %>
         <%= render DropdownComponent.new(
               label: "Access",
               options: [ "All", "Available", "Locked" ],
               selected_option: "All",
-              color: :red,
+              color: :space,
               action: "change->shop#filter"
             ) %>
         <%= render DropdownComponent.new(
               label: "Sort by",
               options: [ "Prices", "Alphabetical" ],
               selected_option: "Prices",
-              color: :green,
+              color: :space,
               action: "change->shop#filter"
             ) %>
         <%= render DropdownComponent.new(
               label: "Region",
               options: @region_options,
               selected_option: Shop::Regionalizable::REGIONS.dig(@user_region, :name),
-              color: :blue,
+              color: :space,
               action: "change->shop#filter"
             ) %>
       </div>

--- a/app/views/shop/index.html.erb
+++ b/app/views/shop/index.html.erb
@@ -116,54 +116,9 @@
         </ul>
       </section>
 
-      <aside class="shop-hub__sidebar" aria-label="Shop status">
-        <section class="shop-hub__sidebar-block">
-          <h2 class="shop-hub__sidebar-title">YOUR ORDERS</h2>
-          <% if current_user && @sidebar_orders.any? %>
-            <ul class="shop-hub__sidebar-list">
-              <% @sidebar_orders.each do |order| %>
-                <li class="shop-hub__sidebar-card">
-                  <p class="shop-hub__sidebar-card-title">Order (ID: <%= order.id %>) <%= order.aasm_state&.humanize&.downcase %></p>
-                  <p class="shop-hub__sidebar-card-body"><%= truncate(order.shop_item&.name.to_s, length: 60) %></p>
-                </li>
-              <% end %>
-            </ul>
-            <%= link_to "see more →", shop_my_orders_path, class: "shop-hub__sidebar-link" %>
-          <% else %>
-            <p class="shop-hub__sidebar-empty">No orders yet.</p>
-          <% end %>
-        </section>
-
-        <section class="shop-hub__sidebar-block">
-          <h2 class="shop-hub__sidebar-title">SHOP UPDATES</h2>
-          <p class="shop-hub__sidebar-empty">No updates right now.</p>
-        </section>
-
-        <section class="shop-hub__sidebar-block shop-hub__sidebar-block--wishlist">
-          <h2 class="shop-hub__sidebar-title">WISHLIST</h2>
-
-          <div class="shop-goals"
-               data-controller="shop-goals"
-               data-shop-goals-balance-value="<%= @user_balance %>"
-               data-shop-goals-stardust-icon-url-value="<%= image_path('icons/stardust.png') %>">
-            <div class="shop-goals__container" data-shop-goals-target="container" style="display: none;">
-              <div class="shop-goals__items" data-shop-goals-target="items"></div>
-            </div>
-            <p class="shop-hub__sidebar-empty" data-shop-goals-empty>
-              Tap the star on any item to add it here.
-            </p>
-            <script>
-              try {
-                var w = JSON.parse(localStorage.getItem("shop_wishlist"));
-                if (w && Object.keys(w).length) {
-                  document.currentScript.previousElementSibling.style.display = "none";
-                  document.currentScript.previousElementSibling.previousElementSibling.style.display = "block";
-                }
-              } catch (e) {}
-            </script>
-          </div>
-        </section>
-      </aside>
+      <div class="shop-hub__rail">
+        <%= render DiscoverRailComponent.new %>
+      </div>
 
       <% if @new_items&.any? %>
         <section class="shop-hub__items shop-hub__items--new" aria-label="New items">

--- a/app/views/shop/index.html.erb
+++ b/app/views/shop/index.html.erb
@@ -13,6 +13,52 @@
   <% end %>
 
   <% tutorial_active = @shop_mode == :tutorial && @tutorial_items.values.all?(&:present?) %>
+  <% pick_ids = tutorial_active ? @tutorial_items.values.compact.map(&:id) : [] %>
+  <%# Once a user has verified IDV but still owes the address step, re-show the
+      picks intro spotlight regardless of prior dismissal — the picks now lead
+      to the address screen instead of the IDV modal, so it's a fresh "next
+      step" cue rather than a repeat of the original one. %>
+  <% post_verify_address_step = tutorial_active && current_user && current_user.identity_verified? && current_user.addresses.empty? %>
+  <% show_picks_intro = tutorial_active && current_user && (!current_user.has_dismissed?("shop_picks_intro") || post_verify_address_step) %>
+
+  <% if tutorial_active %>
+    <section class="shop-hub__tutorial-card" aria-label="Shop tutorial">
+      <div class="shop-hub__tutorial-card-header">
+        <h2 class="shop-hub__tutorial-card-title">Complete the tutorial to unlock the shop</h2>
+        <p class="shop-hub__tutorial-card-subtitle">Pick one of these to walk through how ordering works.</p>
+      </div>
+      <div class="shop-hub__picks">
+        <ul class="shop-hub__picks-row" id="shop-picks">
+          <% [ @tutorial_items[:stickers], @tutorial_items[:nothing] ].compact.each do |item| %>
+            <li class="shop-hub__items-card">
+              <%= render "shop/item_card",
+                    item: item,
+                    mode: :tutorial,
+                    region: @user_region,
+                    balance: @user_balance,
+                    tutorial_item_ids: pick_ids,
+                    spotlight: false %>
+            </li>
+          <% end %>
+          <li class="shop-hub__picks-cue">
+            <%= image_tag "shop/buy_something.png", alt: "", class: "shop-hub__picks-cue-graphic", aria: { hidden: true } %>
+            <span class="shop-hub__picks-cue-row">
+              <%= inline_svg_tag "icons/tour-arrow.svg", class: "shop-hub__picks-cue-arrow", aria: { hidden: true }, focusable: false %>
+              <span class="shop-hub__picks-cue-text">Choose one to go through the tutorial.</span>
+            </span>
+            <% unless current_user&.has_dismissed?("shop_picks_intro") %>
+              <button type="button"
+                      class="shop-hub__picks-cue-dismiss"
+                      onclick="document.dispatchEvent(new CustomEvent('welcome-tour:dismiss')); this.remove()">Ok, I'll do it!</button>
+            <% end %>
+          </li>
+        </ul>
+      </div>
+      <% if show_picks_intro %>
+        <%= render "shop/picks_intro_tour" %>
+      <% end %>
+    </section>
+  <% end %>
 
   <div class="shop-hub__layout">
     <header class="shop-hub__topbar">
@@ -47,7 +93,6 @@
     </header>
 
     <% if @shop_open %>
-      <% pick_ids = tutorial_active ? @tutorial_items.values.compact.map(&:id) : [] %>
       <section class="shop-hub__main">
         <ul class="shop-hub__category-grid" aria-label="Shop categories">
           <% @categories.each do |category| %>
@@ -120,49 +165,21 @@
         </section>
       </aside>
 
-      <% if tutorial_active || @random_items&.any? %>
-        <section class="shop-hub__items" aria-label="Items">
+      <% if @new_items&.any? %>
+        <section class="shop-hub__items shop-hub__items--new" aria-label="New items">
           <div class="shop-hub__items-header">
-            <h2 class="shop-hub__section-title">Discover</h2>
+            <h2 class="shop-hub__section-title">New</h2>
             <%= link_to "See all →", shop_category_path("all"), class: "shop-hub__see-all", data: { turbo: true } %>
           </div>
-
-          <% if tutorial_active %>
-            <div class="shop-hub__picks">
-              <ul class="shop-hub__picks-row" id="shop-picks">
-                <% [ @tutorial_items[:stickers], @tutorial_items[:nothing] ].compact.each do |item| %>
-                  <li class="shop-hub__items-card">
-                    <%= render "shop/item_card",
-                          item: item,
-                          mode: :tutorial,
-                          region: @user_region,
-                          balance: @user_balance,
-                          tutorial_item_ids: pick_ids,
-                          spotlight: false %>
-                  </li>
-                <% end %>
-                <li class="shop-hub__picks-cue">
-                  <%= image_tag "shop/buy_something.png", alt: "", class: "shop-hub__picks-cue-graphic", aria: { hidden: true } %>
-                  <span class="shop-hub__picks-cue-row">
-                    <%= inline_svg_tag "icons/tour-arrow.svg", class: "shop-hub__picks-cue-arrow", aria: { hidden: true }, focusable: false %>
-                    <span class="shop-hub__picks-cue-text">Pick one of these to try buying something!</span>
-                  </span>
-                  <% unless current_user&.has_dismissed?("shop_picks_intro") %>
-                    <button type="button"
-                            class="shop-hub__picks-cue-dismiss"
-                            onclick="document.dispatchEvent(new CustomEvent('welcome-tour:dismiss')); this.remove()">Ok, I'll do it!</button>
-                  <% end %>
-                </li>
-              </ul>
-            </div>
-            <% if current_user && !current_user.has_dismissed?("shop_picks_intro") %>
-              <%= render "shop/picks_intro_tour" %>
-            <% end %>
-          <% end %>
-
-          <% if @random_items&.any? %>
-            <ul class="shop-hub__items-grid">
-              <% @random_items.each do |item| %>
+          <div class="shop-hub__items-scroll" data-controller="horizontal-scroll">
+            <button type="button" class="shop-hub__scroll-arrow shop-hub__scroll-arrow--left"
+                    data-horizontal-scroll-target="left"
+                    data-action="click->horizontal-scroll#scrollLeft"
+                    aria-label="Scroll left">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+            </button>
+            <ul class="shop-hub__items-grid" data-horizontal-scroll-target="track">
+              <% @new_items.each do |item| %>
                 <li class="shop-hub__items-card">
                   <%= render "shop/item_card",
                         item: item,
@@ -173,7 +190,48 @@
                 </li>
               <% end %>
             </ul>
-          <% end %>
+            <button type="button" class="shop-hub__scroll-arrow shop-hub__scroll-arrow--right"
+                    data-horizontal-scroll-target="right"
+                    data-action="click->horizontal-scroll#scrollRight"
+                    aria-label="Scroll right">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+            </button>
+          </div>
+        </section>
+      <% end %>
+
+      <% if @popular_items&.any? %>
+        <section class="shop-hub__items shop-hub__items--popular" aria-label="Popular items">
+          <div class="shop-hub__items-header">
+            <h2 class="shop-hub__section-title">Popular</h2>
+            <%= link_to "See all →", shop_category_path("all"), class: "shop-hub__see-all", data: { turbo: true } %>
+          </div>
+          <div class="shop-hub__items-scroll" data-controller="horizontal-scroll">
+            <button type="button" class="shop-hub__scroll-arrow shop-hub__scroll-arrow--left"
+                    data-horizontal-scroll-target="left"
+                    data-action="click->horizontal-scroll#scrollLeft"
+                    aria-label="Scroll left">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+            </button>
+            <ul class="shop-hub__items-grid" data-horizontal-scroll-target="track">
+              <% @popular_items.each do |item| %>
+                <li class="shop-hub__items-card">
+                  <%= render "shop/item_card",
+                        item: item,
+                        mode: @shop_mode,
+                        region: @user_region,
+                        balance: @user_balance,
+                        tutorial_item_ids: pick_ids %>
+                </li>
+              <% end %>
+            </ul>
+            <button type="button" class="shop-hub__scroll-arrow shop-hub__scroll-arrow--right"
+                    data-horizontal-scroll-target="right"
+                    data-action="click->horizontal-scroll#scrollRight"
+                    aria-label="Scroll right">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+            </button>
+          </div>
         </section>
       <% end %>
     <% else %>

--- a/app/views/shop/index.html.erb
+++ b/app/views/shop/index.html.erb
@@ -78,7 +78,7 @@
                 label: "Region",
                 options: @region_options,
                 selected_option: Shop::Regionalizable::REGIONS.dig(@user_region, :name),
-                color: :blue,
+                color: :space,
                 action: "change->shop#filter"
               ) %>
         </div>

--- a/app/views/shop/index.html.erb
+++ b/app/views/shop/index.html.erb
@@ -131,7 +131,7 @@
                     data-horizontal-scroll-target="left"
                     data-action="click->horizontal-scroll#scrollLeft"
                     aria-label="Scroll left">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"> <polyline points="15 18 9 12 15 6" /> </svg>
             </button>
             <ul class="shop-hub__items-grid" data-horizontal-scroll-target="track">
               <% @new_items.each do |item| %>
@@ -149,7 +149,7 @@
                     data-horizontal-scroll-target="right"
                     data-action="click->horizontal-scroll#scrollRight"
                     aria-label="Scroll right">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"> <polyline points="9 18 15 12 9 6" /> </svg>
             </button>
           </div>
         </section>
@@ -166,7 +166,7 @@
                     data-horizontal-scroll-target="left"
                     data-action="click->horizontal-scroll#scrollLeft"
                     aria-label="Scroll left">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"> <polyline points="15 18 9 12 15 6" /> </svg>
             </button>
             <ul class="shop-hub__items-grid" data-horizontal-scroll-target="track">
               <% @popular_items.each do |item| %>
@@ -184,7 +184,7 @@
                     data-horizontal-scroll-target="right"
                     data-action="click->horizontal-scroll#scrollRight"
                     aria-label="Scroll right">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"> <polyline points="9 18 15 12 9 6" /> </svg>
             </button>
           </div>
         </section>

--- a/app/views/shop/order.html.erb
+++ b/app/views/shop/order.html.erb
@@ -261,7 +261,7 @@
                                 options: address_options,
                                 selected_option: "#{primary_addr["first_name"]} #{primary_addr["last_name"]} - #{primary_addr["line_1"]}, #{primary_addr["city"]}",
                                 longest_option_string: longest_option,
-                                color: :blue
+                                color: :space
                             ) %>
                         </div>
 


### PR DESCRIPTION
changed overall layout to put the tutorial at the top

<img width="1242" height="880" alt="image" src="https://github.com/user-attachments/assets/c92b718d-240a-4498-a47c-a32ca347955f" />

made more horizontal scrolling thingies
<img width="1239" height="912" alt="image" src="https://github.com/user-attachments/assets/f010cb57-b028-4e6c-954e-a0d34caf7b8a" />

updated it so that instead of 'buy' it just says how much currency it costs
