### PR TITLE
feat(admin): make it so you can unlink users identities

### DIFF
--- a/app/controllers/admin/users/identities_controller.rb
+++ b/app/controllers/admin/users/identities_controller.rb
@@ -1,0 +1,39 @@
+class Admin::Users::IdentitiesController < Admin::ApplicationController
+  before_action :set_user
+  before_action :set_identity
+
+  def destroy
+    authorize @user, :unlink_identity?
+
+    provider = @identity.provider
+    uid = @identity.uid
+
+    PaperTrail.request(whodunnit: current_user.id) do
+      @identity.destroy!
+    end
+
+    ::PaperTrail::Version.create!(
+      item_type: "User",
+      item_id: @user.id,
+      event: "identity_unlinked",
+      whodunnit: current_user.id.to_s,
+      object_changes: {
+        provider: [ provider, nil ],
+        uid: [ uid, nil ]
+      }.to_json
+    )
+
+    flash[:notice] = "#{provider.titleize} identity unlinked from #{@user.display_name}."
+    redirect_to admin_user_path(@user)
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:user_id])
+  end
+
+  def set_identity
+    @identity = @user.identities.find(params[:id])
+  end
+end

--- a/app/policies/admin/user_policy.rb
+++ b/app/policies/admin/user_policy.rb
@@ -70,6 +70,10 @@ class Admin::UserPolicy < ApplicationPolicy
     user&.admin? || user&.fraud_dept?
   end
 
+  def unlink_identity?
+    user&.admin?
+  end
+
   private
 
   def protected_role?

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -86,6 +86,13 @@
           <% if identity.provider == "hack_club" %>
             <%= link_to "go to idv backend", "#{HCAService.backend_url("/identities/#{identity.uid}")}", target: "_blank" %>
           <% end %>
+
+          <% if policy(@user).unlink_identity? %>
+            <%= button_to "Unlink",
+                          admin_user_identity_path(@user, identity),
+                          method: :delete,
+                          data: { confirm: "Are you sure you want to unlink the #{identity.provider.titleize} identity (#{identity.uid}) from #{@user.display_name}? This cannot be undone." } %>
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -594,6 +594,7 @@ Rails.application.routes.draw do
         resource  :verification,        only: [ :create ]
         resource  :vote_balance,        only: [ :update ]
         resource  :ysws_override,       only: [ :update ]
+        resources :identities,          only: [ :destroy ]
         resources :votes,               only: [ :index ]
       end
     end


### PR DESCRIPTION
## what's this do?

previously, identities were forever. Once you were someone, you always were. Now, we have revolutionized that and come to the realization that you can actually not be the person you are. Thus we invented unlinking identities. This new feature allows admins to do this freely, taking identity to identity away from people.

## show it works

hopefully it does

## ai?

yea claude
