### PR TITLE
fix avoid username-availability fetch on profile load

### DIFF
--- a/app/javascript/controllers/username_availability_controller.js
+++ b/app/javascript/controllers/username_availability_controller.js
@@ -14,9 +14,9 @@ export default class extends Controller {
     this.lastQuery = null;
     this.abortController = null;
     this.timer = null;
+    this._initialValue = this.inputTarget.value;
     this._setSubmitDisabled(true);
     this._updateCounter();
-    this.check();
   }
 
   disconnect() {
@@ -27,6 +27,12 @@ export default class extends Controller {
   onInput() {
     if (this.timer) clearTimeout(this.timer);
     this._updateCounter();
+
+    if (this.inputTarget.value === this._initialValue) {
+      this._setState("available", "");
+      return;
+    }
+
     this._setState("checking", "Checking\u2026");
     this.timer = setTimeout(() => this.check(), this.debounceValue);
   }


### PR DESCRIPTION
## what's this do?

stops fetching from username_availability when in /profile
when editing the username, only fetches on input change, if the input matches the initial username, it doesn't fetch

## show it works

before:


https://github.com/user-attachments/assets/7ab309e4-1f30-4566-94a5-38d1a6c8df1e

after:


https://github.com/user-attachments/assets/f87460b4-d062-4b7b-8352-f475682dc97e



## ai?

only for understanding code architecture

closes #273 