### PR TITLE
fix(hca): ensure that changing emails in hca does not result in conflict

### DIFF
--- a/app/services/sessions/hca_login_service.rb
+++ b/app/services/sessions/hca_login_service.rb
@@ -139,11 +139,22 @@ module Sessions
       end
 
       def assign_user_attributes(user, fields, is_new_user)
-        if user.email.present? && fields[:email].present? && user.email != fields[:email]
-          user.guest_email = user.email
-          user.email = fields[:email]
-        else
-          user.email ||= fields[:email]
+        new_email = fields[:email]
+        if new_email.present? && user.email != new_email
+          conflicting_user = User.where.not(id: user.id).find_by("LOWER(email) = ?", new_email.downcase)
+          if conflicting_user
+            if conflicting_user.identities.where(provider: "hack_club").none?
+              conflicting_user.update_columns(email: nil)
+              Rails.logger.info("HCA login: reclaimed email #{new_email} from orphan user #{conflicting_user.id} for user #{user.id}")
+            else
+              Rails.logger.warn("HCA login: skipping email update for user #{user.id} — #{new_email} belongs to HCA-linked user #{conflicting_user.id}")
+            end
+          end
+
+          unless conflicting_user&.identities&.where(provider: "hack_club")&.exists?
+            user.guest_email = user.email if user.email.present?
+            user.email = new_email
+          end
         end
 
         user.display_name = User.random_funny_display_name if user.display_name.to_s.strip.blank?


### PR DESCRIPTION
## what's this do?

previously when you changed emails in hca, it would create a funky duplicate account. Now it properly handles the switch!

## show it works

hard to get a ss

## ai?

all ai
