### PR TITLE
fix(reviewer): claiming/unclaiming for ship review

### DIFF
--- a/app/assets/stylesheets/pages/certification/ships/_show.scss
+++ b/app/assets/stylesheets/pages/certification/ships/_show.scss
@@ -219,7 +219,7 @@
     border: 1px solid rgba(129, 255, 255, 0.2);
     border-radius: 8px;
 
-  &__countdown {
+    &__countdown {
       font-variant-numeric: tabular-nums;
       font-weight: 700;
 

--- a/app/assets/stylesheets/pages/certification/ships/_show.scss
+++ b/app/assets/stylesheets/pages/certification/ships/_show.scss
@@ -305,10 +305,6 @@
       color: var(--color-brand-highlight);
     }
   }
-
-  &__unclaim-form {
-    display: none;
-  }
 }
 
 // Drag-and-drop zone for the verdict walkthrough video.

--- a/app/assets/stylesheets/pages/certification/ships/_show.scss
+++ b/app/assets/stylesheets/pages/certification/ships/_show.scss
@@ -207,6 +207,28 @@
     }
   }
 
+  &__claim-banner {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--space-xs) var(--space-s);
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--color-brand-mint);
+    background: rgba(129, 255, 255, 0.08);
+    border: 1px solid rgba(129, 255, 255, 0.2);
+    border-radius: 8px;
+
+  &__countdown {
+      font-variant-numeric: tabular-nums;
+      font-weight: 700;
+
+      &.is-expired {
+        color: var(--color-brand-salmon);
+      }
+    }
+  }
+
   &__fieldset {
     display: flex;
     flex-direction: column;
@@ -282,6 +304,10 @@
     &:focus-visible {
       color: var(--color-brand-highlight);
     }
+  }
+
+  &__unclaim-form {
+    display: none;
   }
 }
 

--- a/app/controllers/admin/certification/ships/claims_controller.rb
+++ b/app/controllers/admin/certification/ships/claims_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Admin::Certification::Ships::ClaimsController < Admin::Certification::ApplicationController
+  before_action :set_ship
+
+  # POST /admin/certification/ship/:ship_id/claim
+  def create
+    authorize @ship, policy_class: Admin::Certification::Ships::ClaimPolicy
+
+    claimed = ::Certification::Ship.atomic_claim!(@ship.id, current_user)
+    if claimed
+      redirect_to admin_certification_ship_path(claimed)
+    else
+      redirect_to admin_certification_ships_path, alert: "Couldn't claim that review, someone else got it"
+    end
+  end
+
+  # DELETE /admin/certification/ship/:ship_id/claim
+  def destroy
+    authorize @ship, policy_class: Admin::Certification::Ships::ClaimPolicy
+
+    @ship.release_claim!
+    redirect_to admin_certification_ships_path, notice: "Unclaimed review for \u201c#{@ship.project.title}.\u201d"
+  end
+
+  private
+
+  def set_ship
+    @ship = ::Certification::Ship.find(params[:ship_id])
+  end
+end

--- a/app/controllers/admin/certification/ships/claims_controller.rb
+++ b/app/controllers/admin/certification/ships/claims_controller.rb
@@ -7,6 +7,7 @@ class Admin::Certification::Ships::ClaimsController < Admin::Certification::Appl
   def create
     authorize @ship, policy_class: Admin::Certification::Ships::ClaimPolicy
 
+    ::Certification::Ship.release_all_for(current_user)
     claimed = ::Certification::Ship.atomic_claim!(@ship.id, current_user)
     if claimed
       redirect_to admin_certification_ship_path(claimed)

--- a/app/controllers/admin/certification/ships_controller.rb
+++ b/app/controllers/admin/certification/ships_controller.rb
@@ -1,6 +1,6 @@
 class Admin::Certification::ShipsController < Admin::Certification::ApplicationController
-  before_action :release_other_claims, only: [ :next, :claim ]
-  before_action :set_ship, only: [ :show, :update, :claim, :unclaim ]
+  before_action :release_other_claims, only: [ :next ]
+  before_action :set_ship, only: [ :show, :update ]
   before_action :set_body_class, only: [ :index, :show, :update ]
 
   def index
@@ -63,22 +63,6 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
       new_skip = (skip_ids + [ candidate.id ]).uniq
       redirect_to next_admin_certification_ships_path(skip: new_skip.join(","))
     end
-  end
-
-  def claim
-    authorize @ship, :claim?
-    claimed = ::Certification::Ship.atomic_claim!(@ship.id, current_user)
-    if claimed
-      redirect_to admin_certification_ship_path(claimed)
-    else
-      redirect_to admin_certification_ships_path, alert: "Couldn't claim that review — someone else got it."
-    end
-  end
-
-  def unclaim
-    authorize @ship, :unclaim?
-    @ship.release_claim!
-    redirect_to admin_certification_ships_path, notice: "Unclaimed review for “#{@ship.project.title}.”"
   end
 
   private

--- a/app/controllers/admin/certification/ships_controller.rb
+++ b/app/controllers/admin/certification/ships_controller.rb
@@ -34,10 +34,6 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
 
   def show
     authorize @ship
-    if @ship.pending? && @ship.reviewer_id == current_user.id &&
-       @ship.claim_expires_at.present? && @ship.claim_expires_at < Time.current + 5.minutes
-      @ship.update!(claim_expires_at: Time.current + ::Certification::Reviewable::CLAIM_TTL)
-    end
     @reviewed_today = ::Certification::Ship.reviewed_today(current_user)
   end
 

--- a/app/controllers/admin/certification/ships_controller.rb
+++ b/app/controllers/admin/certification/ships_controller.rb
@@ -1,6 +1,6 @@
 class Admin::Certification::ShipsController < Admin::Certification::ApplicationController
   before_action :release_other_claims, only: [ :next, :claim ]
-  before_action :set_ship, only: [ :show, :update, :claim ]
+  before_action :set_ship, only: [ :show, :update, :claim, :unclaim ]
   before_action :set_body_class, only: [ :index, :show, :update ]
 
   def index
@@ -34,6 +34,10 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
 
   def show
     authorize @ship
+    if @ship.pending? && @ship.reviewer_id == current_user.id &&
+       @ship.claim_expires_at.present? && @ship.claim_expires_at < Time.current + 5.minutes
+      @ship.update!(claim_expires_at: Time.current + ::Certification::Reviewable::CLAIM_TTL)
+    end
     @reviewed_today = ::Certification::Ship.reviewed_today(current_user)
   end
 
@@ -73,6 +77,12 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
     else
       redirect_to admin_certification_ships_path, alert: "Couldn't claim that review — someone else got it."
     end
+  end
+
+  def unclaim
+    authorize @ship, :unclaim?
+    @ship.release_claim!
+    redirect_to admin_certification_ships_path, notice: "Unclaimed review for “#{@ship.project.title}.”"
   end
 
   private

--- a/app/javascript/controllers/certification/queue_controller.js
+++ b/app/javascript/controllers/certification/queue_controller.js
@@ -5,9 +5,15 @@ import { Controller } from "@hotwired/stimulus";
 // or date changes, and ticks the per-row claim countdowns.
 export default class extends Controller {
   static targets = ["tab", "panel", "filters", "countdown"];
-  static values = { period: String };
+  static values = { period: String, serverNow: String };
 
   connect() {
+    if (this.hasServerNowValue) {
+      const serverNow = new Date(this.serverNowValue).getTime();
+      this.timeOffset = serverNow - Date.now();
+    } else {
+      this.timeOffset = 0;
+    }
     this.tick();
     this.timer = setInterval(() => this.tick(), 1000);
   }
@@ -33,7 +39,7 @@ export default class extends Controller {
   }
 
   tick() {
-    const now = Date.now();
+    const now = Date.now() + (this.timeOffset || 0);
     this.countdownTargets.forEach((el) => {
       const target = new Date(el.dataset.expiresAt).getTime();
       const remaining = Math.max(0, Math.floor((target - now) / 1000));

--- a/app/models/concerns/certification/reviewable.rb
+++ b/app/models/concerns/certification/reviewable.rb
@@ -38,7 +38,10 @@ module Certification
 
     def release_claim!
       return unless pending? && reviewer_id.present?
-      update!(reviewer_id: nil, claim_expires_at: nil)
+
+      self.class
+        .where(id: id, status: self.class.statuses[:pending])
+        .update_all(reviewer_id: nil, claim_expires_at: nil, updated_at: Time.current)
     end
 
     def claim_held_by?(user)

--- a/app/models/concerns/certification/reviewable.rb
+++ b/app/models/concerns/certification/reviewable.rb
@@ -2,7 +2,7 @@ module Certification
   module Reviewable
     extend ActiveSupport::Concern
 
-    CLAIM_TTL = 5.minutes
+    CLAIM_TTL = 30.minutes
 
     class_methods do
       def available_for(user)
@@ -38,7 +38,7 @@ module Certification
 
     def release_claim!
       return unless pending? && reviewer_id.present?
-      update_columns(reviewer_id: nil, claim_expires_at: nil, updated_at: Time.current)
+      update!(reviewer_id: nil, claim_expires_at: nil)
     end
 
     def claim_held_by?(user)

--- a/app/policies/admin/certification/ship_policy.rb
+++ b/app/policies/admin/certification/ship_policy.rb
@@ -12,13 +12,6 @@ class Admin::Certification::ShipPolicy < ApplicationPolicy
 
   def next? = user&.can_review?
 
-  def claim? = user&.can_review? && not_own_project?
-
-  def unclaim?
-    return false unless user&.can_review? && not_own_project?
-    record.claim_held_by?(user) || (record.reviewer_id == user.id && record.claim_expired?)
-  end
-
   class Scope < ApplicationPolicy::Scope
     def resolve
       return scope.none unless user&.can_review?

--- a/app/policies/admin/certification/ship_policy.rb
+++ b/app/policies/admin/certification/ship_policy.rb
@@ -7,12 +7,17 @@ class Admin::Certification::ShipPolicy < ApplicationPolicy
 
   def update?
     return false unless user&.can_review? && not_own_project?
-    record.claim_held_by?(user)
+    record.claim_held_by?(user) || (record.reviewer_id == user.id && record.claim_expired?)
   end
 
   def next? = user&.can_review?
 
   def claim? = user&.can_review? && not_own_project?
+
+  def unclaim?
+    return false unless user&.can_review? && not_own_project?
+    record.claim_held_by?(user) || (record.reviewer_id == user.id && record.claim_expired?)
+  end
 
   class Scope < ApplicationPolicy::Scope
     def resolve

--- a/app/policies/admin/certification/ships/claim_policy.rb
+++ b/app/policies/admin/certification/ships/claim_policy.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# create? → reviewer can claim the ship
+# destroy? → reviewer can unclaim the ship
+class Admin::Certification::Ships::ClaimPolicy < ApplicationPolicy
+  def create?
+    user&.can_review? && not_own_project?
+  end
+
+  def destroy?
+    return false unless user&.can_review? && not_own_project?
+
+    record.claim_held_by?(user) || (record.reviewer_id == user.id && record.claim_expired?)
+  end
+
+  private
+
+  def not_own_project?
+    return true unless record.respond_to?(:project_id)
+
+    !user.memberships.where(project_id: record.project_id).exists?
+  end
+end

--- a/app/views/admin/certification/ships/_form.html.erb
+++ b/app/views/admin/certification/ships/_form.html.erb
@@ -88,4 +88,3 @@
     <%= link_to "Back to queue", admin_certification_ships_path, class: "review-form__back" %>
   </div>
 <% end %>
-

--- a/app/views/admin/certification/ships/_form.html.erb
+++ b/app/views/admin/certification/ships/_form.html.erb
@@ -1,13 +1,13 @@
 <%# Unclaim form is rendered outside the verdict form to avoid invalid nesting.
     The button inside the verdict form references it via the HTML `form` attribute. %>
-<%= form_with url: unclaim_admin_certification_ship_path(ship), method: :post,
-      id: "unclaim-form-#{ship.id}", class: "review-form__unclaim-form" do %>
+<%= form_with url: admin_certification_ship_claim_path(ship), method: :delete,
+      id: "unclaim-form-#{ship.id}" do %>
 <% end %>
 
 <%= form_with model: ship, url: admin_certification_ship_path(ship), method: :patch, class: "review-form" do |f| %>
 <% if ship.claim_expires_at.present? %>
   <div class="review-form__claim-banner">
-    <span><%= ship.claim_expired? ? "Claim expired" : "Claim active" %></span>
+    <span>Claim active</span>
     <span class="review-form__countdown"
           data-certification--queue-target="countdown"
           data-expires-at="<%= ship.claim_expires_at.iso8601 %>"></span>

--- a/app/views/admin/certification/ships/_form.html.erb
+++ b/app/views/admin/certification/ships/_form.html.erb
@@ -1,4 +1,18 @@
+<%# Unclaim form is rendered outside the verdict form to avoid invalid nesting.
+    The button inside the verdict form references it via the HTML `form` attribute. %>
+<%= form_with url: unclaim_admin_certification_ship_path(ship), method: :post,
+      id: "unclaim-form-#{ship.id}", class: "review-form__unclaim-form" do %>
+<% end %>
+
 <%= form_with model: ship, url: admin_certification_ship_path(ship), method: :patch, class: "review-form" do |f| %>
+<% if ship.claim_expires_at.present? %>
+  <div class="review-form__claim-banner">
+    <span><%= ship.claim_expired? ? "Claim expired" : "Claim active" %></span>
+    <span class="review-form__countdown"
+          data-certification--queue-target="countdown"
+          data-expires-at="<%= ship.claim_expires_at.iso8601 %>"></span>
+  </div>
+<% end %>
   <% if ship.errors.any? %>
     <div class="review-form__errors">
       <ul>
@@ -67,6 +81,11 @@
     <%= f.submit "Submit verdict", class: "action-btn action-btn--large action-btn--primary" %>
     <%= link_to "Skip and get next", next_admin_certification_ships_path(skip: ship.id),
           class: "action-btn action-btn--small action-btn--secondary" %>
+    <button type="submit" form="unclaim-form-<%= ship.id %>"
+            class="action-btn action-btn--small action-btn--destructive">
+      Unclaim review
+    </button>
     <%= link_to "Back to queue", admin_certification_ships_path, class: "review-form__back" %>
   </div>
 <% end %>
+

--- a/app/views/admin/certification/ships/show.html.erb
+++ b/app/views/admin/certification/ships/show.html.erb
@@ -2,7 +2,7 @@
 
 <%
   owner = @ship.project.memberships.find(&:owner?)&.user
-  can_review = @ship.reviewer_id == current_user.id && @ship.pending?
+  can_review = @ship.claim_held_by?(current_user) && @ship.pending?
 %>
 
 <div class="app-layout app-layout--wide"
@@ -78,7 +78,7 @@
         <% else %>
           <div class="ship-review__claim">
             <p>You don't currently hold the claim on this review.</p>
-            <%= button_to "Claim this review", claim_admin_certification_ship_path(@ship), method: :post,
+            <%= button_to "Claim this review", admin_certification_ship_claim_path(@ship), method: :post,
                   class: "action-btn action-btn--large action-btn--primary" %>
             <%= link_to "Back to queue", admin_certification_ships_path,
                   class: "action-btn action-btn--small action-btn--secondary" %>

--- a/app/views/admin/certification/ships/show.html.erb
+++ b/app/views/admin/certification/ships/show.html.erb
@@ -2,10 +2,12 @@
 
 <%
   owner = @ship.project.memberships.find(&:owner?)&.user
-  can_review = @ship.reviewer_id == current_user.id && !@ship.claim_expired?
+  can_review = @ship.reviewer_id == current_user.id && @ship.pending?
 %>
 
-<div class="app-layout app-layout--wide">
+<div class="app-layout app-layout--wide"
+     data-controller="certification--queue"
+     data-certification--queue-server-now-value="<%= Time.current.iso8601 %>">
   <div class="app-layout__main app-layout__main--wide ship-review">
     <%= link_to "← back to queue", admin_certification_ships_path, class: "ship-review__back" %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -694,9 +694,8 @@ Rails.application.routes.draw do
         collection do
           get :next
         end
-        member do
-          post :claim
-          post :unclaim
+        scope module: :ships do
+          resource :claim, only: [ :create, :destroy ]
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -696,6 +696,7 @@ Rails.application.routes.draw do
         end
         member do
           post :claim
+          post :unclaim
         end
       end
 


### PR DESCRIPTION
## what's this do?
Adds a way to unclaim your review, fixed the claim functionality as it was resetting the TTL on every page load which was very buggy and might be confusing to shipwrights, it's now a hard 30-minute lock from when you claimed it :)
Note: The UI is will have a rework. It is currently unpolished as it is not a priority for now 

## show it works
<img width="459" height="800" alt="image" src="https://github.com/user-attachments/assets/73704b3e-8405-484b-a72e-e111a5478ab9" />

## ai?
Claude