### PR TITLE
Update user project design to use grid

### DIFF
--- a/app/assets/stylesheets/pages/user/_show.scss
+++ b/app/assets/stylesheets/pages/user/_show.scss
@@ -775,7 +775,7 @@ turbo-frame#profile_tabs {
 .profile-project-card {
   display: flex;
   flex-direction: column;
-  height:100%;
+  height: 100%;
   gap: var(--space-m);
   background: var(--color-set-2-bg);
   // Use box-shadow as a fake border so the banner image can extend over it
@@ -880,7 +880,7 @@ turbo-frame#profile_tabs {
 
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  overflow:hidden;
+  overflow: hidden;
   line-clamp: 4;
   -webkit-line-clamp: 4;
 }
@@ -999,7 +999,7 @@ turbo-frame#profile_tabs {
   }
 
   .project-list {
-  	grid-template-columns: 1fr;
+    grid-template-columns: 1fr;
   }
 }
 

--- a/app/assets/stylesheets/pages/user/_show.scss
+++ b/app/assets/stylesheets/pages/user/_show.scss
@@ -760,8 +760,8 @@ turbo-frame#profile_tabs {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
   gap: var(--space-l);
 }
 
@@ -774,8 +774,9 @@ turbo-frame#profile_tabs {
 // radius shared by every container.
 .profile-project-card {
   display: flex;
+  flex-direction: column;
+  height:100%;
   gap: var(--space-m);
-  padding-right: var(--space-m);
   background: var(--color-set-2-bg);
   // Use box-shadow as a fake border so the banner image can extend over it
   // without being clipped by border-radius.
@@ -792,7 +793,7 @@ turbo-frame#profile_tabs {
 }
 
 .profile-project-card__banner {
-  width: 180px;
+  width: 100%;
   flex-shrink: 0;
   align-self: stretch;
   background: var(--color-overlay-light-soft);
@@ -800,7 +801,7 @@ turbo-frame#profile_tabs {
   // Inherit the parent card's left-side rounding so the image's corners
   // visually overlap the card's box-shadow border.
   border-top-left-radius: var(--profile-radius);
-  border-bottom-left-radius: var(--profile-radius);
+  border-top-right-radius: var(--profile-radius);
 }
 
 .profile-project-card__banner-img {
@@ -808,15 +809,15 @@ turbo-frame#profile_tabs {
   height: 100%;
   object-fit: cover;
   display: block;
+  aspect-ratio: 3;
 }
 
 .profile-project-card__body {
   flex: 1;
   min-width: 0;
-  padding: var(--space-m) 0;
+  padding: 0 var(--space-m) var(--space-m) var(--space-m);
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
   gap: var(--space-m);
 }
 
@@ -876,6 +877,12 @@ turbo-frame#profile_tabs {
   margin: 0;
   font-size: var(--font-size-l);
   line-height: 1.3;
+
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow:hidden;
+  line-clamp: 4;
+  -webkit-line-clamp: 4;
 }
 
 .profile-project-card__updated {
@@ -928,6 +935,7 @@ turbo-frame#profile_tabs {
   box-shadow: none;
   border: 2px dashed var(--color-space-border);
   justify-content: center;
+  align-items: center;
   padding: var(--space-m);
   font-size: var(--font-size-m);
   opacity: 0.7;
@@ -988,6 +996,10 @@ turbo-frame#profile_tabs {
 
   .profile-project-card__body {
     padding: 0 var(--space-m) var(--space-m);
+  }
+
+  .project-list {
+  	grid-template-columns: 1fr;
   }
 }
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -269,7 +269,7 @@
         <% if own_profile %>
           <li class="project-list__item">
             <%= link_to new_project_path, class: "profile-project-card profile-project-card--new" do %>
-              <span>Create a new Project</span>
+              <span>+ Create a new Project</span>
             <% end %>
           </li>
         <% end %>


### PR DESCRIPTION
## what's this do?

Updates the design of the /@username/projects page
It is now a grid, with cards being vertical.
I did this so banners could have a consistent aspect ratio.

## show it works

### Before:

Banners have inconsistent heights causing them to be display differently with different length descriptions

<img height="500" alt="image" src="https://github.com/user-attachments/assets/c7740b8d-a236-4048-8167-94ad414f9f38" />

### After:

Larger screens are shown a grid where the card layout is vertical, the image is full width and has a fixed aspect ratio of 3

<img height="500" alt="image" src="https://github.com/user-attachments/assets/c81ea18d-e4d7-4b57-a563-6b87e46e9c1a" />

The layout is also responsive, hasn't changed much from the original design.

<img height="500" alt="image" src="https://github.com/user-attachments/assets/306835ec-32de-49f3-8095-8b7d0cae5d97" />

## ai?

No AI used
