### PR TITLE
fix(shop): user is nil error for certain shop pages that didn't gate for signin

### DIFF
--- a/app/components/shop_item_card_component.rb
+++ b/app/components/shop_item_card_component.rb
@@ -73,7 +73,7 @@ class ShopItemCardComponent < ViewComponent::Base
   end
 
   def order_url
-    logged_in ? helpers.shop_item_path(item_id) : "/"
+    helpers.shop_item_path(item_id)
   end
 
   def display_price

--- a/app/policies/shop_policy.rb
+++ b/app/policies/shop_policy.rb
@@ -1,6 +1,6 @@
 class ShopPolicy < ApplicationPolicy
   def index?
-    true
+    signed_in_any?
   end
 
   def show?

--- a/app/views/shop/items/show.html.erb
+++ b/app/views/shop/items/show.html.erb
@@ -74,6 +74,7 @@
              <% end %>
             <div class="shop-order__customs-warning" data-customs-warning-target="warning" style="display: none;"></div>
         </div>
+        <% if current_user %>
         <div class="shop-order__details" data-controller="order-form" data-order-form-has-addresses-value="<%= current_user.addresses.any? %>" data-order-form-base-ticket-cost-value="<%= @sale_price || @shop_item.ticket_cost || 0 %>" data-order-form-user-balance-value="<%= current_user.balance || 0 %>" data-order-form-addresses-value="<%= current_user.addresses.to_json %>" data-order-form-blocked-countries-value="<%= @shop_item.blocked_countries.to_json %>" data-order-form-stardust-icon-url-value="<%= image_path('icons/stardust.png') %>" data-action="address-select:change@document->order-form#addressChanged">
             <h2>Complete your order:</h2>
             <%= form_with url: shop_orders_path(shop_item_id: @shop_item.id), method: :post, local: true, id: "order-form" do |form| %>
@@ -325,5 +326,17 @@
                   data: { "order-form-target": "submitButton" }
                 ) %>
         </div>
+        <% else %>
+        <div class="shop-order__details">
+            <h2>Sign in to order</h2>
+            <p>You need to be signed in to place an order.</p>
+            <%= render ActionButtonComponent.new(
+                text: "Sign in with Hack Club",
+                href: "/auth/hack_club",
+                size: :large,
+                variant: :primary
+            ) %>
+        </div>
+        <% end %>
     </div>
 </div>

--- a/app/views/shop/items/show.html.erb
+++ b/app/views/shop/items/show.html.erb
@@ -330,12 +330,6 @@
         <div class="shop-order__details">
             <h2>Sign in to order</h2>
             <p>You need to be signed in to place an order.</p>
-            <%= render ActionButtonComponent.new(
-                text: "Sign in with Hack Club",
-                href: "/auth/hack_club",
-                size: :large,
-                variant: :primary
-            ) %>
         </div>
         <% end %>
     </div>


### PR DESCRIPTION
## what's this do?

previously the shop was bad at handling nil users so it was throwing a bunch of errors. this helps by just extending the non-signed-in policy to shop show pages as well.

## show it works

<img width="2224" height="1348" alt="image" src="https://github.com/user-attachments/assets/738f2070-0889-41b7-bbf9-942026e59b9c" />

## ai?

all of it
