### PR TITLE
HCA improvements

### DIFF
--- a/app/assets/stylesheets/pages/_onboarding.scss
+++ b/app/assets/stylesheets/pages/_onboarding.scss
@@ -643,11 +643,22 @@ $slider-star: url("onboarding/star-radio-active.svg");
 }
 
 @keyframes slider-jiggle {
-  0%, 100% { transform: translateX(0); }
-  20% { transform: translateX(-6px) rotate(-3deg); }
-  40% { transform: translateX(5px) rotate(2deg); }
-  60% { transform: translateX(-3px) rotate(-1deg); }
-  80% { transform: translateX(2px); }
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-6px) rotate(-3deg);
+  }
+  40% {
+    transform: translateX(5px) rotate(2deg);
+  }
+  60% {
+    transform: translateX(-3px) rotate(-1deg);
+  }
+  80% {
+    transform: translateX(2px);
+  }
 }
 
 .onboarding-experience__slider.jiggle {

--- a/app/assets/stylesheets/pages/_onboarding.scss
+++ b/app/assets/stylesheets/pages/_onboarding.scss
@@ -132,6 +132,12 @@
     margin: 0 0 2rem;
   }
 
+  &__hint {
+    font-size: 0.9rem;
+    opacity: 0.7;
+    margin: 0.5rem 0 0;
+  }
+
   &__body {
     font-size: 1rem;
     font-weight: 700;
@@ -1157,4 +1163,12 @@ $slider-star: url("onboarding/star-radio-active.svg");
   &__continue {
     margin-top: 1rem;
   }
+}
+
+.onboarding-guest-email__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.25rem;
+  margin-top: 2.5rem;
 }

--- a/app/controllers/concerns/onboarding_resumable.rb
+++ b/app/controllers/concerns/onboarding_resumable.rb
@@ -1,12 +1,11 @@
 # Shared logic for resuming or expiring an interrupted signup-wizard session.
 #
-# A "mid-onboarding" user is a guest who entered the wizard but never reached
-# the final name step (onboarded_at still nil). The freshness window is anchored
-# on when they started the wizard (created_at).
+# A "mid-onboarding" user is one who has never completed onboarding
+# (onboarded_at still nil) — regardless of whether they entered via the email
+# flow (guest) or directly through HCA. The freshness window is anchored on
+# when they started (created_at).
 #
-# Gated on the :new_onboarding flag: only when it's on is the wizard the sole
-# way to become an onboarded_at-nil guest, so the signal can't be confused with
-# project-setup / link-gate guests from the old flow.
+# Gated on the :new_onboarding flag.
 module OnboardingResumable
   extend ActiveSupport::Concern
 
@@ -17,7 +16,7 @@ module OnboardingResumable
   def onboarding_in_progress?(user)
     return false unless Flipper.enabled?(:new_onboarding)
 
-    user&.guest? && user.onboarded_at.nil?
+    user.present? && user.onboarded_at.nil?
   end
 
   # Within the active window, anchored on when they first started onboarding.

--- a/app/controllers/onboarding/wizard_controller.rb
+++ b/app/controllers/onboarding/wizard_controller.rb
@@ -12,8 +12,8 @@ class Onboarding::WizardController < ApplicationController
                                                       name submit_name]
 
   def start
-    # A fully-linked member has nothing left to onboard.
-    if current_user&.hca_linked?
+    # Already completed onboarding — nothing to do.
+    if current_user&.onboarded_at.present?
       redirect_to home_path and return
     end
 
@@ -26,6 +26,11 @@ class Onboarding::WizardController < ApplicationController
     existing = User.find_by(email: normalized)
 
     if existing&.hca_linked?
+      if existing.onboarded_at.nil?
+        session[:user_id] = existing.id
+        redirect_to onboarding_resume_path(existing) and return
+      end
+
       # OmniAuth 2.x with omniauth-rails_csrf_protection blocks GET, so we
       # render an auto-submitting POST form instead of redirecting.
       @login_hint = normalized
@@ -37,17 +42,25 @@ class Onboarding::WizardController < ApplicationController
 
       if onboarding_in_progress?(existing)
         if onboarding_fresh?(existing)
-          # Started within the window — drop them back where they left off.
           redirect_to onboarding_resume_path(existing) and return
         else
-          # Stale placeholder account — wipe progress and start over.
           restart_onboarding!(existing)
           redirect_to onboarding_welcome_path and return
         end
       end
 
-      # Guest who already finished the wizard (still needs to link HCA later).
       redirect_to home_path and return
+    end
+
+    guest_email_owner = User.find_by(guest_email: normalized)
+    if guest_email_owner
+      session[:guest_email_claim] = normalized
+      redirect_to onboarding_guest_email_path and return
+    end
+
+    if HCAService.email_known?(normalized)
+      @login_hint = normalized
+      return render :redirecting_to_hca
     end
 
     user = create_guest!(normalized)
@@ -57,9 +70,17 @@ class Onboarding::WizardController < ApplicationController
 
   def welcome; end
 
-  def birthday; end
+  def birthday
+    if current_user.age_attestation.present?
+      redirect_to params[:back] ? onboarding_welcome_path : onboarding_resume_path(current_user)
+    end
+  end
 
   def submit_birthday
+    if current_user.age_attestation.present?
+      redirect_to onboarding_resume_path(current_user) and return
+    end
+
     case params[:attestation]
     when "teen_13_18"
       current_user.update!(age_attestation: "teen_13_18")
@@ -142,7 +163,52 @@ class Onboarding::WizardController < ApplicationController
     end
   end
 
+  def guest_email
+    @claimed_email = session[:guest_email_claim]
+    unless @claimed_email
+      redirect_to root_path and return
+    end
+
+    owner = User.find_by(guest_email: @claimed_email)
+    unless owner
+      session.delete(:guest_email_claim)
+      redirect_to root_path and return
+    end
+
+    @censored_hca_email = censor_email(owner.email)
+  end
+
+  def guest_email_yes
+    claimed_email = session.delete(:guest_email_claim)
+    owner = User.find_by(guest_email: claimed_email)
+
+    unless owner
+      redirect_to root_path, alert: "Something went wrong. Please try again." and return
+    end
+
+    @login_hint = owner.email
+    @nudge_email = owner.email
+    render :redirecting_to_hca
+  end
+
+  def guest_email_no
+    claimed_email = session.delete(:guest_email_claim)
+    owner = User.find_by(guest_email: claimed_email)
+    owner&.update!(guest_email: nil)
+
+    user = create_guest!(claimed_email)
+    session[:user_id] = user.id
+    redirect_to onboarding_welcome_path
+  end
+
   private
+
+  def censor_email(email)
+    local, domain = email.split("@", 2)
+    return email if local.length <= 2
+
+    "#{local[0]}#{"*" * (local.length - 2)}#{local[-1]}@#{domain}"
+  end
 
   def create_guest!(email)
     5.times do
@@ -160,7 +226,7 @@ class Onboarding::WizardController < ApplicationController
   end
 
   def require_onboarding_guest!
-    return if current_user&.guest?
+    return if current_user.present? && current_user.onboarded_at.nil?
     redirect_to root_path, alert: "Please start signup from the homepage."
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  include OnboardingResumable
+
   def create
     result = Sessions::HCALoginService.new(
       auth: request.env["omniauth.auth"],
@@ -18,7 +20,20 @@ class SessionsController < ApplicationController
     session[:user_id] = result.user.id
 
     return_to = safe_return_to(session.delete(:return_to))
-    redirect_to(return_to || (result.user.setup_complete? ? profile_projects_path(result.user.display_name) : home_path), notice: "Signed in with Hack Club")
+
+    destination = if result.user.onboarded_at.nil? && result.user.age_attestation_ineligible?
+      onboarding_age_gate_path
+    elsif return_to
+      return_to
+    elsif result.user.onboarded_at.nil?
+      onboarding_resume_path(result.user)
+    elsif result.user.setup_complete?
+      profile_projects_path(result.user.display_name)
+    else
+      home_path
+    end
+
+    redirect_to destination, notice: "Signed in with Hack Club"
   end
 
   def destroy

--- a/app/javascript/controllers/project_form_controller.js
+++ b/app/javascript/controllers/project_form_controller.js
@@ -370,7 +370,8 @@ export default class extends Controller {
 
     const autofilled = this.readmeUrlTarget.dataset.autofilled === "true";
     const derivedFromRepo = this.readmeDerivedFromRepo(readmeValue);
-    this.userEditedReadme = readmeValue.length > 0 && !autofilled && !derivedFromRepo;
+    this.userEditedReadme =
+      readmeValue.length > 0 && !autofilled && !derivedFromRepo;
     this.setReadmeLocked(autofilled || derivedFromRepo);
   }
 
@@ -381,7 +382,11 @@ export default class extends Controller {
     if (!repoValue) return false;
 
     let url;
-    try { url = new URL(repoValue); } catch { return false; }
+    try {
+      url = new URL(repoValue);
+    } catch {
+      return false;
+    }
 
     const host = url.host.toLowerCase();
     const [, owner, rawRepo] = (url.pathname || "").split("/");
@@ -390,7 +395,9 @@ export default class extends Controller {
     const repo = rawRepo.replace(/\.git$/i, "");
 
     if (host === "github.com") {
-      return readmeValue.includes(`raw.githubusercontent.com/${owner}/${repo}/`);
+      return readmeValue.includes(
+        `raw.githubusercontent.com/${owner}/${repo}/`,
+      );
     } else if (host === "gitlab.com") {
       return readmeValue.includes(`gitlab.com/${owner}/${repo}/`);
     }

--- a/app/models/mission/guide_variant.rb
+++ b/app/models/mission/guide_variant.rb
@@ -14,7 +14,7 @@
 # Indexes
 #
 #  index_mission_guide_variants_on_mission_id    (mission_id)
-#  index_mission_guide_variants_unique_language  (mission_id, lower((language)::text)) UNIQUE
+#  index_mission_guide_variants_unique_language  (mission_id,language) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/models/mission/step_body.rb
+++ b/app/models/mission/step_body.rb
@@ -13,7 +13,7 @@
 # Indexes
 #
 #  index_mission_step_bodies_on_mission_step_id  (mission_step_id)
-#  index_mission_step_bodies_unique_language     (mission_step_id, lower((language)::text)) UNIQUE
+#  index_mission_step_bodies_unique_language     (mission_step_id,language) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@
 #  experience_level             :string
 #  first_name                   :string
 #  granted_roles                :string           default([]), not null, is an Array
+#  guest_email                  :string
 #  has_gotten_free_stickers     :boolean          default(FALSE)
 #  has_pending_achievements     :boolean          default(FALSE), not null
 #  hcb_email                    :string

--- a/app/services/hca_service.rb
+++ b/app/services/hca_service.rb
@@ -42,6 +42,23 @@ module HCAService
     result&.dig("identity") || {}
   end
 
+  def email_known?(email)
+    return false if email.blank?
+
+    response = check_connection.get("/api/external/check") do |req|
+      req.params["email"] = email
+      req.headers["Accept"] = "application/json"
+    end
+
+    return false unless response.success?
+
+    result = JSON.parse(response.body)
+    result["result"] != "not_found"
+  rescue StandardError => e
+    Rails.logger.warn("HCA email check error: #{e.class}: #{e.message}")
+    false
+  end
+
   def portal_url(path, return_to:)
     uri = URI.join(host, "/portal/#{path}")
     uri.query = { return_to: return_to }.to_query
@@ -58,5 +75,12 @@ module HCAService
 
   def connection
     @connection ||= Faraday.new(url: host)
+  end
+
+  def check_connection
+    @check_connection ||= Faraday.new(url: host) do |f|
+      f.options.open_timeout = 3
+      f.options.timeout = 5
+    end
   end
 end

--- a/app/services/sessions/hca_login_service.rb
+++ b/app/services/sessions/hca_login_service.rb
@@ -79,6 +79,7 @@ module Sessions
           last_name:           data["last_name"].to_s.strip,
           verification_status: data["verification_status"].to_s,
           ysws_eligible:       data["ysws_eligible"] == true,
+          birthday:            (Date.parse(data["birthday"].to_s) rescue nil),
           slack_id:            data["slack_id"].to_s,
           uid:                 data["id"].to_s
         }
@@ -136,11 +137,24 @@ module Sessions
       end
 
       def assign_user_attributes(user, fields, is_new_user)
-        user.email ||= fields[:email]
+        if user.email.present? && fields[:email].present? && user.email != fields[:email]
+          user.guest_email = user.email
+          user.email = fields[:email]
+        else
+          user.email ||= fields[:email]
+        end
+
         user.display_name = User.random_funny_display_name if user.display_name.to_s.strip.blank?
         user.first_name = fields[:first_name] if fields[:first_name].present?
         user.last_name = fields[:last_name] if fields[:last_name].present?
         user.slack_id = fields[:slack_id] if user.slack_id.to_s != fields[:slack_id]
+
+        if user.age_attestation.blank?
+          case hca_age_attestation(fields)
+          when :teen then user.age_attestation = "teen_13_18"
+          when :ineligible then user.age_attestation = "ineligible"
+          end
+        end
 
         if is_new_user && referral_code.present? && referral_code.length <= 64
           user.ref = referral_code
@@ -172,6 +186,21 @@ module Sessions
         fail_result(:identity_save_failed, "Unable to link your Hack Club account. Please contact support.")
       end
 
+      def age_from_birthday(birthday)
+        today = Date.current
+        age = today.year - birthday.year
+        age -= 1 if today < birthday + age.years
+        age
+      end
+
+      def hca_age_attestation(fields)
+        return :teen if fields[:ysws_eligible]
+        return nil if fields[:birthday].nil?
+
+        age = age_from_birthday(fields[:birthday])
+        age >= 13 && age <= 18 ? :teen : :ineligible
+      end
+
       def age_violation?(user, identity_data)
         user.age_attestation_teen_13_18? && hca_birthday_contradicts_teen?(identity_data)
       end
@@ -183,9 +212,7 @@ module Sessions
         birthday = Date.parse(birthday_str) rescue nil
         return false if birthday.nil?
 
-        today = Date.current
-        age = today.year - birthday.year
-        age -= 1 if today < birthday + age.years
+        age = age_from_birthday(birthday)
         age < 13 || age > 18
       end
 

--- a/app/views/onboarding/wizard/guest_email.html.erb
+++ b/app/views/onboarding/wizard/guest_email.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, "Existing account" %>
+<main class="onboarding-screen onboarding-screen--guest-email" data-controller="onboarding-transition">
+  <div class="onboarding-screen__content">
+    <h1 class="onboarding-screen__title">Have you logged in before?</h1>
+    <p class="onboarding-screen__subhead">
+      It looks like this email was used on an account that later signed in with
+      <strong><%= @censored_hca_email %></strong>. Is that you?
+    </p>
+
+    <div class="onboarding-guest-email__actions">
+      <%= form_with url: onboarding_guest_email_yes_path, method: :post, data: { turbo: false } do %>
+        <button type="submit" class="action-btn action-btn--primary action-btn--large">
+          <span class="action-btn__label">Yes, that's me — sign in</span>
+        </button>
+      <% end %>
+
+      <%= form_with url: onboarding_guest_email_no_path, method: :post, data: { turbo: false } do %>
+        <button type="submit" class="action-btn action-btn--secondary action-btn--large">
+          <span class="action-btn__label">No, give me a new account</span>
+        </button>
+      <% end %>
+    </div>
+  </div>
+</main>

--- a/app/views/onboarding/wizard/redirecting_to_hca.html.erb
+++ b/app/views/onboarding/wizard/redirecting_to_hca.html.erb
@@ -3,6 +3,9 @@
   <div class="onboarding-screen__content">
     <h1 class="onboarding-screen__title">Welcome back!</h1>
     <p class="onboarding-screen__subhead">Connecting you to your Hack Club account…</p>
+    <% if @nudge_email %>
+      <p class="onboarding-screen__hint">Next time, sign in directly with <strong><%= @nudge_email %></strong>.</p>
+    <% end %>
 
     <%= form_with url: hack_club_auth_path(login_hint: @login_hint),
                    method: :post, local: true,

--- a/app/views/projects/setup/link_account.html.erb
+++ b/app/views/projects/setup/link_account.html.erb
@@ -16,7 +16,7 @@
     <%= form_with url: hack_club_auth_path(login_hint: current_user.email),
                    method: :post, local: true,
                    data: { turbo: false },
-                   html: { target: "_blank", rel: "noopener", class: "project-setup-link__form" } do %>
+                   html: { class: "project-setup-link__form" } do %>
       <%= render ActionButtonComponent.new(
             text: "Link or create Hack Club Account",
             variant: :primary,

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -25,7 +25,6 @@
   highlight_incomplete_fields = (can_edit_project && params[:complete].present?) ? @project.incomplete_info_fields : []
 %>
 
-
 <div class="app-layout">
   <div class="app-layout__main">
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -522,6 +522,9 @@ Rails.application.routes.draw do
     get  :interests_result,          to: "wizard#interests_result"
     get  :name,                      to: "wizard#name"
     post :name,                      to: "wizard#submit_name"
+    get  :guest_email,               to: "wizard#guest_email"
+    post :guest_email_yes,           to: "wizard#guest_email_yes"
+    post :guest_email_no,            to: "wizard#guest_email_no"
   end
 
   namespace :admin, constraints: AdminConstraint do

--- a/db/migrate/20260530182421_add_guest_email_to_users.rb
+++ b/db/migrate/20260530182421_add_guest_email_to_users.rb
@@ -1,0 +1,6 @@
+class AddGuestEmailToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :guest_email, :string
+    add_index :users, :guest_email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_29_133839) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_30_182421) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
@@ -352,7 +352,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_29_133839) do
     t.bigint "mission_id", null: false
     t.integer "position", default: 0, null: false
     t.datetime "updated_at", null: false
-    t.index "mission_id, lower((language)::text)", name: "index_mission_guide_variants_unique_language", unique: true
+    t.index ["mission_id", "language"], name: "index_mission_guide_variants_unique_language", unique: true
     t.index ["mission_id"], name: "index_mission_guide_variants_on_mission_id"
   end
 
@@ -410,7 +410,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_29_133839) do
     t.string "language", null: false
     t.bigint "mission_step_id", null: false
     t.datetime "updated_at", null: false
-    t.index "mission_step_id, lower((language)::text)", name: "index_mission_step_bodies_unique_language", unique: true
+    t.index ["mission_step_id", "language"], name: "index_mission_step_bodies_unique_language", unique: true
     t.index ["mission_step_id"], name: "index_mission_step_bodies_on_mission_step_id"
   end
 
@@ -1073,6 +1073,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_29_133839) do
     t.string "experience_level"
     t.string "first_name"
     t.string "granted_roles", default: [], null: false, array: true
+    t.string "guest_email"
     t.boolean "has_gotten_free_stickers", default: false
     t.boolean "has_pending_achievements", default: false, null: false
     t.string "hcb_email"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -16,6 +16,7 @@
 #  experience_level             :string
 #  first_name                   :string
 #  granted_roles                :string           default([]), not null, is an Array
+#  guest_email                  :string
 #  has_gotten_free_stickers     :boolean          default(FALSE)
 #  has_pending_achievements     :boolean          default(FALSE), not null
 #  hcb_email                    :string

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -14,6 +14,7 @@
 #  experience_level             :string
 #  first_name                   :string
 #  granted_roles                :string           default([]), not null, is an Array
+#  guest_email                  :string
 #  has_gotten_free_stickers     :boolean          default(FALSE)
 #  has_pending_achievements     :boolean          default(FALSE), not null
 #  hcb_email                    :string


### PR DESCRIPTION
- open hca link in same tab so it doesn't end up creating an extra tab
- when you link hca, override the email address but if there was a different email, set that as new guest email
- have a new screen for if you signed in with the guest email and not the hca email
- allow guest emails to disconnect from primary emails
- if you already have birthday from hca, skip asking if they're a teen