### PR TITLE
feat(raffle): enroll all users, gate raffle to US/CA only

### DIFF
--- a/app/components/discover_rail/raffle_widget.rb
+++ b/app/components/discover_rail/raffle_widget.rb
@@ -5,11 +5,14 @@ module DiscoverRail
     register_as :raffle
 
     def render?
-      user.present? && enrolled?
+      user.present? && participant.present?
     end
 
     def participant
-      @participant ||= Raffle::Participant.find_by(user_id: user.id)
+      return @participant if defined?(@participant)
+      @participant = Raffle::Participant.find_by(user_id: user.id)
+      @participant ||= Raffle::Participant.find_or_enroll!(user) if Raffle::Week.current
+      @participant
     end
 
     def week

--- a/engines/raffle/app/models/raffle/participant.rb
+++ b/engines/raffle/app/models/raffle/participant.rb
@@ -30,12 +30,10 @@ module Raffle
     end
 
     def self.find_or_enroll!(user)
-      return nil unless country_eligible?(user)
-
       participant = find_or_initialize_by(user: user)
       if participant.new_record?
         participant.age_group = :teen
-        participant.signup_week = Raffle::Week.current
+        participant.signup_week = Raffle::Week.current if country_eligible?(user)
         participant.save!
       end
       participant

--- a/lib/tasks/raffle.rake
+++ b/lib/tasks/raffle.rake
@@ -1,14 +1,4 @@
 namespace :raffle do
-  desc "Start the raffle by creating week 1 (idempotent)"
-  task start: :environment do
-    if Raffle::Week.current
-      puts "Week #{Raffle::Week.current.number} is already active."
-    else
-      week = Raffle::Week.create!(number: 1, status: :active, opened_at: Time.current)
-      puts "Created week ##{week.number}."
-    end
-  end
-
   desc "Enroll all users who aren't already enrolled (everyone gets a referral code)"
   task enroll_existing: :environment do
     enrolled = 0

--- a/lib/tasks/raffle.rake
+++ b/lib/tasks/raffle.rake
@@ -1,0 +1,28 @@
+namespace :raffle do
+  desc "Start the raffle by creating week 1 (idempotent)"
+  task start: :environment do
+    if Raffle::Week.current
+      puts "Week #{Raffle::Week.current.number} is already active."
+    else
+      week = Raffle::Week.create!(number: 1, status: :active, opened_at: Time.current)
+      puts "Created week ##{week.number}."
+    end
+  end
+
+  desc "Enroll all users who aren't already enrolled (everyone gets a referral code)"
+  task enroll_existing: :environment do
+    enrolled = 0
+    skipped = 0
+
+    User.find_each do |user|
+      if Raffle::Participant.exists?(user_id: user.id)
+        skipped += 1
+      else
+        Raffle::Participant.find_or_enroll!(user)
+        enrolled += 1
+      end
+    end
+
+    puts "Enrolled #{enrolled} users, skipped #{skipped} already enrolled."
+  end
+end


### PR DESCRIPTION
auto-enroll all users to referral & give them all a referral code

rake tasks:
- raffle:start — create week 1
- raffle:enroll_existing — bulk-enroll all existing users