### PR TITLE
fix(missions): attach error

### DIFF
--- a/app/controllers/projects/setup_controller.rb
+++ b/app/controllers/projects/setup_controller.rb
@@ -90,6 +90,9 @@ class Projects::SetupController < ApplicationController
 
     is_first_attach = existing.nil?
 
+    # Detach any active mission that isn't the one being selected.
+    project.mission_attachments.active.where.not(mission_id: mission.id).find_each(&:detach!)
+
     if existing
       existing.update!(detached_at: nil, attached_at: Time.current)
     else


### PR DESCRIPTION

## what's this do?
Basically you could attach to a mission while being attached to one, which violated active record validation. This pr makes it so it deattaches prev and then you can select one.
[sentry error](https://hack-club.sentry.io/issues/7518120736/?project=4511484628500480&query=is%3Aunresolved&referrer=issue-stream)
## ai?
claude