### PR TITLE
feat(root): add social proof links to footer on marketing page

### DIFF
--- a/app/views/landing/sections/_footer.html.erb
+++ b/app/views/landing/sections/_footer.html.erb
@@ -26,8 +26,8 @@
         </nav>
       </div>
       <div class="landing-footer__text">
-        <p>Hack Club is a 501(c)(3) nonprofit and network of 100k+ technical high schoolers. We believe you learn best by building, so we're creating community and providing grants so you can make awesome projects. In the past few years, we've partnered with GitHub to run Summer of Making, hosted the world's longest hackathon on land, and ran Canada's largest high school hackathon.</p>
-        <p>At Hack Club, students aren't just learning, they're shipping.</p>
+        <p>Hack Club is a 501(c)(3) nonprofit and network of 100k+ technical high schoolers. We believe you learn best by building, so we're creating community and providing grants so you can make awesome projects. In the past few years, we've <%= link_to "sent 30 teen hackers hiking the Pacific Crest Trail", "https://www.youtube.com/watch?v=ufMUJ9D1fi8" %>, <%= link_to "hosted a hackathon for the worst ideas", "https://www.youtube.com/watch?v=8iM1W8kXrQA" %>, and <%= link_to "ran the largest hardware hackathon at GitHub HQ", "https://www.youtube.com/watch?v=kaEFv7e49mo" %>.</p>
+        <p>Read about Hack Club in <%= link_to "The Wall Street Journal", "https://www.wsj.com/articles/teen-hackers-try-to-convince-parents-they-are-up-to-good-11569922200" %>, <%= link_to "CBS News", "https://www.cbsnews.com/sanfrancisco/news/hack-club-hosts-teen-coders-san-francisco/" %>, and <%= link_to "NASA.gov", "https://www.nasa.gov/learning-resources/space-out-this-summer-with-variety-of-nasa-stem-activities/" %>, or watch us <%= link_to "on stage with AMD CEO Lisa Su at CES", "https://www.youtube.com/live/UbfAhFxDomE?si=5DiK1_hGqKrB_r50&t=7033" %>.</p>
         <p>Made with &#9829;&#xFE0E; by teenagers, for teenagers at Hack Club</p>
       </div>
     </div>


### PR DESCRIPTION
Before:

<img width="1151" height="363" alt="Screenshot 2026-05-30 at 19 46 14" src="https://github.com/user-attachments/assets/81c978c6-d974-4fd7-aa8e-7a9dcb300088" />

After:

<img width="1148" height="433" alt="Screenshot 2026-05-30 at 19 46 10" src="https://github.com/user-attachments/assets/d72d8570-4e15-4032-9e8c-86deebec3c81" />
