### PR TITLE
fix(project): checking for valid project url now uses GET instead of HEAD

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -508,9 +508,7 @@ class Project < ApplicationRecord
     cache_key = "url_reachable_#{Digest::MD5.hexdigest(url)}"
     Rails.cache.fetch(cache_key, expires_in: 5.minutes) do
       next false unless SafeUrl.safe_to_probe?(url)
-      uri = URI.parse(url)
-      response = head_with_redirects(uri)
-      response.is_a?(Net::HTTPSuccess) || response.is_a?(Net::HTTPRedirection)
+      probe_url(URI.parse(url))
     end
   rescue URI::InvalidURIError, SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH,
          Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError
@@ -533,23 +531,24 @@ class Project < ApplicationRecord
     PostCreationToSlackJob.perform_later(self)
   end
 
-  def head_with_redirects(uri, limit = 3)
-    if limit <= 0
-      Net::HTTPServiceUnavailable.new("1.1", "503", "Too many redirects")
-    else
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = (uri.scheme == "https")
-      http.open_timeout = 10
-      http.read_timeout = 10
-      response = http.request_head(uri.request_uri)
+  def probe_url(uri, limit = 3)
+    return false if limit <= 0
 
-      if response.is_a?(Net::HTTPRedirection) && response["location"]
-        next_uri = URI.parse(response["location"])
-        return Net::HTTPForbidden.new("1.1", "403", "Redirect target not safe") unless SafeUrl.safe_to_probe?(next_uri.to_s)
-        head_with_redirects(next_uri, limit - 1)
-      else
-        response
-      end
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = (uri.scheme == "https")
+    http.open_timeout = 10
+    http.read_timeout = 10
+    response = http.request_head(uri.request_uri)
+
+    if response.is_a?(Net::HTTPRedirection) && response["location"]
+      next_uri = URI.parse(response["location"])
+      return false unless SafeUrl.safe_to_probe?(next_uri.to_s)
+      probe_url(next_uri, limit - 1)
+    elsif response.is_a?(Net::HTTPSuccess)
+      true
+    else
+      # Some servers don't support HEAD — fall back to GET
+      http.request_get(uri.request_uri).is_a?(Net::HTTPSuccess)
     end
   end
 end


### PR DESCRIPTION
<img width="312" height="216" alt="image" src="https://github.com/user-attachments/assets/4bed9b4b-da1d-4cd3-84af-97f8704d8784" />

many static site hosts don't implement HEAD so switching the check for 'complete project info' button in profile from using HEAD, which fails sometimes, to using GET as a fallback, which is consistent with the result from when you try to edit the project and enter the URL there.