### PR TITLE
Show completed Shipwright verdict history

### DIFF
--- a/app/assets/stylesheets/pages/certification/ships/_show.scss
+++ b/app/assets/stylesheets/pages/certification/ships/_show.scss
@@ -185,7 +185,8 @@
     overflow-wrap: anywhere;
   }
 
-  &__claim {
+  &__claim,
+  &__complete-actions {
     display: flex;
     flex-direction: column;
     gap: var(--space-s);
@@ -199,6 +200,114 @@
       margin: 0;
       color: var(--muted);
     }
+  }
+
+  &__verdict-history {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-m);
+    padding: var(--space-l);
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 12px;
+  }
+
+  &__verdict-history-kicker {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  &__verdict-history-title {
+    margin: calc(var(--space-xs) * -1) 0 0;
+    font-size: 1.4rem;
+    line-height: var(--line-height-headers);
+  }
+
+  &__verdict-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-m);
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  &__verdict-item {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-s);
+    padding-top: var(--space-m);
+    border-top: 1px solid var(--card-border);
+  }
+
+  &__verdict-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--space-s);
+    width: 100%;
+    color: var(--muted);
+    font-size: 0.85rem;
+  }
+
+  &__verdict-meta {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: var(--space-xs) var(--space-s);
+    width: 100%;
+    margin: 0;
+
+    dt {
+      color: var(--muted);
+      font-size: 0.85rem;
+    }
+
+    dd {
+      margin: 0;
+      color: var(--color-space-text);
+      font-weight: 700;
+      overflow-wrap: anywhere;
+    }
+  }
+
+  &__verdict-feedback,
+  &__verdict-video {
+    width: 100%;
+
+    h3 {
+      margin: 0 0 var(--space-xs);
+      color: var(--color-brand-blue);
+      font-size: 0.9rem;
+    }
+  }
+
+  &__verdict-feedback-body {
+    color: var(--color-space-text);
+    font-size: 0.95rem;
+    line-height: var(--line-height-body);
+    overflow-wrap: anywhere;
+
+    p {
+      margin: 0;
+    }
+
+    p + p {
+      margin-top: var(--space-xs);
+    }
+  }
+
+  &__verdict-video-link {
+    color: var(--color-space-text);
+    font-weight: 700;
+    text-decoration: underline;
+    text-underline-offset: 3px;
   }
 }
 

--- a/app/controllers/admin/certification/ships_controller.rb
+++ b/app/controllers/admin/certification/ships_controller.rb
@@ -34,7 +34,7 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
 
   def show
     authorize @ship
-    @reviewed_today = ::Certification::Ship.reviewed_today(current_user)
+    load_review_context
   end
 
   def update
@@ -45,6 +45,7 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
       redirect_to next_admin_certification_ships_path,
                   notice: "#{verb} “#{@ship.project.title}.” That's #{count} reviewed today. Keep going!"
     else
+      load_review_context
       render :show, status: :unprocessable_entity
     end
   end
@@ -79,6 +80,17 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
 
   def release_other_claims
     ::Certification::Ship.release_all_for(current_user) if current_user.present?
+  end
+
+  def load_review_context
+    @reviewed_today = ::Certification::Ship.reviewed_today(current_user)
+    @verdict_history = @ship.project.ship_reviews
+                            .where.not(status: :pending)
+                            .includes(:reviewer, verdict_video_attachment: :blob)
+                            .order(
+                              Arel.sql("COALESCE(certification_ship_reviews.decided_at, certification_ship_reviews.updated_at) DESC"),
+                              id: :desc
+                            )
   end
 
   def parse_skip_ids

--- a/app/views/admin/certification/ships/show.html.erb
+++ b/app/views/admin/certification/ships/show.html.erb
@@ -91,13 +91,69 @@
       </section>
 
       <aside class="ship-review__sidebar">
+        <% if @verdict_history.any? %>
+          <section class="ship-review__verdict-history" aria-labelledby="ship-review-verdict-history-title">
+            <p class="ship-review__verdict-history-kicker">Verdict history</p>
+            <h2 class="ship-review__verdict-history-title" id="ship-review-verdict-history-title">Past verdicts</h2>
+
+            <ol class="ship-review__verdict-list">
+              <% @verdict_history.each do |verdict| %>
+                <% reviewed_at = verdict.decided_at || verdict.updated_at %>
+                <li class="ship-review__verdict-item ship-review__verdict-item--<%= verdict.status %>">
+                  <div class="ship-review__verdict-head">
+                    <span class="status-pill status-pill--<%= verdict.status %>"><%= verdict.status.capitalize %></span>
+                    <% if reviewed_at.present? %>
+                      <time datetime="<%= reviewed_at.iso8601 %>" title="<%= l(reviewed_at, format: :long) %>">
+                        <%= time_ago_in_words(reviewed_at) %> ago
+                      </time>
+                    <% end %>
+                  </div>
+
+                  <dl class="ship-review__verdict-meta">
+                    <dt>Reviewed by</dt>
+                    <dd><%= verdict.reviewer&.display_name || "—" %></dd>
+                  </dl>
+
+                  <% if verdict.feedback.present? %>
+                    <section class="ship-review__verdict-feedback" aria-label="Feedback">
+                      <h3>Feedback</h3>
+                      <div class="ship-review__verdict-feedback-body">
+                        <%= simple_format(verdict.feedback, {}, sanitize: true) %>
+                      </div>
+                    </section>
+                  <% end %>
+
+                  <% if verdict.verdict_video.attached? %>
+                    <section class="ship-review__verdict-video" aria-label="Review video">
+                      <h3>Review video</h3>
+                      <%= link_to verdict.verdict_video.filename,
+                            verdict.verdict_video,
+                            target: "_blank",
+                            rel: "noopener",
+                            class: "ship-review__verdict-video-link" %>
+                    </section>
+                  <% end %>
+                </li>
+              <% end %>
+            </ol>
+          </section>
+        <% end %>
+
         <% if can_review %>
           <%= render "form", ship: @ship %>
-        <% else %>
+        <% elsif @ship.pending? %>
           <div class="ship-review__claim">
             <p>You don't currently hold the claim on this review.</p>
             <%= button_to "Claim this review", admin_certification_ship_claim_path(@ship), method: :post,
                   class: "action-btn action-btn--large action-btn--primary" %>
+            <%= link_to "Back to queue", admin_certification_ships_path,
+                  class: "action-btn action-btn--small action-btn--secondary" %>
+          </div>
+        <% else %>
+          <div class="ship-review__complete-actions">
+            <% if @verdict_history.empty? %>
+              <p>This review is no longer pending.</p>
+            <% end %>
             <%= link_to "Back to queue", admin_certification_ships_path,
                   class: "action-btn action-btn--small action-btn--secondary" %>
           </div>


### PR DESCRIPTION
## Summary
- show project-level Shipwright verdict history on ship review pages
- list approved/returned verdicts newest-first with reviewer, reviewed time, feedback, and attached review video link when present
- keep the claim prompt only for pending reviews that the current reviewer does not hold

## Testing
- RUBOCOP_CACHE_ROOT=tmp/rubocop_cache bundle exec rubocop app/controllers/admin/certification/ships_controller.rb
- bundle exec erb_lint app/views/admin/certification/ships/show.html.erb
- yarn -s prettier --check app/assets/stylesheets/pages/certification/ships/_show.scss