### PR TITLE
feat(reviewer): show project AI declaration on ship reviews

### DIFF
--- a/app/assets/stylesheets/pages/certification/ships/_show.scss
+++ b/app/assets/stylesheets/pages/certification/ships/_show.scss
@@ -119,6 +119,12 @@
     overflow-wrap: anywhere;
   }
 
+  &__no-declaration {
+    margin: 0;
+    font-style: italic;
+    color: var(--muted);
+  }
+
   &__links,
   &__meta {
     display: grid;

--- a/app/views/admin/certification/ships/show.html.erb
+++ b/app/views/admin/certification/ships/show.html.erb
@@ -36,6 +36,15 @@
         <% end %>
 
         <div class="ship-review__panel">
+          <h2 class="ship-review__panel-title">AI Declaration</h2>
+          <% if @ship.project.ai_declaration.present? %>
+            <p class="ship-review__description"><%= @ship.project.ai_declaration %></p>
+          <% else %>
+            <p class="ship-review__no-declaration">No AI declaration provided for this project.</p>
+          <% end %>
+        </div>
+
+        <div class="ship-review__panel">
           <h2 class="ship-review__panel-title">Links</h2>
           <dl class="ship-review__links">
             <% if @ship.project.repo_url.present? %>


### PR DESCRIPTION
There weren't any possible way to see if user declared ai or not, so added the ai declaration to the reviewing dash :)


<img width="1645" height="931" alt="image" src="https://github.com/user-attachments/assets/54b90c64-bb74-4619-92a4-1f3be19e9ab3" />
