### PR TITLE
Remove fragment caching from landing

### DIFF
--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -9,7 +9,7 @@ class LandingController < ApplicationController
   def index
     @hide_sidebar = true
     @user_ref_token = flash[:user_ref_token]
-    @prefill_email = params[:e]
+
     prepare_landing_page_state
 
     if current_user

--- a/app/helpers/landing_helper.rb
+++ b/app/helpers/landing_helper.rb
@@ -9,11 +9,4 @@ module LandingHelper
     { url: "https://github.com/SteveMan67/platformed", mod: 5, by: "By Steve, 16", img: "landing/projects/steve.avif", alt: "Project by Steve", desc: "A platformer with a fully functioning level editor, online level sharing, and trigger system, built from the ground up in Javascript for Flavortown." }
   ].freeze
 
-  def landing_static_sections_cache_key
-    [
-      "landing/static-sections/v1",
-      @new_onboarding,
-      Rails.application.config.git_version
-    ]
-  end
 end

--- a/app/helpers/landing_helper.rb
+++ b/app/helpers/landing_helper.rb
@@ -8,5 +8,4 @@ module LandingHelper
     { url: "https://deltea.itch.io/starbird", mod: 4, by: "By Deltea, 16", img: "landing/projects/deltea.png", alt: "Project by Deltea", desc: "A platformer game about a bird collecting stars, made for Milkyway!" },
     { url: "https://github.com/SteveMan67/platformed", mod: 5, by: "By Steve, 16", img: "landing/projects/steve.avif", alt: "Project by Steve", desc: "A platformer with a fully functioning level editor, online level sharing, and trigger system, built from the ground up in Javascript for Flavortown." }
   ].freeze
-
 end

--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -44,11 +44,11 @@
     <%= render "landing/sections/partners" %>
 
     <%= render "landing/sections/faq" %>
-
-    <%= render "landing/sections/cta", new_onboarding: @new_onboarding %>
-
-    <%= render "landing/sections/footer" %>
   <% end %>
+
+  <%= render "landing/sections/cta", new_onboarding: @new_onboarding %>
+
+  <%= render "landing/sections/footer" %>
 </div>
 
 <%= render "landing/sections/user_ref_modal", token: @user_ref_token if @user_ref_token.present? %>

--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -20,31 +20,29 @@
     <%= render "landing/sections/hero" %>
   </div>
 
-  <% cache landing_static_sections_cache_key do %>
-    <%= render "landing/sections/what_is_this" %>
+  <%= render "landing/sections/what_is_this" %>
 
-    <%= render "landing/sections/how_this_works" %>
+  <%= render "landing/sections/how_this_works" %>
 
-    <%= render "landing/sections/project_thumbnails" %>
+  <%= render "landing/sections/project_thumbnails" %>
 
-    <%= render "landing/sections/gain_stardust" %>
+  <%= render "landing/sections/gain_stardust" %>
 
-    <%= render "landing/sections/prizes" %>
+  <%= render "landing/sections/prizes" %>
 
-    <%= render "landing/sections/project_outcome" %>
+  <%= render "landing/sections/project_outcome" %>
 
-    <%= render "landing/sections/weekend" %>
+  <%= render "landing/sections/weekend" %>
 
-    <%= render "landing/sections/what_is_hc" %>
+  <%= render "landing/sections/what_is_hc" %>
 
-    <%= render "landing/sections/highlights" %>
+  <%= render "landing/sections/highlights" %>
 
-    <%= render "landing/sections/done_before" %>
+  <%= render "landing/sections/done_before" %>
 
-    <%= render "landing/sections/partners" %>
+  <%= render "landing/sections/partners" %>
 
-    <%= render "landing/sections/faq" %>
-  <% end %>
+  <%= render "landing/sections/faq" %>
 
   <%= render "landing/sections/cta", new_onboarding: @new_onboarding %>
 

--- a/app/views/landing/sections/_rsvp_form.html.erb
+++ b/app/views/landing/sections/_rsvp_form.html.erb
@@ -15,7 +15,7 @@
       <%= leading %>
       <div class="input-yellow">
         <div>
-          <%= form.email_field :email, placeholder: placeholder, autocomplete: "email", required: true, value: @prefill_email %>
+          <%= form.email_field :email, placeholder: placeholder, autocomplete: "email", required: true %>
         </div>
       </div>
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -341,7 +341,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_045057) do
     t.bigint "mission_id", null: false
     t.integer "position", default: 0, null: false
     t.datetime "updated_at", null: false
-    t.index "mission_id, lower((language)::text)", name: "index_mission_guide_variants_unique_language", unique: true
+    t.index ["mission_id", "language"], name: "index_mission_guide_variants_unique_language", unique: true
     t.index ["mission_id"], name: "index_mission_guide_variants_on_mission_id"
   end
 
@@ -399,7 +399,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_045057) do
     t.string "language", null: false
     t.bigint "mission_step_id", null: false
     t.datetime "updated_at", null: false
-    t.index "mission_step_id, lower((language)::text)", name: "index_mission_step_bodies_unique_language", unique: true
+    t.index ["mission_step_id", "language"], name: "index_mission_step_bodies_unique_language", unique: true
     t.index ["mission_step_id"], name: "index_mission_step_bodies_on_mission_step_id"
   end
 
@@ -1122,7 +1122,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_045057) do
     t.index "lower((display_name)::text)", name: "index_users_on_lower_display_name_unique", unique: true, where: "((display_name IS NOT NULL) AND ((display_name)::text <> ''::text))"
     t.index "lower((email)::text)", name: "index_users_on_lower_email_unique", unique: true, where: "((email IS NOT NULL) AND ((email)::text <> ''::text))"
     t.index ["email"], name: "index_users_on_email"
-    t.index ["guest_email"], name: "index_users_on_guest_email"
     t.index ["onboarded_at"], name: "index_users_on_onboarded_at"
     t.index ["session_token"], name: "index_users_on_session_token", unique: true
     t.index ["slack_id"], name: "index_users_on_slack_id", unique: true


### PR DESCRIPTION
Fragment caching had ended up meaning that people's emails were getting displayed to other users. Disabled fragment caching across home page to fix this and ensure it can't happen.