### PR TITLE
fix: dont let unauth access to /shop/orders

### DIFF
--- a/app/policies/shop_policy.rb
+++ b/app/policies/shop_policy.rb
@@ -1,6 +1,6 @@
 class ShopPolicy < ApplicationPolicy
   def index?
-    true
+    signed_in_any?
   end
 
   def show?


### PR DESCRIPTION
## what's this do?

fixes shop policy to make sure only signed in people can access `/shop/orders`
[sentry err](https://hack-club.sentry.io/issues/7521995112/?project=4511484628500480&query=is%3Aunresolved&referrer=issue-stream)
## ai?
claude