### PR TITLE
fix(onboarding): add dependent: :destroy for raffle FK on user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -105,6 +105,9 @@ class User < ApplicationRecord
   has_many :wishlisted_shop_items, through: :shop_wishlists, source: :shop_item
   has_many :sold_items, class_name: "ShopItem::HackClubberItem", foreign_key: :user_id
 
+  has_one :raffle_participant, class_name: "Raffle::Participant", dependent: :destroy
+  has_one :raffle_referral_as_referred, class_name: "Raffle::Referral", foreign_key: :referred_user_id, dependent: :destroy
+
   has_one_attached :banner
 
   enum :verification_status, {


### PR DESCRIPTION
## what's this do?

when the user was destroyed for being over 18, it didn't cascade to the raffle participant entry. This just adds that cascade.

## show it works



## ai?

claude
