### PR TITLE
feat(edit-project-tooltip): show tooltip explaining what fields are not in edit project info

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -425,6 +425,13 @@ class Project < ApplicationRecord
       .all? { |r| r[:passed] }
   end
 
+  def info_blocker_message
+    req = shipping_requirements
+      .select { |r| INFO_REQUIREMENT_KEYS.include?(r[:key]) }
+      .find { |r| !r[:passed] }
+    req&.dig(:label)
+  end
+
   # The editable info fields (see FIELD_REQUIREMENT_MAP) that still have an
   # unmet requirement — used to highlight what's left to fill in on the form.
   def incomplete_info_fields

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -399,7 +399,12 @@
                     text: "Complete project info",
                     variant: :primary,
                     href: project_path(@project, editing: true, complete: true),
-                    data: { turbo_frame: "project_hero" }
+                    data: {
+                      turbo_frame: "project_hero",
+                      controller: "tooltip",
+                      tooltip_message_value: @project.info_blocker_message,
+                      tooltip_position_value: "top"
+                    }
                   ) %>
             <% else %>
               <%= render ActionButtonComponent.new(

--- a/app/views/projects/show_hackpad.html.erb
+++ b/app/views/projects/show_hackpad.html.erb
@@ -432,7 +432,12 @@
                     text: "Complete project info",
                     variant: :primary,
                     href: project_path(@project, editing: true, complete: true),
-                    data: { turbo_frame: "project_hero" }
+                    data: {
+                      turbo_frame: "project_hero",
+                      controller: "tooltip",
+                      tooltip_message_value: @project.info_blocker_message,
+                      tooltip_position_value: "top"
+                    }
                   ) %>
             <% else %>
               <%= render ActionButtonComponent.new(


### PR DESCRIPTION
tells you what fields you're missing in edit project!

<img width="366" height="219" alt="image" src="https://github.com/user-attachments/assets/31395122-a76b-43c3-abe3-74a3cb0019cb" />
