### PR TITLE
fix post md

### DIFF
--- a/app/components/posts/card_component.html.erb
+++ b/app/components/posts/card_component.html.erb
@@ -53,7 +53,7 @@
       <% end %>
 
       <% if quote_repost? && body.present? %>
-        <div class="feed-post-card__body feed-post-card__body--inline">
+        <div class="feed-post-card__body feed-post-card__body--inline markdown-content">
           <%= helpers.md(body, allow_images: false) %>
         </div>
       <% end %>
@@ -61,7 +61,7 @@
   </header>
 
   <% if body.present? && !quote_repost? %>
-    <div class="feed-post-card__body">
+    <div class="feed-post-card__body markdown-content">
       <%= helpers.md(body, allow_images: false) %>
     </div>
   <% end %>
@@ -118,7 +118,7 @@
                       <span class="comment-modal__post-author">@<%= author_name %></span>
                     <% end %>
                     <% if body.present? %>
-                      <div class="comment-modal__post-body"><%= helpers.md(body, allow_images: false) %></div>
+                      <div class="comment-modal__post-body markdown-content"><%= helpers.md(body, allow_images: false) %></div>
                     <% end %>
                     <p class="comment-modal__replying-to">Replying to <span class="comment-modal__replying-to-name">@<%= author_name %></span></p>
                   </div>

--- a/app/services/markdown_renderer.rb
+++ b/app/services/markdown_renderer.rb
@@ -6,7 +6,7 @@ class MarkdownRenderer
 
   # Bump on any rendered-output change (sanitizer, shortcodes, Rouge, link
   # hardening) — the cache key uses it to invalidate deployment-wide.
-  RENDERER_VERSION      = "v3".freeze
+  RENDERER_VERSION      = "v4".freeze
   CACHE_NAMESPACE       = "markdown".freeze
   GUIDE_CACHE_NAMESPACE = "guide-markdown".freeze
   CACHE_EXPIRES_IN      = 7.days
@@ -37,7 +37,9 @@ class MarkdownRenderer
     Rails.cache.fetch([ CACHE_NAMESPACE, RENDERER_VERSION, "images-#{allow_images}", Digest::SHA1.hexdigest(text) ],
                       expires_in: CACHE_EXPIRES_IN) do
       raw = get_markdown(text)
-      sanitised = sanitize_html(raw, extra_tags: %w[u], extra_attributes: %w[target rel])
+      doc = Nokogiri::HTML::DocumentFragment.parse(raw)
+      highlight_code_blocks(doc)
+      sanitised = sanitize_html(doc.to_html, extra_tags: %w[u], extra_attributes: %w[target rel class])
       doc = Nokogiri::HTML::DocumentFragment.parse(sanitised)
       remove_images(doc) unless allow_images
       harden_links_and_images(doc)
@@ -47,6 +49,17 @@ class MarkdownRenderer
 
   def self.remove_images(doc)
     doc.css("img").remove
+  end
+
+  def self.highlight_code_blocks(doc)
+    doc.css("pre[lang]").each do |pre|
+      lang = pre["lang"]
+      lexer = Rouge::Lexer.find(lang)&.new || Rouge::Lexers::PlainText.new
+      formatter = Rouge::Formatters::HTML.new
+      code = pre.at_css("code") || pre
+      highlighted = formatter.format(lexer.lex(code.text))
+      pre.replace(%(<pre class="guide-code"><code>#{highlighted}</code></pre>))
+    end
   end
 
   def self.harden_links_and_images(doc)

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -19,5 +19,5 @@
       <% end %>
     <% end %>
   </div>
-  <div class="devlog-comment__body"><%= simple_format(comment.body) %></div>
+  <div class="devlog-comment__body"><%= sanitize md(comment.body, allow_images: false), tags: %w[p br strong em b i u s del a], attributes: %w[href target rel] %></div>
 </div>


### PR DESCRIPTION
## what's this do?

previously, post md was not styled right (sub-bullets were not indented and code blocks were not styled), also you could put images in comments

now, comments only support inline md, and posts are properly styled with the styling that was already being applied to guides
also no more images in comments :p

## show it works

<img width="461" height="402" alt="image" src="https://github.com/user-attachments/assets/f96d011e-fef1-4591-90ed-c5251df47f6f" />

## ai?

claude
