### PR TITLE
refactor(missions): reduce sql queries for page

### DIFF
--- a/app/controllers/missions_controller.rb
+++ b/app/controllers/missions_controller.rb
@@ -6,21 +6,14 @@ class MissionsController < ApplicationController
   def index
     authorize Mission
 
-    @available_missions = Mission.available
-                                 .includes(:icon_attachment)
-                                 .order(featured_at: :desc, name: :asc)
-    @upcoming_missions = Mission.enabled
-                                .where("start_at IS NOT NULL AND start_at > ?", Time.current)
-                                .includes(:icon_attachment)
-                                .order(:start_at)
-                                .limit(8)
-    @ended_missions = Mission.enabled
-                             .where("end_at IS NOT NULL AND end_at <= ?", Time.current)
-                             .includes(:icon_attachment)
-                             .order(end_at: :desc)
-                             .limit(8)
+    buckets = Mission.visible_for(current_user).with_attached_icon
+                     .order(featured_at: :desc, name: :asc)
+                     .group_by(&:index_bucket)
 
-    @draft_missions = draft_missions_for_current_user
+    @available_missions = buckets[:available] || []
+    @upcoming_missions  = (buckets[:upcoming] || []).sort_by(&:start_at).first(8)
+    @ended_missions     = (buckets[:ended] || []).sort_by { |m| -m.end_at.to_f }.first(8)
+    @draft_missions     = (buckets[:draft] || []).sort_by { |m| -m.updated_at.to_f }
   end
 
   def show
@@ -56,19 +49,6 @@ class MissionsController < ApplicationController
 
   def set_body_class
     @body_class = "app-layout-page"
-  end
-
-  def draft_missions_for_current_user
-    return Mission.none unless current_user
-
-    scope = Mission.where(enabled: false).includes(:icon_attachment)
-
-    if current_user.admin?
-      scope.order(updated_at: :desc)
-    else
-      owned_ids = Mission::Membership.where(user_id: current_user.id, role: :owner).select(:mission_id)
-      scope.where(id: owned_ids).order(updated_at: :desc)
-    end
   end
 
   def set_mission

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -73,15 +73,34 @@ class Mission < ApplicationRecord
   scope :enabled,  -> { where(enabled: true) }
   scope :featured, -> { where.not(featured_at: nil) }
 
+  scope :visible_for, ->(user) {
+    if user&.admin?
+      all
+    elsif user
+      owned_ids = Mission::Membership.where(user_id: user.id, role: :owner).select(:mission_id)
+      where(enabled: true).or(where(id: owned_ids))
+    else
+      enabled
+    end
+  }
+
   scope :available, -> {
     enabled
       .where("start_at IS NULL OR start_at <= ?", Time.current)
       .where("end_at   IS NULL OR end_at   > ?", Time.current)
   }
 
-  def started? = start_at.nil? || start_at <= Time.current
-  def ended?   = end_at.present? && end_at <= Time.current
-  def coming_soon? = !started?
+  def started?(at = Time.current) = start_at.nil? || start_at <= at
+  def ended?(at = Time.current)   = end_at.present? && end_at <= at
+  def coming_soon?(at = Time.current) = !started?(at)
+  def available_at?(at = Time.current) = started?(at) && !ended?(at)
+
+  def index_bucket
+    return :draft unless enabled?
+    return :upcoming if coming_soon?
+    return :ended if ended?
+    :available
+  end
 
   def available_to_builders?
     enabled? && started? && !ended?


### PR DESCRIPTION
## what's this do?

Still not happy with how this looks semantically yet, but i'm happy with the sql generated

## show it works

here's prod with only 2 missions loading hitting the db 10 times (when signed in it causes 22 hits)

<img width="845" height="670" alt="Screenshot 2026-06-01 at 13 08 56" src="https://github.com/user-attachments/assets/fa7efcbe-ed5e-4d50-958e-fefea1b3b3aa" />

here's the changed version loading 10 missions in only 2 sql hits:

<img width="845" height="670" alt="Screenshot 2026-06-01 at 13 09 12" src="https://github.com/user-attachments/assets/f8446f48-9e1b-4819-9cf6-133798de57e9" />
