### PR TITLE
chore(dev): fix procfile default to work with dev instructions

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: bin/rails server -b 0.0.0.0 -p 3000
+web: bin/rails server -b 0.0.0.0 -p $PORT
 css: bin/rails dartsass:watch
-js: yarn build --watch
+js: yarn build --watch=forever


### PR DESCRIPTION
this fixes the dev setup to spin up in non-interactive terminals + take in a port env