### PR TITLE
fix: removing projects with no banners from recommended projects

### DIFF
--- a/app/models/gorse/project_payload.rb
+++ b/app/models/gorse/project_payload.rb
@@ -15,6 +15,7 @@ class Gorse::ProjectPayload
            .where("LOWER(projects.title) NOT IN (?)", PLACEHOLDER_TITLES)
            .where("LOWER(projects.title) NOT LIKE ?", "untitled%")
            .where("projects.devlogs_count > 0 OR projects.shipped_at IS NOT NULL OR projects.duration_seconds > 0")
+           .joins("INNER JOIN active_storage_attachments asa ON asa.record_id = projects.id AND asa.record_type = 'Project' AND asa.name = 'banner'")
   end
 
   def to_h


### PR DESCRIPTION
## what's this do?

hides projects with no banners from the recommended projects at home

## show it works

1. created 5 banner-having projects and 2 bannerless
2. checked the reommendable scope and the 7 where displayed (the frontend limits to 6)
3. before the change 6 of them where previewed, with one of them has no banner
4. after the change only 5 projects with banners appeared

before

https://github.com/user-attachments/assets/ad1c46f5-5344-44c0-bc52-9a005ae485bb

after

https://github.com/user-attachments/assets/6e9a9009-30ff-403b-944b-ec7a1751ceb0



## ai?

No


closes #274 