### PR TITLE
fix(project): make banner default first to mission banner, then default banner

### DIFF
--- a/app/components/projects/shelf_card_component.html.erb
+++ b/app/components/projects/shelf_card_component.html.erb
@@ -1,7 +1,7 @@
 <%= link_to project_path(project), class: "project-shelf-card", data: engagement_data do %>
   <span class="project-shelf-card__media">
-    <% if project.banner.attached? %>
-      <%= image_tag project.banner.variant(:card), alt: "", class: "project-shelf-card__image" %>
+    <% if project.display_banner %>
+      <%= image_tag project.display_banner, alt: "", class: "project-shelf-card__image" %>
     <% else %>
       <%= image_tag "default-banner.png", alt: "", class: "project-shelf-card__image" %>
     <% end %>

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -80,7 +80,7 @@ class UsersController < ApplicationController
     @user.projects
          .select(:id, :title, :description, :created_at, :updated_at,
                  :ship_status, :shipped_at, :devlogs_count, :duration_seconds)
-         .includes(:users, banner_attachment: :blob)
+         .includes(:users, banner_attachment: :blob, mission_attachments: { mission: { banner_attachment: :blob } })
          .order(created_at: :desc)
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -108,6 +108,14 @@ class Project < ApplicationRecord
     current_mission_attachment&.mission
   end
 
+  def display_banner
+    if banner.attached?
+      banner
+    elsif current_mission&.banner&.attached?
+      current_mission.banner
+    end
+  end
+
   # True once this project has shipped to the given mission at least once.
   # After that first ship the mission stays attached (for display) but future
   # ships are regular, non-mission ships.

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -13,7 +13,8 @@
 <% end %>
 
 <%
-  banner_url = @project.banner.attached? ? url_for(@project.banner) : image_path("profile/default-banner.png")
+  display = @project.display_banner
+  banner_url = display ? url_for(display) : image_path("profile/default-banner.png")
   members = @members || @project.users.to_a
   is_member = @is_member
   follower_count = @follower_count || @project.project_follows.size

--- a/app/views/projects/show_hackpad.html.erb
+++ b/app/views/projects/show_hackpad.html.erb
@@ -13,7 +13,8 @@
 <% end %>
 
 <%
-  banner_url = @project.banner.attached? ? url_for(@project.banner) : image_path("profile/default-banner.png")
+  display = @project.display_banner
+  banner_url = display ? url_for(display) : image_path("profile/default-banner.png")
   members = @members || @project.users.to_a
   is_member = @is_member
   follower_count = @follower_count || @project.project_follows.size

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -225,8 +225,10 @@
           <li class="project-list__item">
             <%= link_to project_path(project), class: "profile-project-card" do %>
               <div class="profile-project-card__banner">
-                <% if project.banner.attached? %>
-                  <%= image_tag project.banner, alt: "", class: "profile-project-card__banner-img" %>
+                <% if project.display_banner %>
+                  <%= image_tag project.display_banner, alt: "", class: "profile-project-card__banner-img" %>
+                <% else %>
+                  <%= image_tag "default-banner.png", alt: "", class: "profile-project-card__banner-img" %>
                 <% end %>
               </div>
 

--- a/app/views/votes/_project_card.html.erb
+++ b/app/views/votes/_project_card.html.erb
@@ -2,7 +2,8 @@
     projects/show.html.erb minus edit/follow actions. %>
 <%
   members        = project.users.to_a
-  banner_url     = project.banner.attached? ? url_for(project.banner) : image_path("profile/default-banner.png")
+  display        = project.display_banner
+  banner_url     = display ? url_for(display) : image_path("profile/default-banner.png")
   total_hours    = (project.duration_seconds / 3600.0).round
   follower_count = project.project_follows.size
 %>


### PR DESCRIPTION
## what's this do?

A small change to make a default project feel more a part of a mission- just make the mission banner be the default banner for projects made under it.

Also make the default banner show up in the user/projects page

## show it works

<img width="1333" height="336" alt="image" src="https://github.com/user-attachments/assets/6042d33e-f49e-4179-b897-631545270892" />


## ai?

claude
