### PR TITLE
fix(devlog): switching via project chip in homepage composer logs you out on posting

### DIFF
--- a/app/javascript/controllers/composer_controller.js
+++ b/app/javascript/controllers/composer_controller.js
@@ -117,8 +117,7 @@ export default class extends Controller {
       return;
     }
 
-    // The form uses local:true (non-Turbo), so data-turbo-submits-with won't
-    // fire. Manually swap the button text and disable it to give feedback and
+    // Manually swap the button text and disable it to give feedback and
     // prevent double-clicks.
     if (this.hasSubmitTarget) {
       const label = this.submitTarget.querySelector(".action-btn__label");
@@ -202,7 +201,12 @@ export default class extends Controller {
     chip.classList.add("feed-composer__chip--active");
     chip.setAttribute("aria-current", "true");
 
-    if (this.hasFormTarget) this.formTarget.action = postUrl;
+    if (this.hasFormTarget) {
+      this.formTarget.action = postUrl;
+      const csrfToken = document.querySelector("meta[name='csrf-token']")?.content;
+      const tokenField = this.formTarget.querySelector("input[name='authenticity_token']");
+      if (csrfToken && tokenField) tokenField.value = csrfToken;
+    }
     this.previewTimeUrlValue = previewUrl;
     this.hackatimeLinkedValue = linked;
 


### PR DESCRIPTION
very very important fix. when you click a project chip to switch, the JS now updates the CSRF token along with the form URL