### PR TITLE
fix(shop): working filters and simplified card rendering

### DIFF
--- a/app/assets/stylesheets/components/_shop-item-card.scss
+++ b/app/assets/stylesheets/components/_shop-item-card.scss
@@ -274,13 +274,6 @@
     }
   }
 
-  &--non-interactive {
-    filter: saturate(0.5);
-    opacity: 0.55;
-    pointer-events: none;
-    user-select: none;
-  }
-
   &--out-of-stock {
     .shop-item-card__order-cta {
       display: none;

--- a/app/assets/stylesheets/pages/shop/_tutorial.scss
+++ b/app/assets/stylesheets/pages/shop/_tutorial.scss
@@ -90,11 +90,3 @@
   }
 }
 
-// Non-interactive shop item cards (preview mode + tutorial-locked items)
-// stay visible so users can browse but lose their click affordance.
-.shop-item-card--non-interactive {
-  filter: saturate(0.5);
-  opacity: 0.55;
-  pointer-events: none;
-  user-select: none;
-}

--- a/app/components/shop_item_card_component.html.erb
+++ b/app/components/shop_item_card_component.html.erb
@@ -106,18 +106,17 @@
         </button>
       <% end %>
     <% else %>
-      <% if logged_in %>
-        <%= render ActionButtonComponent.new(
-              text: cta_price_label,
-              leading_icon: cta_price_icon,
-              href: order_url,
-              size: :large,
-              variant: :primary,
-              class: "shop-item-card__order-cta",
-              disabled: balance.to_i < display_price,
-              data: { turbo_frame: "_top" }
-            ) %>
-      <% end %>
+      <% can_buy = logged_in && balance.to_i >= display_price %>
+      <%= render ActionButtonComponent.new(
+            text: cta_price_label,
+            leading_icon: cta_price_icon,
+            href: can_buy ? order_url : nil,
+            size: :large,
+            variant: :primary,
+            class: "shop-item-card__order-cta",
+            disabled: !can_buy,
+            data: can_buy ? { turbo_frame: "_top" } : {}
+          ) %>
     <% end %>
   </div>
 </div>

--- a/app/components/shop_item_card_component.html.erb
+++ b/app/components/shop_item_card_component.html.erb
@@ -1,4 +1,4 @@
-<div class="shop-item-card<%= ' shop-item-card--achievement-locked' if locked_by_achievement %><%= ' shop-item-card--mission-locked' if mission_locked %><%= ' shop-item-card--out-of-stock' if out_of_stock? %><%= ' shop-item-card--on-sale' if on_sale %><%= ' shop-item-card--with-bow' if show_bow %><%= ' shop-item-card--non-interactive' unless interactive %><%= ' shop-item-card--spotlight' if tutorial_spotlight %>"
+<div class="shop-item-card<%= ' shop-item-card--achievement-locked' if locked_by_achievement %><%= ' shop-item-card--mission-locked' if mission_locked %><%= ' shop-item-card--out-of-stock' if out_of_stock? %><%= ' shop-item-card--on-sale' if on_sale %><%= ' shop-item-card--with-bow' if show_bow %><%= ' shop-item-card--spotlight' if tutorial_spotlight %>"
      data-categories="<%= categories.join(',') %>"
      data-regions="<%= enabled_regions.join(',') %>"
      data-achievement-locked="<%= locked_by_achievement %>"
@@ -14,9 +14,8 @@
       image_href = "#"
       image_opts = { class: "shop-item-card__image-wrap", onclick: "event.preventDefault(); #{OPEN_VERIFY_MODAL}" }
     else
-      image_href = interactive ? order_url : "#"
-      image_opts = { class: "shop-item-card__image-wrap", data: (interactive ? { turbo_frame: "_top" } : { turbo: false }) }
-      image_opts[:tabindex] = "-1" unless interactive
+      image_href = order_url
+      image_opts = { class: "shop-item-card__image-wrap", data: { turbo_frame: "_top" } }
     end
   %>
   <%= link_to image_href, image_opts do %>
@@ -51,7 +50,7 @@
     <% end %>
   <% end %>
 
-  <% if logged_in && interactive %>
+  <% if logged_in %>
     <button type="button"
             class="shop-item-card__star"
             data-shop-wishlist-target="starButton"
@@ -106,12 +105,8 @@
           <span class="action-btn__label"><%= cta_price_label %></span>
         </button>
       <% end %>
-    <% when :tutorial_locked %>
-      <span class="action-btn action-btn--large action-btn--primary action-btn--disabled shop-item-card__order-cta shop-item-card__order-cta--locked" aria-disabled="true">Not enough Stardust</span>
-    <% when :preview_locked %>
-      <span class="action-btn action-btn--large action-btn--secondary action-btn--disabled shop-item-card__order-cta shop-item-card__order-cta--locked" aria-disabled="true"><%= cta_price_label %></span>
     <% else %>
-      <% if logged_in && interactive %>
+      <% if logged_in %>
         <%= render ActionButtonComponent.new(
               text: cta_price_label,
               leading_icon: cta_price_icon,
@@ -119,14 +114,9 @@
               size: :large,
               variant: :primary,
               class: "shop-item-card__order-cta",
-              disabled: balance < display_price,
+              disabled: balance.to_i < display_price,
               data: { turbo_frame: "_top" }
             ) %>
-      <% elsif logged_in %>
-        <span class="action-btn action-btn--large action-btn--secondary shop-item-card__order-cta shop-item-card__order-cta--locked" aria-disabled="true">
-          <% if cta_price_icon %><%= image_tag cta_price_icon, class: "action-btn__icon action-btn__icon--leading", "aria-hidden": true %><% end %>
-          <span class="action-btn__label"><%= cta_price_label %></span>
-        </span>
       <% end %>
     <% end %>
   </div>

--- a/app/components/shop_item_card_component.rb
+++ b/app/components/shop_item_card_component.rb
@@ -1,14 +1,14 @@
 class ShopItemCardComponent < ViewComponent::Base
   include MarkdownHelper
 
-  CTA_MODES = %i[order tutorial_buy tutorial_verify tutorial_locked preview_locked].freeze
+  CTA_MODES = %i[order tutorial_buy tutorial_verify].freeze
 
   # JS to pop the shared verify modal (mounted in the layout for unverified
   # users). Used when a tutorial pick's gate is "verify your identity" — we
   # surface the popup in place instead of routing to a separate screen.
   OPEN_VERIFY_MODAL = "document.getElementById('idv-verify-modal')?.showModal()".freeze
 
-  attr_reader :item_id, :name, :description, :hours, :price, :image_url, :item_type, :balance, :enabled_regions, :regional_price, :logged_in, :interactive, :tutorial_spotlight, :cta_mode, :remaining_stock, :limited, :on_sale, :sale_percentage, :original_price, :created_at, :show_bow, :show_time_ago, :purchase_count, :is_new, :enabled_until, :locked_by_achievement, :required_achievement_names, :required_achievement_hints, :mission_locked, :unlocking_mission_names
+  attr_reader :item_id, :name, :description, :hours, :price, :image_url, :item_type, :balance, :enabled_regions, :regional_price, :logged_in, :tutorial_spotlight, :cta_mode, :remaining_stock, :limited, :on_sale, :sale_percentage, :original_price, :created_at, :show_bow, :show_time_ago, :purchase_count, :is_new, :enabled_until, :locked_by_achievement, :required_achievement_names, :required_achievement_hints, :mission_locked, :unlocking_mission_names
 
   def initialize(item_id:, name:, description:, hours:, price:, image_url:, item_type: nil, balance: nil, enabled_regions: [], regional_price: nil, logged_in: true, interactive: true, tutorial_spotlight: false, cta_mode: :order, remaining_stock: nil, limited: false, on_sale: false, sale_percentage: nil, original_price: nil, created_at: nil, show_bow: false, show_time_ago: false, purchase_count: nil, is_new: false, enabled_until: nil, locked_by_achievement: false, required_achievement_names: [], required_achievement_hints: [], mission_locked: false, unlocking_mission_names: [])
     @item_id = item_id
@@ -22,7 +22,6 @@ class ShopItemCardComponent < ViewComponent::Base
     @enabled_regions = enabled_regions
     @regional_price = regional_price || price
     @logged_in = logged_in
-    @interactive = interactive
     @tutorial_spotlight = tutorial_spotlight
     @cta_mode = CTA_MODES.include?(cta_mode) ? cta_mode : :order
     @remaining_stock = remaining_stock

--- a/app/controllers/shop/base_controller.rb
+++ b/app/controllers/shop/base_controller.rb
@@ -24,22 +24,13 @@ class Shop::BaseController < ApplicationController
   end
 
   def load_shop_items
-    excluded_free_stickers = current_user && (has_ordered_free_stickers? || current_user.shop_tutorial_completed?)
     shop_page_data = ShopItem.cached_shop_page_data
     @shop_items = shop_page_data[:buyable_standalone]
-    @shop_items = @shop_items.reject { |item| item.type == "ShopItem::FreeStickers" } if excluded_free_stickers
-    @featured_item = featured_free_stickers_item unless excluded_free_stickers
+    @shop_items = @shop_items.reject { |item| item.type.in?(%w[ShopItem::FreeStickers ShopItem::TutorialNothing]) }
     @recently_added_items = shop_page_data[:recently_added]
     @user_balance = current_user&.cached_balance || 0
 
-    preload_shop_item_images(@shop_items + Array(@recently_added_items) + [ @featured_item ].compact)
-
-    if @shop_mode == :tutorial && @tutorial_items[:nothing].present?
-      tutorial_ids = @tutorial_items.values.compact.map(&:id).to_set
-      @shop_items = @shop_items + [ @tutorial_items[:nothing] ]
-      tutorial_picks, rest = @shop_items.partition { |item| tutorial_ids.include?(item.id) }
-      @shop_items = tutorial_picks + rest
-    end
+    preload_shop_item_images(@shop_items + Array(@recently_added_items))
   end
 
   def preload_shop_item_images(items)
@@ -50,16 +41,6 @@ class Shop::BaseController < ApplicationController
       records: items,
       associations: { image_attachment: [ :blob, :record ] }
     ).call
-  end
-
-  def has_ordered_free_stickers?
-    current_user.has_gotten_free_stickers? ||
-      current_user.shop_orders.joins(:shop_item).where(shop_items: { type: "ShopItem::FreeStickers" }).exists?
-  end
-
-  def featured_free_stickers_item
-    item = ShopItem.find_by(id: 1, type: "ShopItem::FreeStickers", enabled: true)
-    item if item&.enabled_in_region?(@user_region)
   end
 
   def tutorial_item?(shop_item)

--- a/app/controllers/shop/items_controller.rb
+++ b/app/controllers/shop/items_controller.rb
@@ -5,6 +5,11 @@ class Shop::ItemsController < Shop::BaseController
     context: -> { { sidebar_orders: @sidebar_orders || [], user_balance: @user_balance || 0 } }
 
   def index
+    if params[:q].present?
+      redirect_to shop_category_path("all", q: params[:q])
+      return
+    end
+
     prepare_shop_chrome
     load_shop_items
     load_hub_sections
@@ -96,11 +101,6 @@ class Shop::ItemsController < Shop::BaseController
     return if @shop_items.blank?
 
     pool = @shop_items.select { |item| item.image.attached? && item.enabled_in_region?(@user_region) }
-
-    if @shop_mode == :tutorial && @tutorial_items
-      pick_ids = @tutorial_items.values.compact.map(&:id).to_set
-      pool = pool.reject { |item| pick_ids.include?(item.id) }
-    end
 
     shuffled = pool.shuffle
     @new_items     = shuffled.first(8)

--- a/app/javascript/controllers/shop_controller.js
+++ b/app/javascript/controllers/shop_controller.js
@@ -10,8 +10,12 @@ export default class extends Controller {
     this.categoryFilter = "All";
     this.priceRange = "none";
     this.regionFilter = this.userRegionValue;
-    this.searchQuery = "";
     this.accessFilter = "All";
+
+    const searchInput = this.element.querySelector(
+      '[data-action*="shop#search"]',
+    );
+    this.searchQuery = (searchInput?.value || "").toLowerCase();
 
     this.setupSortButton();
     this.applyFiltersAndSort();
@@ -55,7 +59,9 @@ export default class extends Controller {
   }
 
   applyFiltersAndSort() {
-    const itemsContainer = document.querySelector(".shop__items");
+    const itemsContainer =
+      document.querySelector(".shop-category__items") ||
+      document.querySelector(".shop__items");
     if (!itemsContainer) return;
 
     const items = Array.from(
@@ -131,7 +137,9 @@ export default class extends Controller {
   }
 
   sortItems() {
-    const itemsContainer = document.querySelector(".shop__items");
+    const itemsContainer =
+      document.querySelector(".shop-category__items") ||
+      document.querySelector(".shop__items");
     if (!itemsContainer) return;
 
     const items = Array.from(

--- a/app/views/shop/items/_item_card.html.erb
+++ b/app/views/shop/items/_item_card.html.erb
@@ -1,12 +1,7 @@
 <%#
-  Renders a full ShopItemCardComponent for `item`, deriving interactivity and
-  CTA from the shop `mode` (:preview / :tutorial / :normal). Shared by the
-  category subpage, the hub's Discover row, and the tutorial picks so all three
-  show the same complete card instead of a summary tile.
-
   Locals:
     item              - ShopItem (required)
-    mode              - shop mode symbol (default :normal)
+    mode              - shop mode symbol (:tutorial / :normal)
     region            - region code for pricing
     balance           - viewer's Stardust balance
     tutorial_item_ids - ids of the two tutorial picks (default [])
@@ -20,19 +15,11 @@
 <% item_achievement_locked = item.achievement_locked_for?(current_user) %>
 <% is_tutorial_pick = tutorial_item_ids.include?(item.id) %>
 <% show_spotlight = local_assigns.fetch(:spotlight, is_tutorial_pick && mode == :tutorial) %>
-<%# Only preview mode locks everything. In tutorial mode the shop behaves
-    normally — the two picks just get a "Buy now" + spotlight, every other item
-    stays a normal orderable card, so a card looks the same here as it does on
-    a category page. %>
-<% item_interactive = mode != :preview %>
-<%# A tutorial pick's first gate is "verify your identity" when the viewer
-    isn't verified yet — surface the verify popup in place rather than routing
-    to a separate screen. Otherwise it's a normal "Buy now". %>
 <% pick_needs_verify = is_tutorial_pick && current_user && !current_user.identity_submitted? %>
-<% cta_mode = case mode
-              when :preview  then :preview_locked
-              when :tutorial then is_tutorial_pick ? (pick_needs_verify ? :tutorial_verify : :tutorial_buy) : :order
-              else                :order
+<% cta_mode = if mode == :tutorial && is_tutorial_pick
+                pick_needs_verify ? :tutorial_verify : :tutorial_buy
+              else
+                :order
               end %>
 <%= render ShopItemCardComponent.new(
   item_id: item.id,
@@ -46,7 +33,6 @@
   enabled_regions: item.enabled_region_codes,
   regional_price: sale_price,
   logged_in: current_user.present?,
-  interactive: item_interactive,
   tutorial_spotlight: show_spotlight,
   cta_mode: cta_mode,
   remaining_stock: item.remaining_stock,

--- a/app/views/shop/items/_preview_banner.html.erb
+++ b/app/views/shop/items/_preview_banner.html.erb
@@ -69,10 +69,8 @@
           <li class="shop-hub__items-card">
             <%= render "shop/items/item_card",
                   item: item,
-                  mode: :preview,
                   region: @user_region,
                   balance: 0,
-                  tutorial_item_ids: [],
                   spotlight: false %>
           </li>
         <% end %>

--- a/app/views/shop/items/category.html.erb
+++ b/app/views/shop/items/category.html.erb
@@ -1,9 +1,8 @@
 <% content_for :title, @category_title %>
 
-<div class="shop-category shop-category--mode-<%= @shop_mode %>"
+<div class="shop-category"
      data-controller="shop"
-     data-shop-user-region-value="<%= @user_region %>"
-     data-shop-mode-value="<%= @shop_mode %>">
+     data-shop-user-region-value="<%= @user_region %>">
 
   <header class="shop-category__title-row">
     <span class="shop-category__title-divider shop-category__title-divider--left" aria-hidden="true"></span>
@@ -73,15 +72,12 @@
 
     <%= turbo_frame_tag "shop_items" do %>
       <div class="shop-category__items">
-        <% tutorial_item_ids = @shop_mode == :tutorial ? @tutorial_items.values.compact.map(&:id) : [] %>
         <% @shop_items.each do |item| %>
           <% if item.image.present? && item.enabled_in_region?(@user_region) %>
             <%= render "shop/items/item_card",
                   item: item,
-                  mode: @shop_mode,
                   region: @user_region,
-                  balance: @user_balance,
-                  tutorial_item_ids: tutorial_item_ids %>
+                  balance: @user_balance %>
           <% end %>
         <% end %>
         <% if @shop_items.empty? %>

--- a/app/views/shop/items/index.html.erb
+++ b/app/views/shop/items/index.html.erb
@@ -3,10 +3,9 @@
 <% content_for :og_description, "Spend your Stardust on stickers, hardware, and other prizes. Earn Stardust by building projects and voting!" %>
 <% content_for :og_image, og_image_url('shop', format: :png) %>
 
-<div class="shop-hub shop-hub--mode-<%= @shop_mode %>"
+<div class="shop-hub"
      data-controller="shop"
-     data-shop-user-region-value="<%= @user_region %>"
-     data-shop-mode-value="<%= @shop_mode %>">
+     data-shop-user-region-value="<%= @user_region %>">
 
   <% if @shop_mode == :preview %>
     <%= render "shop/items/preview_banner" %>
@@ -158,10 +157,8 @@
                 <li class="shop-hub__items-card">
                   <%= render "shop/items/item_card",
                         item: item,
-                        mode: @shop_mode,
                         region: @user_region,
-                        balance: @user_balance,
-                        tutorial_item_ids: pick_ids %>
+                        balance: @user_balance %>
                 </li>
               <% end %>
             </ul>
@@ -193,10 +190,8 @@
                 <li class="shop-hub__items-card">
                   <%= render "shop/items/item_card",
                         item: item,
-                        mode: @shop_mode,
                         region: @user_region,
-                        balance: @user_balance,
-                        tutorial_item_ids: pick_ids %>
+                        balance: @user_balance %>
                 </li>
               <% end %>
             </ul>

--- a/app/views/shop/regions/update.turbo_stream.erb
+++ b/app/views/shop/regions/update.turbo_stream.erb
@@ -3,26 +3,10 @@
     <div class="shop-category__items">
       <% @shop_items.each do |item| %>
         <% if item.image.present? && item.enabled_in_region?(@user_region) %>
-          <% sale_price = item.price_for_region(@user_region) %>
-          <%= render ShopItemCardComponent.new(
-            item_id: item.id,
-            name: item.name,
-            description: item.description,
-            hours: item.fixed_estimate(sale_price).to_i,
-            price: item.ticket_cost,
-            image_url: item.image.variant(:carousel_lg),
-            item_type: item.type,
-            balance: @user_balance,
-            enabled_regions: item.enabled_region_codes,
-            regional_price: sale_price,
-            logged_in: true,
-            remaining_stock: item.remaining_stock,
-            limited: item.limited?,
-            on_sale: item.on_sale?,
-            sale_percentage: item.sale_percentage,
-            original_price: item.base_price_for_region(@user_region),
-            enabled_until: item.enabled_until
-          ) %>
+          <%= render "shop/items/item_card",
+                item: item,
+                region: @user_region,
+                balance: @user_balance %>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
## Summary

- **Search actually works now** — hub search redirects to the "all" category page where client-side filtering takes over. The Stimulus controller was targeting `.shop__items` but the HTML uses `.shop-category__items`; fixed the selector.
- **Dropdowns work** — price range, access, sort, and region filters all function correctly on category pages.
- **No more gray preview-mode cards** — the `--non-interactive` state (opacity 0.55, desaturated, pointer-events none) caused jarring visual flips on region change and was confusing UX. Buy buttons now naturally disable when balance < price.
- **Region change is consistent** — the Turbo Stream uses the shared `_item_card` partial instead of a divergent inline render that was missing achievement locks, purchase counts, sale info, etc.
- **Tutorial items excluded from regular listings** — FreeStickers and TutorialNothing only appear in the dedicated tutorial section on the hub, not in category pages or carousels.

## Changes

| File | What |
|------|------|
| `shop_controller.js` | Fix container selector, read initial `?q=` on connect |
| `items_controller.rb` | Redirect hub search to `/shop/category/all?q=…`, remove tutorial pool exclusion (now handled in `load_shop_items`) |
| `base_controller.rb` | Always exclude tutorial items from `@shop_items`, remove dead helpers |
| `shop_item_card_component.rb` | Drop `interactive` attr, remove dead CTA modes |
| `shop_item_card_component.html.erb` | Remove non-interactive class/paths, simplify CTA switch |
| `_item_card.html.erb` | Remove preview mode logic, simplify to tutorial vs order |
| `category.html.erb` | Drop mode data-attrs, remove tutorial_item_ids |
| `index.html.erb` | Drop mode data-attrs, simplify carousel renders |
| `update.turbo_stream.erb` | Use shared `_item_card` partial |
| `_shop-item-card.scss` / `_tutorial.scss` | Remove `--non-interactive` CSS |

## Test plan

- [ ] Visit `/shop` — hub renders with category tiles, New/Popular carousels
- [ ] Type in hub search bar, submit — redirects to `/shop/category/all?q=…` with items filtered
- [ ] On category page: change Price Range, Access, Sort by, Region dropdowns — items filter/sort client-side
- [ ] Change region — cards re-render via Turbo Stream with correct prices, badges, and buy buttons
- [ ] As a preview-mode user (incomplete prerequisites): cards show normally with disabled buy buttons, no gray overlay
- [ ] Tutorial section on hub still shows FreeStickers/TutorialNothing picks correctly
- [ ] FreeStickers do NOT appear in category pages or carousels