### PR TITLE
security(gems): add cooldown setting to rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
-source "https://rubygems.org"
+# https://blog.rubygems.org/2026/06/03/cooldown-let-new-gems-be-vetted.html
+source "https://rubygems.org", cooldown: 7
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 8.1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -871,4 +871,4 @@ DEPENDENCIES
   with_advisory_lock
 
 BUNDLED WITH
-  4.0.4
+  4.0.13


### PR DESCRIPTION
fyi, this may start throwing warnings on local builds! if you're getting warnings about bundler version just rebuild with docker or run `gem install bundler; bundle update --bundler` locally