### PR TITLE
fix: disabling users from reposting their own devlogs

### DIFF
--- a/app/assets/stylesheets/components/_feed.scss
+++ b/app/assets/stylesheets/components/_feed.scss
@@ -543,6 +543,7 @@
   a:not(.feed-post-card__overlay-link),
   button,
   summary,
+  .feed-post-card__action,
   input,
   textarea,
   select,

--- a/app/components/posts/card_component.html.erb
+++ b/app/components/posts/card_component.html.erb
@@ -97,7 +97,12 @@
     <% if show_reposts %>
       <% if repostable? %>
         <div class="feed-post-card__repost">
-          <% if reposted_by_current_user? %>
+          <% if own_post? %>
+            <span class="feed-post-card__action feed-post-card__action--disabled" aria-label="You cannot repost your own devlog">
+              <%= inline_svg_tag "icons/repost.svg", class: "feed-post-card__action-icon" %>
+              <span><%= repost_count %></span>
+            </span>
+          <% elsif reposted_by_current_user? %>
             <%= button_to post_repost_path(repost_target),
                   method: :delete,
                   class: "feed-post-card__action feed-post-card__action--active",

--- a/app/components/posts/card_component.html.erb
+++ b/app/components/posts/card_component.html.erb
@@ -98,7 +98,11 @@
       <% if repostable? %>
         <div class="feed-post-card__repost">
           <% if own_post? %>
-            <span class="feed-post-card__action feed-post-card__action--disabled" aria-label="You cannot repost your own devlog">
+            <span class="feed-post-card__action feed-post-card__action--disabled"
+                  aria-label="You cannot repost your own devlog"
+                  title="You cannot repost your own devlog"
+                  data-controller="tooltip"
+                  data-tooltip-message-value="You cannot repost your own devlog">
               <%= inline_svg_tag "icons/repost.svg", class: "feed-post-card__action-icon" %>
               <span><%= repost_count %></span>
             </span>

--- a/app/components/posts/card_component.rb
+++ b/app/components/posts/card_component.rb
@@ -153,6 +153,10 @@ module Posts
       repost_target&.postable_type == "Post::Devlog"
     end
 
+    def own_post?
+      current_user.present? && repost_target&.user_id == current_user.id
+    end
+
     def repost_count
       repost_target&.reposts_count.to_i
     end

--- a/app/models/post/repost.rb
+++ b/app/models/post/repost.rb
@@ -46,6 +46,8 @@ class Post::Repost < ApplicationRecord
     if original_post.present? && user.present?
       if original_post.postable_type != "Post::Devlog"
         errors.add(:original_post, "must be a devlog")
+      elsif original_post.user_id == user_id
+        errors.add(:original_post, "cannot be your own devlog")
       elsif original_post.postable.blank? || original_post.postable.deleted?
         errors.add(:original_post, "must be available")
       elsif !Post.visible_to(user).where(id: original_post.id).exists?

--- a/app/policies/post/repost_policy.rb
+++ b/app/policies/post/repost_policy.rb
@@ -1,6 +1,6 @@
 class Post::RepostPolicy < ApplicationPolicy
   def create?
-    logged_in?
+    logged_in? && record.original_post&.user_id != user.id
   end
 
   def destroy?


### PR DESCRIPTION
## what's this do?

Disables users from reposting their own devlogs

## show it works

trying to repost your own devlogs:

https://github.com/user-attachments/assets/056cec33-daae-4168-91ee-7321d864e4f0

reposting someone's else:


https://github.com/user-attachments/assets/2802ad9d-bb95-411b-9b3c-a21af8a5815e


## ai?

checking if there's any conflicts
