### PR TITLE
Make entire link project dropdown box clickable

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -148,10 +148,11 @@
                 <% else %>
                   <div data-controller="hackatime-link">
                     <div class="project-show__hackatime-picker">
-                      <div class="project-show__hackatime-box" data-hackatime-link-target="box">
-                        <button type="button" class="project-show__hackatime-add" data-action="hackatime-link#toggle" data-hackatime-link-target="addBtn" aria-label="Add Hackatime project">
+                    <!-- data-hackatime-link-target="box" -->
+                      <div class="project-show__hackatime-box" role="button" tabindex="0" aria-pressed="false" data-contoller="addBtn" data-action="click->hackatime-link#toggle keydown.enter->hackatime-link#toggle">
+                        <div  class="project-show__hackatime-add" aria-label="Add Hackatime project">
                           <%= inline_svg_tag "icons/plus.svg", class: "project-show__hackatime-add-icon" %>
-                        </button>
+                        </div>
                         <div class="project-show__hackatime-tags" data-hackatime-link-target="tags">
                           <span class="project-show__hackatime-placeholder"
                                 data-hackatime-link-target="placeholder"

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -148,7 +148,6 @@
                 <% else %>
                   <div data-controller="hackatime-link">
                     <div class="project-show__hackatime-picker">
-                    <!-- data-hackatime-link-target="box" -->
                       <div class="project-show__hackatime-box" role="button" tabindex="0" aria-pressed="false" data-contoller="addBtn" data-action="click->hackatime-link#toggle keydown.enter->hackatime-link#toggle">
                         <div  class="project-show__hackatime-add" aria-label="Add Hackatime project">
                           <%= inline_svg_tag "icons/plus.svg", class: "project-show__hackatime-add-icon" %>


### PR DESCRIPTION
## what's this do?

Before, only the small plus button could be pressed. Now, the entire box can be pressed

## show it works


https://github.com/user-attachments/assets/0a850f30-c5c4-4128-a865-ae346d9adbfe


## ai?

nope