### PR TITLE
fix(onboarding): initial username check

### DIFF
--- a/app/javascript/controllers/username_availability_controller.js
+++ b/app/javascript/controllers/username_availability_controller.js
@@ -8,15 +8,19 @@ export default class extends Controller {
     url: String,
     debounce: { type: Number, default: 350 },
     max: { type: Number, default: 30 },
+    checkOnConnect: { type: Boolean, default: false },
   };
 
   connect() {
     this.lastQuery = null;
     this.abortController = null;
     this.timer = null;
-    this._initialValue = this.inputTarget.value;
+    this._initialValue = this.checkOnConnectValue ? null : this.inputTarget.value;
     this._setSubmitDisabled(true);
     this._updateCounter();
+    if (this.checkOnConnectValue && this.inputTarget.value.trim() !== "") {
+      this.check();
+    }
   }
 
   disconnect() {

--- a/app/javascript/controllers/username_availability_controller.js
+++ b/app/javascript/controllers/username_availability_controller.js
@@ -15,7 +15,9 @@ export default class extends Controller {
     this.lastQuery = null;
     this.abortController = null;
     this.timer = null;
-    this._initialValue = this.checkOnConnectValue ? null : this.inputTarget.value;
+    this._initialValue = this.checkOnConnectValue
+      ? null
+      : this.inputTarget.value;
     this._setSubmitDisabled(true);
     this._updateCounter();
     if (this.checkOnConnectValue && this.inputTarget.value.trim() !== "") {

--- a/app/views/onboarding/wizard/name.html.erb
+++ b/app/views/onboarding/wizard/name.html.erb
@@ -12,7 +12,8 @@
                    data: {
                      controller: "username-availability",
                      username_availability_url_value: username_availability_path,
-                     username_availability_max_value: User::MAX_DISPLAY_NAME_LENGTH
+                     username_availability_max_value: User::MAX_DISPLAY_NAME_LENGTH,
+                     username_availability_check_on_connect_value: true
                    } do |f| %>
       <% max_len = User::MAX_DISPLAY_NAME_LENGTH %>
       <div class="onboarding-name__field">


### PR DESCRIPTION
reverts a portion of #299 that broke username checking on initial onboarding.

original:
<img width="868" height="336" alt="image" src="https://github.com/user-attachments/assets/8110bb6e-41d7-4987-aab7-444757d88658" />
would treat the generated username as a default and not check it, making button disabled.

fixed:

<img width="810" height="342" alt="image" src="https://github.com/user-attachments/assets/c0e4bc6a-e6fd-426d-822c-a348c28df628" />
