### PR TITLE
feat(projects): make project followers clickable to display the followers list

### DIFF
--- a/app/assets/stylesheets/pages/projects/_show.scss
+++ b/app/assets/stylesheets/pages/projects/_show.scss
@@ -599,6 +599,17 @@ turbo-frame#project_hero {
 
 .project-show__followers {
   font-size: 1rem;
+  background: none;
+  border: none;
+  color: inherit;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 // Author avatars stack horizontally with a slight overlap, like a multi-user

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -371,6 +371,13 @@ class ProjectsController < ApplicationController
     end
   end
 
+  def followers
+    @project = Project.find(params[:id])
+    authorize @project, :show?
+    @followers = @project.followers.order(:display_name)
+    render "users/followers", layout: false
+  end
+
   def readme
     unless turbo_frame_request?
       redirect_to project_path(@project)

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -25,7 +25,7 @@
   highlight_incomplete_fields = (can_edit_project && params[:complete].present?) ? @project.incomplete_info_fields : []
 %>
 
-<div class="app-layout">
+<div class="app-layout" data-controller="profile-modal">
   <div class="app-layout__main">
 
     <%= turbo_frame_tag "project_hero" do %>
@@ -337,7 +337,13 @@
             <% end %>
 
             <div class="project-show__read-footer">
-              <span class="project-show__followers"><strong><%= follower_count %></strong> <%= "follower".pluralize(follower_count) %></span>
+              <%= button_tag type: "button",
+                             class: "project-show__followers",
+                             data: { action: "click->profile-modal#open",
+                                     "profile-modal-url-param": followers_project_path(@project),
+                                     "profile-modal-title-param": "Followers" } do %>
+                <strong><%= follower_count %></strong> <%= "follower".pluralize(follower_count) %>
+              <% end %>
               <div class="project-show__panel-actions">
                 <% if @project.fire? %>
                   <span class="project-show__badge project-show__badge--fire">⭐ Super Star Project</span>
@@ -841,4 +847,17 @@
   <% end %>
 
   <%= render DiscoverRailComponent.new %>
+
+  <dialog id="followers-modal"
+          class="followers-modal"
+          data-profile-modal-target="dialog"
+          data-action="click->profile-modal#backdropClose">
+    <header class="followers-modal__header">
+      <h2 class="followers-modal__title" data-profile-modal-target="title">Followers</h2>
+      <button type="button" class="followers-modal__close" data-action="click->profile-modal#close" aria-label="Close">×</button>
+    </header>
+    <div class="followers-modal__body" data-profile-modal-target="body">
+      <p class="followers-modal__loading">Loading…</p>
+    </div>
+  </dialog>
 </div>

--- a/app/views/projects/show_hackpad.html.erb
+++ b/app/views/projects/show_hackpad.html.erb
@@ -25,7 +25,7 @@
   highlight_incomplete_fields = (can_edit_project && params[:complete].present?) ? @project.incomplete_info_fields : []
 %>
 
-<div class="app-layout">
+<div class="app-layout" data-controller="profile-modal">
   <div class="app-layout__main">
 
     <%= turbo_frame_tag "project_hero" do %>
@@ -328,7 +328,13 @@
             <% end %>
 
             <div class="project-show__read-footer">
-              <span class="project-show__followers"><strong><%= follower_count %></strong> <%= "follower".pluralize(follower_count) %></span>
+              <%= button_tag type: "button",
+                             class: "project-show__followers",
+                             data: { action: "click->profile-modal#open",
+                                     "profile-modal-url-param": followers_project_path(@project),
+                                     "profile-modal-title-param": "Followers" } do %>
+                <strong><%= follower_count %></strong> <%= "follower".pluralize(follower_count) %>
+              <% end %>
               <div class="project-show__panel-actions">
                 <% if @project.fire? %>
                   <span class="project-show__badge project-show__badge--fire">⭐ Super Star Project</span>
@@ -837,4 +843,17 @@
   <% end %>
 
   <%= render DiscoverRailComponent.new %>
+
+  <dialog id="followers-modal"
+          class="followers-modal"
+          data-profile-modal-target="dialog"
+          data-action="click->profile-modal#backdropClose">
+    <header class="followers-modal__header">
+      <h2 class="followers-modal__title" data-profile-modal-target="title">Followers</h2>
+      <button type="button" class="followers-modal__close" data-action="click->profile-modal#close" aria-label="Close">×</button>
+    </header>
+    <div class="followers-modal__body" data-profile-modal-target="body">
+      <p class="followers-modal__loading">Loading…</p>
+    </div>
+  </dialog>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -749,6 +749,7 @@ Rails.application.routes.draw do
       get :readme
       post :follow
       delete :unfollow
+      get :followers
     end
   end
 


### PR DESCRIPTION

## what's this do?
Changed the static project followers count on the project page into a clickable element. Clicking it now opens a modal that displays a list of all users following the project :)

<!-- a sentence or two! -->

## show it works

<img width="783" height="563" alt="image" src="https://github.com/user-attachments/assets/b8bce1dd-b9db-4143-8a88-33f98b2fc2bb" />
## ai?

<!-- did you use AI tools? which ones? no judgment, we just wanna know. see AI_POLICY.md for details -->
Minimal usage :)