### PR TITLE
fix(profile): make followers/following open the modal

### DIFF
--- a/app/assets/stylesheets/pages/user/_show.scss
+++ b/app/assets/stylesheets/pages/user/_show.scss
@@ -962,6 +962,12 @@ turbo-frame#profile_tabs {
 
 // Followers/following modal
 .followers-modal {
+  // Explicit centering: CSS resets (margin: 0) override the browser's UA
+  // sheet which centers dialogs via margin: auto. We restore it here so
+  // showModal() renders the sheet in the middle of the viewport.
+  position: fixed;
+  inset: 0;
+  margin: auto;
   border: none;
   border-radius: var(--profile-radius);
   padding: 0;
@@ -969,6 +975,13 @@ turbo-frame#profile_tabs {
   color: var(--color-space-text);
   width: min(440px, 90vw);
   max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  &:not([open]) {
+    display: none;
+  }
 
   &::backdrop {
     background: var(--color-backdrop);
@@ -1000,6 +1013,7 @@ turbo-frame#profile_tabs {
 }
 
 .followers-modal__body {
+  flex: 1;
   padding: var(--space-m);
   overflow-y: auto;
 }

--- a/app/javascript/controllers/profile_modal_controller.js
+++ b/app/javascript/controllers/profile_modal_controller.js
@@ -40,6 +40,18 @@ export default class extends Controller {
     dialog.close?.() || dialog.removeAttribute("open");
   }
 
+  backdropClose(event) {
+    const dialog = this._dialog();
+    if (!dialog) return;
+    const rect = dialog.getBoundingClientRect();
+    const clickedInside =
+      rect.top <= event.clientY &&
+      event.clientY <= rect.top + rect.height &&
+      rect.left <= event.clientX &&
+      event.clientX <= rect.left + rect.width;
+    if (!clickedInside) this.close();
+  }
+
   _dialog() {
     if (this.hasDialogTarget) return this.dialogTarget;
     return document.getElementById("followers-modal");

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,7 +12,7 @@
 <% own_profile = current_user&.id == @user.id %>
 <% banner_url = @user.banner.attached? ? url_for(@user.banner) : image_path("profile/default-banner.png") %>
 
-<div class="app-layout">
+<div class="app-layout" data-controller="profile-modal">
   <div class="app-layout__main">
     <%= turbo_frame_tag "profile_card" do %>
     <%= form_with model: @user, url: user_path(@user), method: :patch, multipart: true,
@@ -296,17 +296,17 @@
   </div>
 
   <%= render DiscoverRailComponent.new %>
-</div>
 
-<dialog id="followers-modal"
-        class="followers-modal"
-        data-controller="profile-modal"
-        data-profile-modal-target="dialog">
-  <header class="followers-modal__header">
-    <h2 class="followers-modal__title" data-profile-modal-target="title">Followers</h2>
-    <button type="button" class="followers-modal__close" data-action="click->profile-modal#close" aria-label="Close">×</button>
-  </header>
-  <div class="followers-modal__body" data-profile-modal-target="body">
-    <p class="followers-modal__loading">Loading…</p>
-  </div>
-</dialog>
+  <dialog id="followers-modal"
+          class="followers-modal"
+          data-profile-modal-target="dialog"
+          data-action="click->profile-modal#backdropClose">
+    <header class="followers-modal__header">
+      <h2 class="followers-modal__title" data-profile-modal-target="title">Followers</h2>
+      <button type="button" class="followers-modal__close" data-action="click->profile-modal#close" aria-label="Close">×</button>
+    </header>
+    <div class="followers-modal__body" data-profile-modal-target="body">
+      <p class="followers-modal__loading">Loading…</p>
+    </div>
+  </dialog>
+</div>


### PR DESCRIPTION
Clicking the followers and following counts on profile pages buttons did nothing. This fixes the issue so they open a modal showing the full user list

- Moved `data-controller="profile-modal"` from the `<dialog>` to the outer `.app-layout` div so trigger buttons and dialog targets share a common ancestor
- Move the `<dialog>` inside `.app-layout` so Stimulus can resolve its targets (`dialog`, `title`, `body`)
- Fix top-left positioning by adding `position: fixed; inset: 0; margin: auto` to override the global `margin: 0` reset that was breaking native `<dialog>` centering
- Added `backdropClose` handler so clicking outside the modal closes it


<img width="883" height="496" alt="image" src="https://github.com/user-attachments/assets/6615b110-fa1f-432b-b05e-d1df16b846cc" />
