### PR TITLE
fix (css): logged-out pages now uses the stardance theme

### DIFF
--- a/app/assets/stylesheets/layout/_base.scss
+++ b/app/assets/stylesheets/layout/_base.scss
@@ -11,8 +11,8 @@ body {
   --sidebar-reserved: calc(var(--sidebar-width) + var(--sidebar-inset));
 
   margin: 0;
-  color: var(--color-text-body);
-  background-color: var(--color-bg);
+  color: var(--color-space-text);
+  background-color: var(--color-space-bg);
   display: flex;
   flex-direction: column;
   min-height: 100vh;
@@ -40,13 +40,6 @@ body.signed-in {
     margin-right: 20px;
     margin-bottom: 180px; // extra space for bottom-bar
   }
-}
-
-// Shop and guides pages keep the dark space backdrop even when logged out.
-body.shop-page:not(.signed-in),
-body.guides-page:not(.signed-in) {
-  background-color: var(--color-space-bg);
-  color: var(--color-space-text);
 }
 
 body.shop-page.signed-in {


### PR DESCRIPTION
The default `body` styles in `layout/_base.scss` were still using the old FT color tokens (`--color-bg` and `--color-text-body`), causing all logged-out pages to render with the old theme. Only `body.signed-in` was correctly using the stardance theme

### Changes

* Updated the default `body` styles to use the stardance theme (`--color-space-bg` and `--color-space-text`) for all pages.
* Removed the `shop` and `guides` `:not(.signed-in)` overrides, which were previously added as workarounds for this issue and are no longer necessary.



Before:
<img width="1888" height="945" alt="image" src="https://github.com/user-attachments/assets/4b65da34-ba57-4dbe-a95e-a90591d0ad00" />
After:
<img width="1906" height="938" alt="image" src="https://github.com/user-attachments/assets/31b5d63c-27cb-4c93-8a92-7c9ad0aa5d17" />
