### PR TITLE
fix(shop): allow buying items again 

### DIFF
--- a/app/policies/shop_policy.rb
+++ b/app/policies/shop_policy.rb
@@ -1,21 +1,17 @@
 class ShopPolicy < ApplicationPolicy
+  def index?
+    signed_in_any?
+  end
+
   def show?
     true
   end
 
-  def my_orders?
+  def create?
     signed_in_any?
   end
 
-  def cancel_order?
-    signed_in_any?
-  end
-
-  def order?
-    signed_in_any?
-  end
-
-  def create_order?
+  def cancel?
     signed_in_any?
   end
 end


### PR DESCRIPTION
The shop controller refactor renamed actions from create_order/order/ my_orders/cancel_order to RESTful create/show/index/cancel, but the policy methods were never updated. Pundit fell through to ApplicationPolicy which returns false for everything → 403.

thanks claude