### PR TITLE
fix(profile): display join date in "Month Day (ordinalized), Year" format

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -77,7 +77,7 @@
                       aria-live="polite"></span>
               </div>
             <% end %>
-            <p class="profile__joined">Joined <%= @user.created_at.to_date.strftime("%-d %b %Y") %></p>
+            <p class="profile__joined">Joined <%= "#{@user.created_at.strftime("%B")} #{@user.created_at.day.ordinalize}, #{@user.created_at.year}" %></p>
           </div>
         </div>
 


### PR DESCRIPTION
https://hackclub.slack.com/archives/C0AR0M43H61/p1780259070651079

At the request of Zach
> Polish: Date format should use USA date format. “May 31st, 2026”