### PR TITLE
fix(ahoy): add job to backfill ahoy event creation

### DIFF
--- a/app/jobs/ahoy_backfill_project_created_job.rb
+++ b/app/jobs/ahoy_backfill_project_created_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AhoyBackfillProjectCreatedJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    result = ActiveRecord::Base.connection.execute(<<~SQL)
+      INSERT INTO ahoy_events (name, user_id, time, properties)
+      SELECT 'project_created', pm.user_id, MIN(pm.created_at), '{"source":"backfill"}'::jsonb
+      FROM project_memberships pm
+      WHERE NOT EXISTS (
+        SELECT 1 FROM ahoy_events ae
+        WHERE ae.user_id = pm.user_id AND ae.name = 'project_created'
+      )
+      GROUP BY pm.user_id
+    SQL
+
+    Rails.logger.info("[AhoyBackfillProjectCreated] backfilled #{result.cmd_tuples} events")
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -140,3 +140,9 @@ production:
     schedule: every day at 4am America/New_York
     concurrency: 1
     description: "Hard-delete guest users (no HCA identity) older than 30 days"
+
+  ahoy_backfill_project_created_ahoy_events:
+    class: AhoyBackfillProjectCreatedJob
+    schedule: every day at 5am America/New_York
+    concurrency: 1
+    description: "Backfill missing ahoy events from DB tables for funnel tracking"


### PR DESCRIPTION
this backfills the missing events from https://github.com/hackclub/stardance/pull/347, it's recurring but i anticipate this can be reverted after a day or two once we confirm things are working again