### PR TITLE
feat(api): add referrals to ambassadors api

### DIFF
--- a/app/controllers/api/v1/ambassador_referrals_controller.rb
+++ b/app/controllers/api/v1/ambassador_referrals_controller.rb
@@ -31,7 +31,6 @@ class Api::V1::AmbassadorReferralsController < Api::V1::BaseController
 
       {
         prefix: Rsvp::AMBASSADOR_REFERRAL_PREFIX,
-        rsvp: rsvp_mode,
         count: referrals.size,
         referrals: referrals
       }
@@ -44,7 +43,7 @@ class Api::V1::AmbassadorReferralsController < Api::V1::BaseController
         user.ambassador_referral_payload(
           hours_logged: hours(metrics.logged_seconds[user.id]),
           hours_approved: hours(metrics.approved_seconds[user.id])
-        )
+        ).merge(rsvp: false)
       end
     end
 
@@ -56,6 +55,7 @@ class Api::V1::AmbassadorReferralsController < Api::V1::BaseController
       rsvps.map do |rsvp|
         user = users_by_email[rsvp.email.to_s.downcase]
         rsvp.ambassador_referral_payload.merge(
+          rsvp: user.blank?,
           verification_status: user&.verification_status,
           hours_logged: user ? hours(metrics.logged_seconds[user.id]) : nil,
           hours_approved: user ? hours(metrics.approved_seconds[user.id]) : nil

--- a/app/controllers/api/v1/ambassador_referrals_controller.rb
+++ b/app/controllers/api/v1/ambassador_referrals_controller.rb
@@ -3,31 +3,30 @@ class Api::V1::AmbassadorReferralsController < Api::V1::BaseController
   private_constant :BOOLEAN
 
   def index
-    render json: payload(scope_for_mode)
+    render json: payload(User.ambassador_referrals, rsvp_scope: Rsvp.ambassador_referrals)
   end
 
   def show
     code = params[:id].to_s
     if code.start_with?(Rsvp::AMBASSADOR_REFERRAL_PREFIX)
-      render json: payload(scope_for_mode.matching_ref(code))
+      render json: payload(
+        User.ambassador_referrals.matching_ref(code),
+        rsvp_scope: Rsvp.ambassador_referrals.matching_ref(code)
+      )
     else
       render json: { error: "Not found" }, status: :not_found
     end
   end
 
   private
-    def rsvp_mode?
+    def include_rsvps?
       BOOLEAN.cast(params[:rsvp])
     end
 
-    def scope_for_mode
-      rsvp_mode? ? Rsvp.ambassador_referrals : User.ambassador_referrals
-    end
-
-    def payload(scope)
-      rsvp_mode = rsvp_mode?
+    def payload(scope, rsvp_scope:)
       records = scope.order(:id).to_a
-      referrals = rsvp_mode ? rsvp_items(records) : user_items(records)
+      referrals = user_items(records)
+      referrals += rsvp_items(rsvp_scope.order(:id).to_a) if include_rsvps?
 
       {
         prefix: Rsvp::AMBASSADOR_REFERRAL_PREFIX,
@@ -50,15 +49,13 @@ class Api::V1::AmbassadorReferralsController < Api::V1::BaseController
     def rsvp_items(rsvps)
       users_by_email = User.matching_emails(rsvps.map(&:email))
                            .index_by { |user| user.email.to_s.downcase }
-      metrics = AmbassadorReferralMetrics.new(users_by_email.values)
 
-      rsvps.map do |rsvp|
-        user = users_by_email[rsvp.email.to_s.downcase]
+      rsvps.reject { |rsvp| users_by_email.key?(rsvp.email.to_s.downcase) }.map do |rsvp|
         rsvp.ambassador_referral_payload.merge(
-          rsvp: user.blank?,
-          verification_status: user&.verification_status,
-          hours_logged: user ? hours(metrics.logged_seconds[user.id]) : nil,
-          hours_approved: user ? hours(metrics.approved_seconds[user.id]) : nil
+          rsvp: true,
+          verification_status: nil,
+          hours_logged: nil,
+          hours_approved: nil
         )
       end
     end

--- a/app/controllers/api/v1/ambassador_referrals_controller.rb
+++ b/app/controllers/api/v1/ambassador_referrals_controller.rb
@@ -1,24 +1,69 @@
 class Api::V1::AmbassadorReferralsController < Api::V1::BaseController
+  BOOLEAN = ActiveModel::Type::Boolean.new
+  private_constant :BOOLEAN
+
   def index
-    render json: referral_payload(Rsvp.ambassador_referrals)
+    render json: payload(scope_for_mode)
   end
 
   def show
-    if params[:id].to_s.start_with?(Rsvp::AMBASSADOR_REFERRAL_PREFIX)
-      render json: referral_payload(Rsvp.ambassador_referrals.where("LOWER(ref) = ?", params[:id].to_s.downcase))
+    code = params[:id].to_s
+    if code.start_with?(Rsvp::AMBASSADOR_REFERRAL_PREFIX)
+      render json: payload(scope_for_mode.matching_ref(code))
     else
       render json: { error: "Not found" }, status: :not_found
     end
   end
 
   private
-    def referral_payload(referrals)
-      referrals = referrals.order(:id)
+    def rsvp_mode?
+      BOOLEAN.cast(params[:rsvp])
+    end
+
+    def scope_for_mode
+      rsvp_mode? ? Rsvp.ambassador_referrals : User.ambassador_referrals
+    end
+
+    def payload(scope)
+      rsvp_mode = rsvp_mode?
+      records = scope.order(:id).to_a
+      referrals = rsvp_mode ? rsvp_items(records) : user_items(records)
 
       {
         prefix: Rsvp::AMBASSADOR_REFERRAL_PREFIX,
+        rsvp: rsvp_mode,
         count: referrals.size,
-        referrals: referrals.map(&:ambassador_referral_payload)
+        referrals: referrals
       }
+    end
+
+    def user_items(users)
+      metrics = AmbassadorReferralMetrics.new(users)
+
+      users.map do |user|
+        user.ambassador_referral_payload(
+          hours_logged: hours(metrics.logged_seconds[user.id]),
+          hours_approved: hours(metrics.approved_seconds[user.id])
+        )
+      end
+    end
+
+    def rsvp_items(rsvps)
+      users_by_email = User.matching_emails(rsvps.map(&:email))
+                           .index_by { |user| user.email.to_s.downcase }
+      metrics = AmbassadorReferralMetrics.new(users_by_email.values)
+
+      rsvps.map do |rsvp|
+        user = users_by_email[rsvp.email.to_s.downcase]
+        rsvp.ambassador_referral_payload.merge(
+          verification_status: user&.verification_status,
+          hours_logged: user ? hours(metrics.logged_seconds[user.id]) : nil,
+          hours_approved: user ? hours(metrics.approved_seconds[user.id]) : nil
+        )
+      end
+    end
+
+    def hours(seconds)
+      ((seconds || 0) / 3600.0).round(2)
     end
 end

--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -51,11 +51,12 @@ class Rsvp < ApplicationRecord
   after_commit :enqueue_geocode_job, on: :create
   after_commit :increment_signup_counter, on: :create, if: -> { Flipper.enabled?(:new_onboarding) }
 
-  class << self
-    def ambassador_referrals
-      where("LOWER(ref) LIKE ?", "#{AMBASSADOR_REFERRAL_PREFIX}%")
-    end
-  end
+  scope :ambassador_referrals, -> {
+    where(arel_table[:ref].lower.matches("#{AMBASSADOR_REFERRAL_PREFIX}%"))
+  }
+  scope :matching_ref, ->(ref) {
+    where(arel_table[:ref].lower.eq(ref.to_s.downcase))
+  }
 
   def ambassador_referral_payload
     {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -159,6 +159,17 @@ class User < ApplicationRecord
   after_commit :enqueue_geocode_job, on: :create
 
   scope :discoverable, -> { joins(:hack_club_identity).distinct }
+  scope :ambassador_referrals, -> {
+    where(arel_table[:ref].lower.matches("#{Rsvp::AMBASSADOR_REFERRAL_PREFIX}%"))
+  }
+  scope :matching_ref, ->(ref) {
+    where(arel_table[:ref].lower.eq(ref.to_s.downcase))
+  }
+  scope :matching_emails, ->(emails) {
+    normalized_emails = Array(emails).map { |email| email.to_s.downcase }.select(&:present?)
+
+    normalized_emails.empty? ? none : where(arel_table[:email].lower.in(normalized_emails))
+  }
 
   validates :banner, content_type: [ "image/png", "image/jpeg", "image/webp", "image/gif" ],
                      size: { less_than: 8.megabytes }
@@ -222,6 +233,21 @@ class User < ApplicationRecord
     return random_funny_display_name if local.blank?
 
     "#{local.first(MAX_DISPLAY_NAME_LENGTH - 5)}_#{rand(1000..9999)}"
+  end
+
+  def ambassador_referral_payload(hours_logged:, hours_approved:)
+    {
+      id: id,
+      email: email,
+      ref: ref,
+      user_ref: user_ref,
+      verification_status: verification_status,
+      hours_logged: hours_logged,
+      hours_approved: hours_approved,
+      onboarded_at: onboarded_at,
+      created_at: created_at,
+      updated_at: updated_at
+    }
   end
 
   def active_project_for_mission(mission)

--- a/app/services/ambassador_referral_metrics.rb
+++ b/app/services/ambassador_referral_metrics.rb
@@ -1,0 +1,68 @@
+class AmbassadorReferralMetrics
+  POSTS = Post.arel_table
+  POST_DEVLOGS = Post::Devlog.arel_table
+
+  private_constant :POSTS, :POST_DEVLOGS
+
+  def initialize(users)
+    @user_ids = users.map(&:id).uniq
+  end
+
+  def logged_seconds
+    @logged_seconds ||= compute_logged_seconds
+  end
+
+  def approved_seconds
+    @approved_seconds ||= compute_approved_seconds
+  end
+
+  private
+    def compute_logged_seconds
+      return {} if @user_ids.empty?
+
+      Post.of_devlogs(join: true)
+          .where(user_id: @user_ids, post_devlogs: { deleted_at: nil })
+          .group(:user_id)
+          .sum(POST_DEVLOGS[:duration_seconds])
+    end
+
+    def compute_approved_seconds
+      return {} if @user_ids.empty?
+
+      approved_ships = Post.of_ship_events(join: true)
+                           .where(user_id: @user_ids, post_ship_events: { certification_status: "approved" })
+                           .pluck(POSTS[:user_id], POSTS[:project_id], POSTS[:created_at])
+      return {} if approved_ships.empty?
+
+      project_ids    = approved_ships.map { |ship| ship[1] }.uniq
+      ship_times     = ship_times_by_project(project_ids)
+      project_starts = Project.where(id: project_ids).pluck(:id, :created_at).to_h
+      devlogs        = devlogs_by_project(project_ids)
+
+      approved_ships.each_with_object(Hash.new(0)) do |(user_id, project_id, shipped_at), totals|
+        window_start = ship_times[project_id].select { |time| time < shipped_at }.max || project_starts[project_id]
+        totals[user_id] += devlogs[project_id].sum do |(logged_at, seconds)|
+          logged_at.between?(window_start, shipped_at) ? seconds.to_i : 0
+        end
+      end
+    end
+
+    def ship_times_by_project(project_ids)
+      Post.of_ship_events
+          .where(project_id: project_ids)
+          .order(:created_at)
+          .pluck(:project_id, :created_at)
+          .each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(project_id, time), grouped|
+            grouped[project_id] << time
+          end
+    end
+
+    def devlogs_by_project(project_ids)
+      Post.of_devlogs(join: true)
+          .where(project_id: project_ids, post_devlogs: { deleted_at: nil })
+          .pluck(POSTS[:project_id], POSTS[:created_at], POST_DEVLOGS[:duration_seconds])
+          .each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(project_id, logged_at, seconds), grouped|
+            grouped[project_id] << [ logged_at, seconds ]
+          end
+    end
+end


### PR DESCRIPTION
## what's this do?

Modify /api/v1/ambassador_referrals to send hours_logged (computed again for the user themselves and not project_seconds because it's not forwards compatible with group projects), hours_approved and verification_status. Also sends back users instead of RSVP rows now! At the moment, we're upgrading RSVPs to Users as well.

In addition, there is a new ?rsvp=true (false by default) flag that injects pure RSVPs into the list too. RSVPs don't show up otherwise. And a new rsvp param inside each referral.

## show it works

<img width="614" height="317" alt="image" src="https://github.com/user-attachments/assets/1fb0ba59-f6c2-4200-995e-0612f28b456c" />

## ai

opus