### PR TITLE
Fix welcome flow for inaccuracies

### DIFF
--- a/app/assets/stylesheets/pages/_project_setup.scss
+++ b/app/assets/stylesheets/pages/_project_setup.scss
@@ -100,27 +100,30 @@
 
   &__card {
     align-items: stretch;
-    background: rgba(8, 6, 31, 0.75);
-    border: 2px solid rgba(255, 255, 255, 0.5);
-    border-radius: 0.5rem;
+    background: var(--color-set-2-bg);
+    border: 1px solid var(--color-space-border);
+    border-radius: var(--profile-radius);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
     color: white;
     cursor: pointer;
     display: flex;
-    font-family: "Exo 2", sans-serif;
+    font-family: var(--font-family-text);
     gap: 1rem;
     padding: 1rem 1.1rem;
     text-align: left;
     transition:
-      border-color 150ms ease,
-      background 150ms ease,
-      transform 150ms ease;
+      border-color 180ms ease,
+      box-shadow 180ms ease,
+      transform 180ms ease;
     width: 100%;
 
     &:hover,
     &:focus-visible {
-      background: rgba(8, 6, 31, 0.95);
-      border-color: var(--color-brand-mint);
-      transform: translateY(-2px);
+      border-color: var(--color-brand-lilac);
+      box-shadow:
+        0 4px 16px rgba(0, 0, 0, 0.3),
+        0 0 0 1px var(--color-brand-lilac-soft);
+      transform: translateY(-3px);
     }
   }
 
@@ -157,7 +160,7 @@
   }
 
   &__card-description {
-    color: rgba(255, 255, 255, 0.8);
+    color: rgba(255, 255, 255, 0.7);
     font-size: 0.9rem;
     line-height: 1.35;
   }
@@ -167,12 +170,13 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.4rem;
+    margin-top: var(--space-xxs);
   }
 
   &__card-difficulty {
-    background: rgba(255, 255, 255, 0.1);
+    background: var(--color-brand-lilac-soft);
     border-radius: 999px;
-    color: var(--color-brand-cream);
+    color: var(--color-brand-lilac);
     font-size: 0.7rem;
     font-weight: 700;
     letter-spacing: 0.05em;
@@ -181,7 +185,7 @@
   }
 
   &__card-steps {
-    background: rgba(255, 255, 255, 0.1);
+    background: var(--color-space-surface-faint);
     border-radius: 999px;
     color: rgba(255, 255, 255, 0.85);
     font-size: 0.7rem;
@@ -189,10 +193,46 @@
     padding: 0.15rem 0.55rem;
   }
 
+  &__card-duration {
+    background: var(--color-brand-mint-soft);
+    border-radius: 999px;
+    color: var(--color-brand-mint);
+    font-size: 0.7rem;
+    font-weight: 600;
+    padding: 0.15rem 0.55rem;
+  }
+
+  &__card-prize {
+    background: var(--color-brand-yellow-soft);
+    border-radius: 999px;
+    color: var(--color-brand-yellow);
+    font-size: 0.7rem;
+    font-weight: 700;
+    margin-top: var(--space-xxs);
+    padding: 0.15rem 0.55rem;
+    align-self: flex-start;
+  }
+
   &__empty {
-    color: rgba(255, 255, 255, 0.8);
-    font-size: 1rem;
-    margin: 2rem 0;
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-m);
+    margin: 3rem 0;
+    text-align: center;
+  }
+
+  &__empty-icon {
+    color: var(--color-brand-lilac);
+    font-size: 2.5rem;
+  }
+
+  &__empty-text {
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 1.05rem;
+    line-height: 1.5;
+    margin: 0;
+    max-width: 360px;
   }
 
   &__later-form {
@@ -205,7 +245,7 @@
     border: none;
     color: white;
     cursor: pointer;
-    font-family: "Exo 2", sans-serif;
+    font-family: var(--font-family-text);
     font-size: 1rem;
     font-weight: 700;
     padding: 0.5rem 0.75rem;

--- a/app/components/posts/composer_component.html.erb
+++ b/app/components/posts/composer_component.html.erb
@@ -134,8 +134,7 @@
     </p>
     <p class="empty-project-banner__subhead">to begin posting</p>
     <span class="empty-project-banner__reward">
-      <span class="empty-project-banner__reward-label">EARNS 10 STARDUST</span>
-      <%= image_tag "icons/stardust.png", alt: "", class: "empty-project-banner__reward-icon" %>
+      <span class="empty-project-banner__reward-label">EARN FREE STICKERS</span>
     </span>
   <% end %>
 <% end %>

--- a/app/views/home/_welcome_tour.html.erb
+++ b/app/views/home/_welcome_tour.html.erb
@@ -26,7 +26,7 @@
     },
     {
       selector: ".empty-project-banner, .feed-composer",
-      text: "When you're ready, create your first project! Complete it and ship to earn free stickers.",
+      text: "When you're ready, create your first project! After you post your first devlog, you can get free stickers!",
       padding: 12,
       radius: 12
     }

--- a/app/views/home/_welcome_tour.html.erb
+++ b/app/views/home/_welcome_tour.html.erb
@@ -26,7 +26,7 @@
     },
     {
       selector: ".empty-project-banner, .feed-composer",
-      text: "When you're ready, create your first project to earn 10 free stardust to use in the shop!",
+      text: "When you're ready, create your first project! Complete it and ship to earn free stickers.",
       padding: 12,
       radius: 12
     }

--- a/app/views/projects/setup/missions.html.erb
+++ b/app/views/projects/setup/missions.html.erb
@@ -29,7 +29,7 @@
               <span class="project-setup-missions__card-body">
                 <span class="project-setup-missions__card-title"><%= mission.name %></span>
                 <span class="project-setup-missions__card-description"><%= truncate(mission.description.to_s, length: 110) %></span>
-                <% if mission.difficulty.present? || mission.steps_count > 0 %>
+                <% if mission.difficulty.present? || mission.steps_count > 0 || mission.estimated_completion_label.present? %>
                   <span class="project-setup-missions__card-meta">
                     <% if mission.difficulty.present? %>
                       <span class="project-setup-missions__card-difficulty"><%= mission.difficulty %></span>
@@ -37,7 +37,13 @@
                     <% if mission.steps_count > 0 %>
                       <span class="project-setup-missions__card-steps"><%= mission.steps_count %>-step guide</span>
                     <% end %>
+                    <% if mission.estimated_completion_label.present? %>
+                      <span class="project-setup-missions__card-duration"><%= mission.estimated_completion_label %></span>
+                    <% end %>
                   </span>
+                <% end %>
+                <% if mission.has_prizes? %>
+                  <span class="project-setup-missions__card-prize">Prize available</span>
                 <% end %>
               </span>
             </button>
@@ -45,7 +51,10 @@
         <% end %>
       </div>
     <% else %>
-      <p class="project-setup-missions__empty">Woah there explorer! Looks like you've already seen the whole universe (no more missions are available).</p>
+      <div class="project-setup-missions__empty">
+        <span class="project-setup-missions__empty-icon" aria-hidden="true">✦</span>
+        <p class="project-setup-missions__empty-text">You've explored the whole universe! No more missions are available right now.</p>
+      </div>
     <% end %>
 
     <%= form_with url: projects_setup_submit_mission_path, method: :post,

--- a/app/views/shop/_preview_banner.html.erb
+++ b/app/views/shop/_preview_banner.html.erb
@@ -2,7 +2,7 @@
   <div class="shop-preview__body">
     <p class="shop-preview__eyebrow">browsing as a guest</p>
     <h2 class="shop-preview__title">This is everything you could earn.</h2>
-    <p class="shop-preview__lede">Create your first project to start earning Stardust. The full shop unlocks once your project is set up — until then, take a look around.</p>
+    <p class="shop-preview__lede">Create your first project to start earning prizes. The full shop unlocks once your project is set up — until then, take a look around.</p>
   </div>
 
   <div class="shop-preview__cta">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -275,8 +275,7 @@
           </p>
           <p class="empty-project-banner__subhead">to begin posting</p>
           <span class="empty-project-banner__reward">
-            <span class="empty-project-banner__reward-label">EARNS 10 STARDUST</span>
-            <%= image_tag "icons/stardust.png", alt: "", class: "empty-project-banner__reward-icon" %>
+            <span class="empty-project-banner__reward-label">EARN FREE STICKERS</span>
           </span>
         <% end %>
       <% else %>


### PR DESCRIPTION
  - Fix misleading "earn 10 free stardust" messaging across welcome tour, home feed, profile banner, and shop preview → now says "earn free stickers"
  - Enhance mission picker cards with duration/prize badges, hover effects, and brand-color accents
  - Improve empty state styling on mission picker