### PR TITLE
fix(guest): make sure guest banner doesn't show on landing page

### DIFF
--- a/app/components/onboarding/guest_banner_component.rb
+++ b/app/components/onboarding/guest_banner_component.rb
@@ -3,8 +3,6 @@ module Onboarding
     GRACE_PERIOD = 1.day
 
     def render?
-      return false if helpers.controller.is_a?(LandingController)
-
       visitor? || stale_guest?
     end
 

--- a/app/components/onboarding/guest_banner_component.rb
+++ b/app/components/onboarding/guest_banner_component.rb
@@ -3,6 +3,8 @@ module Onboarding
     GRACE_PERIOD = 1.day
 
     def render?
+      return false if helpers.controller.is_a?(LandingController)
+
       visitor? || stale_guest?
     end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -104,7 +104,7 @@
       <% end %>
     <% end %>
     <div id="flash-region"><%= render "shared/flash" %></div>
-    <%= render Onboarding::GuestBannerComponent.new %>
+    <%= render Onboarding::GuestBannerComponent.new unless @hide_sidebar %>
     <%= yield %>
     <%= render "shared/idv_verify_modal" %>
     <% unless @hide_footer %>


### PR DESCRIPTION
## what's this do?

the guest banner was showing on landing page oops

## show it works

<img width="2880" height="1637" alt="image" src="https://github.com/user-attachments/assets/d3f05e36-777d-40a6-9922-9d121042e98b" />

## ai?

so much ai
