### PR TITLE
fix for projects with empty banners showing up in suggested projects feed

### DIFF
--- a/app/controllers/home/feeds_controller.rb
+++ b/app/controllers/home/feeds_controller.rb
@@ -146,7 +146,9 @@ class Home::FeedsController < ApplicationController
         projects
       else
         Gorse::ProjectPayload.recommendable_scope(current_user)
-                             .with_banner_priority
+                             .where(deleted_at: nil)
+                             .joins(:banner_attachment)
+                             .includes(banner_attachment: :blob)
                              .limit(6)
       end
   end


### PR DESCRIPTION
## what's this do?

quick bug fix to exclude projects that don't have an uploaded banner image. issue submitted by max wofford

## show it works
<img width="566" height="148" alt="image" src="https://github.com/user-attachments/assets/23de4ebd-6ecf-4a75-8a05-06683db2d9ce" />



## ai?

only used ai to explain the syntax; made logic and pinpointed minor bug myself.
