### PR TITLE
fix(missions): make the mission picker modal show + buttons aligned right

### DIFF
--- a/app/assets/stylesheets/pages/missions/_show.scss
+++ b/app/assets/stylesheets/pages/missions/_show.scss
@@ -223,8 +223,13 @@
 .mission-home__hero-actions {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 18px;
   flex-wrap: wrap;
+
+  &--spread {
+    justify-content: space-between;
+    gap: 0;
+  }
 }
 
 .mission-home__cta-form {

--- a/app/assets/stylesheets/pages/projects/_show.scss
+++ b/app/assets/stylesheets/pages/projects/_show.scss
@@ -1869,3 +1869,12 @@ turbo-frame#project_hero {
   flex-shrink: 0;
   gap: 6px;
 }
+
+.mission-browse-modal__empty {
+  color: var(--color-space-text-muted, var(--color-space-text));
+  font-size: var(--font-size-m);
+  line-height: 1.5;
+  margin: 0;
+  text-align: center;
+  padding: var(--space-l) 0;
+}

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -99,19 +99,21 @@ class ProjectsController < ApplicationController
     @show_project_onboarding = @is_member && @posts.empty?
     @project_onboarding_mission = @project.current_mission
 
-    if @is_member && @project.current_mission.nil? && !@project.shipped?
+    @available_missions = if @is_member && @project.current_mission.nil? && !@project.shipped?
       taken_mission_ids = current_user.projects
                                       .where(deleted_at: nil)
                                       .joins(:mission_attachments)
                                       .where(project_mission_attachments: { detached_at: nil, deleted_at: nil })
                                       .pluck("project_mission_attachments.mission_id")
                                       .uniq
-      @available_missions = Mission.available
-                                   .where.not(id: taken_mission_ids)
-                                   .with_attached_icon
-                                   .order(featured_at: :desc)
-                                   .limit(12)
-                                   .to_a
+      Mission.available
+             .where.not(id: taken_mission_ids)
+             .with_attached_icon
+             .order(featured_at: :desc)
+             .limit(12)
+             .to_a
+    else
+      []
     end
 
     @show_project_tour = params[:welcome] == "1" && current_user.present? && @is_member &&

--- a/app/views/missions/show.html.erb
+++ b/app/views/missions/show.html.erb
@@ -75,7 +75,8 @@
           </p>
         <% end %>
 
-        <div class="mission-home__hero-actions">
+        <% has_three_actions = !@active_project && @attachable_projects&.any? && @mission.has_guide? %>
+        <div class="mission-home__hero-actions<%= " mission-home__hero-actions--spread" if has_three_actions %>">
           <% if @active_project %>
             <%= link_to "View my project",
                         project_path(@active_project),

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -840,50 +840,56 @@
     </dialog>
   <% end %>
 
-  <% if @is_member && @available_missions&.any? %>
+  <% if @is_member && @project.current_mission.nil? && !@project.shipped? %>
     <%= render layout: "shared/modal", locals: { id: "mission-browse-modal", title: "Browse missions", class_name: "mission-browse-modal" } do %>
-      <ul class="mission-browse-modal__grid">
-        <% @available_missions.each do |mission| %>
-          <li class="mission-browse-modal__card">
-            <div class="mission-browse-modal__card-icon">
-              <% if mission.icon.attached? %>
-                <%= image_tag mission.icon, alt: "", class: "mission-browse-modal__card-icon-img" %>
-              <% else %>
-                <span class="mission-browse-modal__card-icon-fallback" aria-hidden="true">&#10022;</span>
-              <% end %>
-            </div>
-
-            <div class="mission-browse-modal__card-body">
-              <h3 class="mission-browse-modal__card-title"><%= mission.name %></h3>
-              <p class="mission-browse-modal__card-desc"><%= truncate(mission.description.to_s, length: 120) %></p>
-
-              <ul class="mission-browse-modal__card-meta">
-                <% if mission.difficulty.present? %>
-                  <li class="mission-browse-modal__card-chip mission-browse-modal__card-chip--<%= mission.difficulty %>">
-                    <%= mission.difficulty.titleize %>
-                  </li>
+      <% if @available_missions.any? %>
+        <ul class="mission-browse-modal__grid">
+          <% @available_missions.each do |mission| %>
+            <li class="mission-browse-modal__card">
+              <div class="mission-browse-modal__card-icon">
+                <% if mission.icon.attached? %>
+                  <%= image_tag mission.icon, alt: "", class: "mission-browse-modal__card-icon-img" %>
+                <% else %>
+                  <span class="mission-browse-modal__card-icon-fallback" aria-hidden="true">&#10022;</span>
                 <% end %>
-                <% if mission.steps_count > 0 %>
-                  <li class="mission-browse-modal__card-chip"><%= mission.steps_count %>-step guide</li>
-                <% end %>
-              </ul>
-            </div>
+              </div>
 
-            <div class="mission-browse-modal__card-actions">
-              <%= link_to "Learn more",
-                          mission_path(mission.slug),
-                          class: "action-btn action-btn--small action-btn--secondary",
-                          data: { turbo: false } %>
-              <%= button_to "Attach",
-                            project_mission_path(@project),
-                            method: :post,
-                            params: { mission_slug: mission.slug },
-                            data: { turbo: false },
-                            class: "action-btn action-btn--small action-btn--primary" %>
-            </div>
-          </li>
-        <% end %>
-      </ul>
+              <div class="mission-browse-modal__card-body">
+                <h3 class="mission-browse-modal__card-title"><%= mission.name %></h3>
+                <p class="mission-browse-modal__card-desc"><%= truncate(mission.description.to_s, length: 120) %></p>
+
+                <ul class="mission-browse-modal__card-meta">
+                  <% if mission.difficulty.present? %>
+                    <li class="mission-browse-modal__card-chip mission-browse-modal__card-chip--<%= mission.difficulty %>">
+                      <%= mission.difficulty.titleize %>
+                    </li>
+                  <% end %>
+                  <% if mission.steps_count > 0 %>
+                    <li class="mission-browse-modal__card-chip"><%= mission.steps_count %>-step guide</li>
+                  <% end %>
+                </ul>
+              </div>
+
+              <div class="mission-browse-modal__card-actions">
+                <%= link_to "Learn more",
+                            mission_path(mission.slug),
+                            class: "action-btn action-btn--small action-btn--secondary",
+                            data: { turbo: false } %>
+                <%= button_to "Attach",
+                              project_mission_path(@project),
+                              method: :post,
+                              params: { mission_slug: mission.slug },
+                              data: { turbo: false },
+                              class: "action-btn action-btn--small action-btn--primary" %>
+              </div>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="mission-browse-modal__empty">
+          You're already on a mission for every available challenge — nice! Check back later for new missions.
+        </p>
+      <% end %>
     <% end %>
   <% end %>
 


### PR DESCRIPTION
## what's this do?

previously when there were no missions available the button would just do nothing. Now it shows a helpful no missions left message
also the change to make the tree buttons render right in the mission show page looked weird for 2 buttons so I changed it so that it only does it for 3 buttons.