### PR TITLE
fix(dev): add raffle gemspec on dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get update -qq && \
 
 # Install application gems
 COPY Gemfile Gemfile.lock ./
-COPY engines/raffle ./engines/raffle
+COPY engines/raffle/raffle.gemspec ./engines/raffle/
 RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
     bundle exec bootsnap precompile --gemfile

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -32,6 +32,7 @@ WORKDIR /app
 
 # Install application gems
 COPY Gemfile Gemfile.lock ./
+COPY engines/raffle/raffle.gemspec ./engines/raffle/
 RUN bundle install
 
 # Add a script to be executed every time the container starts


### PR DESCRIPTION
fix dev dockerfile by adding the raffle gemspec. unfortunately i can only test this on my m1 mac running with `DOCKER_DEFAULT_PLATFORM=linux/amd64` for compatibility, and i'm not 100% confident this is a perfect way to test that it builds. merging for now but if your dev docker build breaks after this commit please open a ticket or comment on this pr!