### PR TITLE
fix: lambda arity crash in url_probe_status

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -526,20 +526,12 @@ class Project < ApplicationRecord
     uri = URI.parse(url)
     return nil if PROBE_SKIP_DOMAINS.any? { |d| uri.host&.end_with?(d) }
 
-    probe = -> {
-      response = SafeUrl.safe_get(
-        url,
-        headers: { "User-Agent" => "Stardance project validator (https://stardance.hackclub.com/)" },
-        open_timeout: 5,
-        read_timeout: 5
-      )
-      response.code.to_i
-    }
-
     if cache
-      Rails.cache.fetch("url_probe_v2_#{Digest::MD5.hexdigest(url)}", expires_in: 5.minutes, &probe)
+      Rails.cache.fetch("url_probe_v2_#{Digest::MD5.hexdigest(url)}", expires_in: 5.minutes) do
+        do_url_probe(url)
+      end
     else
-      probe.call
+      do_url_probe(url)
     end
   end
 
@@ -552,6 +544,16 @@ class Project < ApplicationRecord
   end
 
   private
+
+  def do_url_probe(url)
+    response = SafeUrl.safe_get(
+      url,
+      headers: { "User-Agent" => "Stardance project validator (https://stardance.hackclub.com/)" },
+      open_timeout: 5,
+      read_timeout: 5
+    )
+    response.code.to_i
+  end
 
   def devlog_window_start(at)
     previous_devlog = devlogs.where("post_devlogs.created_at < ?", at).order("post_devlogs.created_at desc").first


### PR DESCRIPTION
Rails.cache.fetch passes 2 args to the block in Rails 8.1; lambdas enforce arity and blow up. Replace with an inline block calling a private method.

ok im gonna be honest i don't know why it broke previously but it should be fixed now

fixing #383 