### PR TITLE
Big mission improvements

### DIFF
--- a/app/assets/stylesheets/components/_discover_rail.scss
+++ b/app/assets/stylesheets/components/_discover_rail.scss
@@ -179,11 +179,16 @@
   white-space: nowrap;
 }
 
+.discover-rail__widgets {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
 .discover-rail__section {
   display: flex;
   flex-direction: column;
   gap: 11px;
-  margin-top: 7px;
 }
 
 .discover-rail__heading {

--- a/app/assets/stylesheets/pages/admin/_missions_edit.scss
+++ b/app/assets/stylesheets/pages/admin/_missions_edit.scss
@@ -208,6 +208,12 @@
   }
 }
 
+.admin-mission-edit__guide-url-form {
+  margin-bottom: var(--space-l);
+  padding-bottom: var(--space-l);
+  border-bottom: 1px solid var(--color-space-border, rgba(255, 255, 255, 0.1));
+}
+
 // Explicit fixed centering — showModal()'s default margin: auto is unreliable
 // across Safari + Firefox + Chromium without an explicit transform.
 .admin-mission-edit__paste-dialog {

--- a/app/assets/stylesheets/pages/missions/_show.scss
+++ b/app/assets/stylesheets/pages/missions/_show.scss
@@ -25,7 +25,8 @@
   padding: var(--space-m) var(--space-l);
   border-radius: 12px;
   background: color-mix(in srgb, var(--color-brand-salmon) 10%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-brand-salmon) 30%, transparent);
+  border: 1px solid
+    color-mix(in srgb, var(--color-brand-salmon) 30%, transparent);
 }
 
 .mission-home__locked-message {

--- a/app/assets/stylesheets/pages/missions/_show.scss
+++ b/app/assets/stylesheets/pages/missions/_show.scss
@@ -20,6 +20,27 @@
   display: block;
 }
 
+.mission-home__locked {
+  margin: var(--space-m) 0;
+  padding: var(--space-m) var(--space-l);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--color-brand-salmon) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-brand-salmon) 30%, transparent);
+}
+
+.mission-home__locked-message {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--color-brand-salmon);
+}
+
+.mission-home__locked-link {
+  color: var(--color-brand-cream);
+  font-weight: 600;
+  text-decoration: underline;
+}
+
 .mission-home__crumb {
   display: flex;
   align-items: center;
@@ -459,6 +480,17 @@
   color: var(--color-fg);
   font-weight: 700;
   font-size: 15px;
+
+  a {
+    color: var(--color-brand-cream);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+
+    &:hover,
+    &:focus-visible {
+      color: var(--color-brand-off-white);
+    }
+  }
 }
 
 .mission-home__prize-blurb {

--- a/app/assets/stylesheets/pages/missions/_show.scss
+++ b/app/assets/stylesheets/pages/missions/_show.scss
@@ -437,6 +437,12 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+
+  &.currency-icon,
+  &--contain {
+    object-fit: contain;
+    padding: 10px;
+  }
 }
 
 .mission-home__prize-glyph {

--- a/app/controllers/missions_controller.rb
+++ b/app/controllers/missions_controller.rb
@@ -10,10 +10,24 @@ class MissionsController < ApplicationController
                      .order(featured_at: :desc, name: :asc)
                      .group_by(&:index_bucket)
 
-    @available_missions = buckets[:available] || []
+    @completed_mission_ids = if current_user
+      Mission::Submission
+        .where(status: "approved")
+        .joins(ship_event: :post)
+        .where(posts: { user_id: current_user.id })
+        .distinct
+        .pluck(:mission_id)
+        .to_set
+    else
+      Set.new
+    end
+
+    available = buckets[:available] || []
+    @completed_missions = available.select { |m| @completed_mission_ids.include?(m.id) }
+    @available_missions = available.reject { |m| @completed_mission_ids.include?(m.id) }
     @upcoming_missions  = (buckets[:upcoming] || []).sort_by(&:start_at).first(8)
-    @ended_missions     = (buckets[:ended] || []).sort_by { |m| -m.end_at.to_f }.first(8)
     @draft_missions     = (buckets[:draft] || []).sort_by { |m| -m.updated_at.to_f }
+    @ended_missions     = (buckets[:ended] || []).sort_by { |m| -m.end_at.to_f }.first(8)
   end
 
   def show

--- a/app/controllers/missions_controller.rb
+++ b/app/controllers/missions_controller.rb
@@ -26,6 +26,9 @@ class MissionsController < ApplicationController
     @estimated_label      = @mission.estimated_completion_label
     @active_project       = current_user&.active_project_for_mission(@mission)
     @progress_state       = compute_progress_state(@mission, @active_project, @guide_outline)
+    @unlocked_missions     = @mission.unlocks.enabled.to_a
+    @prerequisites_met     = @mission.prerequisites_met_by?(current_user)
+    @unmet_prerequisites   = @mission.unmet_prerequisites_for(current_user)
 
     if current_user && @active_project.nil?
       @attachable_projects = current_user.projects

--- a/app/controllers/missions_controller.rb
+++ b/app/controllers/missions_controller.rb
@@ -79,9 +79,19 @@ class MissionsController < ApplicationController
 
     return :in_progress unless ship
 
+    submission = ship.mission_submission
+
     case ship.certification_status
     when "approved"
-      ship.payout_basis_locked_at.present? ? :completed : :in_voting
+      if submission&.approved?
+        :completed
+      elsif submission&.pending?
+        :in_review
+      elsif ship.payout_basis_locked_at.present?
+        :completed
+      else
+        :in_voting
+      end
     when "pending"
       :in_review
     else

--- a/app/controllers/projects/missions_controller.rb
+++ b/app/controllers/projects/missions_controller.rb
@@ -5,6 +5,11 @@ class Projects::MissionsController < ApplicationController
     authorize @project, :update?
     mission = Mission.available.find_by!(slug: params[:mission_slug])
 
+    unless mission.prerequisites_met_by?(current_user)
+      unmet = mission.unmet_prerequisites_for(current_user).map(&:name).to_sentence
+      redirect_to project_path(@project), alert: "Complete #{unmet} first to unlock this mission." and return
+    end
+
     @project.mission_attachments.create!(mission: mission, attached_at: Time.current)
 
     redirect_to project_path(@project), notice: "Attached to the #{mission.name} mission."

--- a/app/controllers/projects/setup_controller.rb
+++ b/app/controllers/projects/setup_controller.rb
@@ -82,6 +82,11 @@ class Projects::SetupController < ApplicationController
       redirect_to projects_setup_missions_path, alert: "That mission isn't available." and return
     end
 
+    unless mission.prerequisites_met_by?(current_user)
+      unmet = mission.unmet_prerequisites_for(current_user).map(&:name).to_sentence
+      redirect_to mission_path(mission.slug), alert: "Complete #{unmet} first to unlock this mission." and return
+    end
+
     existing = project.mission_attachments.find_by(mission_id: mission.id)
 
     if existing&.detached_at.nil? && existing.present?

--- a/app/controllers/projects/ships_controller.rb
+++ b/app/controllers/projects/ships_controller.rb
@@ -95,9 +95,20 @@ class Projects::ShipsController < ApplicationController
     end
 
     def resolve_payout_path(mission, payout_path_param)
+      if mission.fixed_stardust_payout&.positive? && !user_has_approved_submission_for?(mission)
+        return "static_prize"
+      end
       return "voting" unless mission.has_prizes?
       return "voting" if user_redeemed_prize_for?(mission)
       payout_path_param.to_s == "voting" ? "voting" : "static_prize"
+    end
+
+    def user_has_approved_submission_for?(mission)
+      Mission::Submission
+        .where(mission_id: mission.id, status: "approved")
+        .joins(ship_event: { post: :user })
+        .where(users: { id: current_user.id })
+        .exists?
     end
 
     def user_redeemed_prize_for?(mission)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -153,7 +153,9 @@ class ProjectsController < ApplicationController
       if is_owner &&
           latest_ship_event.present? &&
           latest_ship_event.certification_status == "approved" &&
-          latest_ship_event.payout.blank?
+          latest_ship_event.payout.blank? &&
+          latest_ship_event.mission_submission&.payout_path != "static_prize" &&
+          !latest_ship_event.mission_submission&.rejected?
 
         required = Post::ShipEvent::VOTES_REQUIRED_FOR_PAYOUT
         current = latest_ship_event.votes.payout_countable.count

--- a/app/models/ledger_entry.rb
+++ b/app/models/ledger_entry.rb
@@ -79,6 +79,7 @@ class LedgerEntry < ApplicationRecord
     when "User::Achievement" then "achievement: #{ledgerable.achievement.name}"
     when "FulfillmentPayoutLine" then "fulfillment payout"
     when "ShowAndTellAttendance" then "show and tell payout"
+    when "Mission::Submission" then "mission payout: #{ledgerable.mission.name}"
     else ledgerable_type.underscore.humanize.downcase
     end
     change_emoji = amount.positive? ? "📈" : "📉"

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -14,6 +14,8 @@
 #  end_at                       :datetime
 #  estimated_completion_minutes :integer
 #  featured_at                  :datetime
+#  fixed_stardust_payout        :integer
+#  guide_url                    :string
 #  name                         :string           not null
 #  prizes_count                 :integer          default(0), not null
 #  slug                         :string           not null

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -49,6 +49,14 @@ class Mission < ApplicationRecord
            class_name: "Mission::GuideVariant", dependent: :destroy, inverse_of: :mission
   has_many :section_completions, class_name: "Mission::SectionCompletion", dependent: :destroy
 
+  has_many :prerequisite_links, class_name: "Mission::Prerequisite",
+           foreign_key: :dependent_mission_id, dependent: :destroy
+  has_many :prerequisites, through: :prerequisite_links, source: :prerequisite_mission
+
+  has_many :dependent_links, class_name: "Mission::Prerequisite",
+           foreign_key: :prerequisite_mission_id, dependent: :destroy
+  has_many :unlocks, through: :dependent_links, source: :dependent_mission
+
   accepts_nested_attributes_for :guide_variants, allow_destroy: true,
                                                  reject_if: ->(attrs) { attrs[:language].blank? && attrs[:body].blank? }
 
@@ -61,7 +69,8 @@ class Mission < ApplicationRecord
   enum :difficulty, DIFFICULTIES.index_with(&:itself), prefix: true
 
   validates :slug, presence: true, uniqueness: true,
-                   format: { with: /\A[a-z0-9][a-z0-9_-]*\z/, message: "must be URL-safe" }
+                   format: { with: /\A[a-z0-9][a-z0-9_-]*\z/, message: "must be URL-safe" },
+                   exclusion: { in: %w[all new], message: "is reserved" }
   validates :name, presence: true
   validates :description, presence: true
   validates :estimated_completion_minutes,
@@ -111,6 +120,31 @@ class Mission < ApplicationRecord
 
   def has_steps?  = steps.any?
   def has_prizes? = prizes.any?
+  def has_prerequisites? = prerequisites.any?
+
+  def prerequisites_met_by?(user)
+    return true unless has_prerequisites?
+    return false if user.nil?
+    completed_mission_ids = Mission::Submission
+      .where(status: "approved")
+      .joins(ship_event: :post)
+      .where(posts: { user_id: user.id })
+      .distinct
+      .pluck(:mission_id)
+    (prerequisite_ids - completed_mission_ids).empty?
+  end
+
+  def unmet_prerequisites_for(user)
+    return [] unless has_prerequisites?
+    return prerequisites.to_a if user.nil?
+    completed_mission_ids = Mission::Submission
+      .where(status: "approved")
+      .joins(ship_event: :post)
+      .where(posts: { user_id: user.id })
+      .distinct
+      .pluck(:mission_id)
+    prerequisites.where.not(id: completed_mission_ids).to_a
+  end
 
   def achievement_slug
     return nil if achievement_name.blank?

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -67,6 +67,9 @@ class Mission < ApplicationRecord
   validates :estimated_completion_minutes,
             numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 100_000 },
             allow_nil: true
+  validates :fixed_stardust_payout,
+            numericality: { only_integer: true, greater_than: 0 },
+            allow_nil: true
   validates :default_project_title, length: { maximum: 120 }, allow_blank: true
   validates :default_project_description, length: { maximum: 1_000 }, allow_blank: true
 

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -121,7 +121,9 @@ class Mission < ApplicationRecord
     guide_variants.order(:position, :id).first
   end
 
-  def has_guide? = guide_variants.any?
+  def has_guide? = guide_variants.any? || guide_url.present?
+
+  def external_guide? = guide_url.present?
 
   def available_languages
     guide_variants.order(:position, :id).pluck(:language)

--- a/app/models/mission/prerequisite.rb
+++ b/app/models/mission/prerequisite.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: mission_prerequisites
+#
+#  id                      :bigint           not null, primary key
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  dependent_mission_id    :bigint           not null
+#  prerequisite_mission_id :bigint           not null
+#
+# Indexes
+#
+#  idx_mission_prereqs_unique                              (prerequisite_mission_id,dependent_mission_id) UNIQUE
+#  index_mission_prerequisites_on_dependent_mission_id     (dependent_mission_id)
+#  index_mission_prerequisites_on_prerequisite_mission_id  (prerequisite_mission_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (dependent_mission_id => missions.id)
+#  fk_rails_...  (prerequisite_mission_id => missions.id)
+#
 class Mission::Prerequisite < ApplicationRecord
   self.table_name = "mission_prerequisites"
 

--- a/app/models/mission/prerequisite.rb
+++ b/app/models/mission/prerequisite.rb
@@ -1,0 +1,8 @@
+class Mission::Prerequisite < ApplicationRecord
+  self.table_name = "mission_prerequisites"
+
+  belongs_to :prerequisite_mission, class_name: "Mission"
+  belongs_to :dependent_mission, class_name: "Mission"
+
+  validates :prerequisite_mission_id, uniqueness: { scope: :dependent_mission_id }
+end

--- a/app/models/mission/submission.rb
+++ b/app/models/mission/submission.rb
@@ -42,6 +42,7 @@ class Mission::Submission < ApplicationRecord
   self.table_name = "mission_submissions"
 
   include SoftDeletable
+  include Ledgerable
   include AASM
 
   has_paper_trail

--- a/app/models/post/ship_event.rb
+++ b/app/models/post/ship_event.rb
@@ -139,6 +139,7 @@ class Post::ShipEvent < ApplicationRecord
 
   def decrement_user_vote_balance
     return unless post&.user
+    return if mission_submission&.payout_path == "static_prize"
 
     post.user.increment!(:vote_balance, -VOTE_COST_PER_SHIP)
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -126,7 +126,7 @@ class Project < ApplicationRecord
   # ships are regular, non-mission ships.
   def shipped_to_mission?(mission)
     return false if mission.nil?
-    mission_submissions.where(mission_id: mission.id).exists?
+    mission_submissions.where(mission_id: mission.id).where.not(status: "rejected").exists?
   end
 
   # needs to be implemented
@@ -570,7 +570,11 @@ class Project < ApplicationRecord
 
   def previous_ship_event_has_payout?
     return true if last_ship_event.nil?
-    last_ship_event.payout.present?
+    return true if last_ship_event.payout.present?
+    sub = last_ship_event.mission_submission
+    return true if sub&.payout_path == "static_prize"
+    return true if sub&.rejected?
+    false
   end
 
   def notify_slack_channel

--- a/app/views/admin/missions/_prizes_frame.html.erb
+++ b/app/views/admin/missions/_prizes_frame.html.erb
@@ -3,6 +3,18 @@
 <%= turbo_frame_tag "admin-mission-edit-prizes" do %>
   <section class="admin-mission-edit__section">
     <h2 class="admin-mission-edit__section-title">Prizes</h2>
+
+    <%= form_with model: mission, url: admin_mission_path(mission.slug), method: :patch, local: true, class: "admin-mission-edit__form" do |f| %>
+      <label>
+        Fixed stardust payout
+        <small class="admin-mission-edit__hint">
+          Builders receive this many stardust when their submission is approved.
+          Leave blank for no fixed payout.
+        </small>
+        <%= f.number_field :fixed_stardust_payout, min: 1, step: 1 %>
+      </label>
+      <%= f.submit "Save stardust payout", class: "action-btn action-btn--small action-btn--primary" %>
+    <% end %>
     <ul class="admin-mission-edit__prizes">
       <% prizes.each do |prize| %>
         <li class="admin-mission-edit__prize">

--- a/app/views/admin/missions/_steps_frame.html.erb
+++ b/app/views/admin/missions/_steps_frame.html.erb
@@ -22,6 +22,20 @@
       </button>
     </header>
 
+    <div class="admin-mission-edit__guide-url-form">
+      <%= form_with model: mission, url: admin_mission_path(mission.slug), method: :patch, local: true, class: "admin-mission-edit__form" do |f| %>
+        <label>
+          External guide URL
+          <small class="admin-mission-edit__hint">
+            If set, all "View guide" links point to this URL instead of the
+            built-in guide below. Leave blank to use the on-platform guide.
+          </small>
+          <%= f.url_field :guide_url, placeholder: "https://..." %>
+        </label>
+        <%= f.submit "Save guide URL", class: "action-btn action-btn--small action-btn--primary" %>
+      <% end %>
+    </div>
+
     <% if available_languages.any? %>
       <nav class="admin-mission-edit__lang-tabs" aria-label="Guide language">
         <% available_languages.each do |lang| %>

--- a/app/views/admin/missions/edit.html.erb
+++ b/app/views/admin/missions/edit.html.erb
@@ -126,6 +126,38 @@
     <%= render "admin/missions/shop_unlocks_frame",
           mission: @mission, unlocks: @unlocks %>
 
+    <section class="admin-mission-edit__section">
+      <h2 class="admin-mission-edit__section-title">Prerequisites</h2>
+      <p class="admin-mission-edit__hint">
+        Missions that must be completed before builders can start this one.
+      </p>
+      <% if @mission.prerequisites.any? %>
+        <ul class="admin-mission-edit__memberships">
+          <% @mission.prerequisites.each do |prereq| %>
+            <li class="admin-mission-edit__membership">
+              <span><%= prereq.name %></span>
+              <%= button_to "Remove",
+                    admin_mission_path(@mission.slug, "mission[remove_prerequisite_id]": prereq.id),
+                    method: :patch,
+                    data: { turbo_confirm: "Remove #{prereq.name} as a prerequisite?" },
+                    class: "action-btn action-btn--small action-btn--destructive" %>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+      <%= form_with model: @mission, url: admin_mission_path(@mission.slug), method: :patch, local: true, class: "admin-mission-edit__form" do |f| %>
+        <label>Add prerequisite mission
+          <%= select_tag "mission[add_prerequisite_id]",
+                options_from_collection_for_select(
+                  Mission.enabled.where.not(id: [@mission.id] + @mission.prerequisite_ids).order(:name),
+                  :id, :name
+                ),
+                prompt: "Select a mission" %>
+        </label>
+        <%= f.submit "Add prerequisite", class: "action-btn action-btn--small action-btn--primary" %>
+      <% end %>
+    </section>
+
     <% if policy(@mission).manage_owners? %>
       <%# Admin-only sections — slug rename, owner add/remove, danger zone.
           Non-admin mission owners can't see any of this; they manage the

--- a/app/views/missions/index.html.erb
+++ b/app/views/missions/index.html.erb
@@ -11,28 +11,29 @@
       </p>
     </header>
 
-    <% if @draft_missions.any? %>
-      <section class="missions-index__section" aria-labelledby="missions-index-drafts">
-        <h2 id="missions-index-drafts" class="missions-index__section-title">Drafts</h2>
-        <ul class="missions-index__grid">
-          <% @draft_missions.each do |mission| %>
-            <li><%= render "missions/mission_card", mission: mission, badge: "Draft", manageable: true %></li>
-          <% end %>
-        </ul>
-      </section>
-    <% end %>
-
     <% if @available_missions.any? %>
       <section class="missions-index__section" aria-labelledby="missions-index-available">
         <h2 id="missions-index-available" class="missions-index__section-title">Available now</h2>
         <ul class="missions-index__grid">
           <% @available_missions.each do |mission| %>
-            <li><%= render "missions/mission_card", mission: mission %></li>
+            <% locked = mission.has_prerequisites? && !(mission.prerequisite_ids.to_set <= @completed_mission_ids) %>
+            <li><%= render "missions/mission_card", mission: mission, badge: locked ? "Locked" : nil %></li>
           <% end %>
         </ul>
       </section>
     <% else %>
       <p class="missions-index__empty">No missions are available right now — check back soon.</p>
+    <% end %>
+
+    <% if @completed_missions.any? %>
+      <section class="missions-index__section" aria-labelledby="missions-index-completed">
+        <h2 id="missions-index-completed" class="missions-index__section-title">Completed</h2>
+        <ul class="missions-index__grid">
+          <% @completed_missions.each do |mission| %>
+            <li><%= render "missions/mission_card", mission: mission, badge: "Completed" %></li>
+          <% end %>
+        </ul>
+      </section>
     <% end %>
 
     <% if @upcoming_missions.any? %>
@@ -46,9 +47,20 @@
       </section>
     <% end %>
 
+    <% if @draft_missions.any? %>
+      <section class="missions-index__section" aria-labelledby="missions-index-drafts">
+        <h2 id="missions-index-drafts" class="missions-index__section-title">Drafts</h2>
+        <ul class="missions-index__grid">
+          <% @draft_missions.each do |mission| %>
+            <li><%= render "missions/mission_card", mission: mission, badge: "Draft", manageable: true %></li>
+          <% end %>
+        </ul>
+      </section>
+    <% end %>
+
     <% if @ended_missions.any? %>
       <section class="missions-index__section missions-index__section--past" aria-labelledby="missions-index-past">
-        <h2 id="missions-index-past" class="missions-index__section-title">Past missions</h2>
+        <h2 id="missions-index-past" class="missions-index__section-title">Ended</h2>
         <ul class="missions-index__grid">
           <% @ended_missions.each do |mission| %>
             <li><%= render "missions/mission_card", mission: mission, badge: "Ended" %></li>

--- a/app/views/missions/show.html.erb
+++ b/app/views/missions/show.html.erb
@@ -12,6 +12,20 @@
         </div>
       <% end %>
 
+      <% if !@prerequisites_met && @unmet_prerequisites.any? %>
+        <div class="mission-home__locked">
+          <p class="mission-home__locked-message">
+            This mission is locked. Complete
+            <% @unmet_prerequisites.each_with_index do |prereq, i| %>
+              <%= ", " if i > 0 && i < @unmet_prerequisites.length - 1 %>
+              <%= " and " if i > 0 && i == @unmet_prerequisites.length - 1 %>
+              <%= link_to prereq.name, mission_path(prereq.slug), class: "mission-home__locked-link" %>
+            <% end %>
+            first to unlock it!
+          </p>
+        </div>
+      <% end %>
+
       <p class="mission-home__crumb">
         <span class="mission-home__crumb-links">
           <%= link_to "Missions", missions_path, class: "mission-home__crumb-link" %>
@@ -82,7 +96,7 @@
                         project_path(@active_project),
                         data: { turbo: false },
                         class: "action-btn action-btn--large action-btn--primary" %>
-          <% else %>
+          <% elsif @prerequisites_met %>
             <%= button_to "Create a project",
                           projects_setup_submit_mission_path,
                           method: :post,
@@ -123,7 +137,7 @@
 
         <%# Prizes card %>
         <% has_stardust = @mission.fixed_stardust_payout&.positive? %>
-        <% if @ordered_prizes.any? || has_stardust %>
+        <% if @ordered_prizes.any? || has_stardust || @unlocked_missions.any? %>
           <section class="mission-home__card mission-home__rewards"
                    aria-labelledby="mission-home-rewards">
             <h2 id="mission-home-rewards" class="mission-home__card-title">
@@ -161,6 +175,24 @@
                     <% if prize.shop_item.description.present? %>
                       <p class="mission-home__prize-blurb"><%= prize.shop_item.description %></p>
                     <% end %>
+                  </div>
+                </li>
+              <% end %>
+              <% @unlocked_missions.each_with_index do |unlocked, idx| %>
+                <% tone = tones[(tone_idx + @ordered_prizes.size + idx) % tones.length] %>
+                <li class="mission-home__prize mission-home__prize--<%= tone %>">
+                  <div class="mission-home__prize-tile">
+                    <% if unlocked.icon.attached? %>
+                      <%= image_tag unlocked.icon, alt: "", class: "mission-home__prize-img mission-home__prize-img--contain" %>
+                    <% else %>
+                      <svg viewBox="0 0 24 24" width="28" height="28" class="mission-home__prize-glyph" aria-hidden="true">
+                        <path d="M12 1.5 13.6 10.4 22.5 12 13.6 13.6 12 22.5 10.4 13.6 1.5 12 10.4 10.4Z" />
+                      </svg>
+                    <% end %>
+                  </div>
+                  <div class="mission-home__prize-body">
+                    <p class="mission-home__prize-title">Unlocks <%= link_to unlocked.name, mission_path(unlocked.slug) %></p>
+                    <p class="mission-home__prize-blurb">Completing this mission will unlock the <%= unlocked.name %> mission</p>
                   </div>
                 </li>
               <% end %>

--- a/app/views/missions/show.html.erb
+++ b/app/views/missions/show.html.erb
@@ -100,7 +100,9 @@
           <% end %>
           <% if @mission.has_guide? %>
             <%= link_to (@active_project ? "View guide" : "Preview guide"),
-                        guide_mission_path(@mission.slug),
+                        @mission.external_guide? ? @mission.guide_url : guide_mission_path(@mission.slug),
+                        target: @mission.external_guide? ? "_blank" : nil,
+                        rel: @mission.external_guide? ? "noopener" : nil,
                         data: { turbo: false },
                         class: "action-btn action-btn--large action-btn--secondary" %>
           <% end %>

--- a/app/views/missions/show.html.erb
+++ b/app/views/missions/show.html.erb
@@ -120,7 +120,8 @@
         <% end %>
 
         <%# Prizes card %>
-        <% if @ordered_prizes.any? %>
+        <% has_stardust = @mission.fixed_stardust_payout&.positive? %>
+        <% if @ordered_prizes.any? || has_stardust %>
           <section class="mission-home__card mission-home__rewards"
                    aria-labelledby="mission-home-rewards">
             <h2 id="mission-home-rewards" class="mission-home__card-title">
@@ -128,8 +129,21 @@
             </h2>
             <ul class="mission-home__prize-list">
               <% tones = %w[yellow lilac peach mint] %>
+              <% tone_idx = 0 %>
+              <% if has_stardust %>
+                <li class="mission-home__prize mission-home__prize--<%= tones[tone_idx % tones.length] %>">
+                  <div class="mission-home__prize-tile">
+                    <%= stardust_icon(extra_class: "mission-home__prize-img") %>
+                  </div>
+                  <div class="mission-home__prize-body">
+                    <p class="mission-home__prize-title"><%= @mission.fixed_stardust_payout %> stardust</p>
+                    <p class="mission-home__prize-blurb">Yours to spend in the shop!</p>
+                  </div>
+                </li>
+                <% tone_idx += 1 %>
+              <% end %>
               <% @ordered_prizes.each_with_index do |prize, idx| %>
-                <% tone = tones[idx % tones.length] %>
+                <% tone = tones[(tone_idx + idx) % tones.length] %>
                 <li class="mission-home__prize mission-home__prize--<%= tone %>">
                   <div class="mission-home__prize-tile">
                     <% if prize.shop_item.respond_to?(:image) && prize.shop_item.image.respond_to?(:attached?) && prize.shop_item.image.attached? %>

--- a/app/views/projects/_mission_panel.html.erb
+++ b/app/views/projects/_mission_panel.html.erb
@@ -52,16 +52,19 @@
         </div>
       </div>
 
+      <% guide_link = mission.external_guide? ? mission.guide_url : guide_mission_path(mission.slug) %>
+      <% guide_target = mission.external_guide? ? "_blank" : nil %>
+      <% guide_rel = mission.external_guide? ? "noopener" : nil %>
       <div class="mission-panel__actions">
         <% if mission.has_guide? %>
           <% if shipped %>
-            <%= link_to "View guide",
-                        guide_mission_path(mission.slug),
+            <%= link_to "View guide", guide_link,
+                        target: guide_target, rel: guide_rel,
                         data: { turbo: false },
                         class: "action-btn action-btn--small action-btn--secondary" %>
           <% else %>
-            <%= link_to (all_done ? "Review guide" : "Continue guide"),
-                        guide_mission_path(mission.slug),
+            <%= link_to (all_done ? "Review guide" : "Continue guide"), guide_link,
+                        target: guide_target, rel: guide_rel,
                         data: { turbo: false },
                         class: "action-btn action-btn--small action-btn--primary" %>
           <% end %>
@@ -101,7 +104,8 @@
             <%= render MarkdownContentComponent.new(markdown: next_step_body, flavor: :guide) %>
           </div>
           <%= link_to "Continue reading →",
-                      guide_mission_path(mission.slug, anchor: "step-#{next_step.id}"),
+                      mission.external_guide? ? mission.guide_url : guide_mission_path(mission.slug, anchor: "step-#{next_step.id}"),
+                      target: guide_target, rel: guide_rel,
                       data: { turbo: false },
                       class: "mission-panel__next-step-more" %>
         <% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -526,13 +526,27 @@
 
     <% if is_member && params[:just_shipped].present? %>
       <%
+        latest_submission = @project.posts
+          .where(postable_type: "Post::ShipEvent")
+          .order(created_at: :desc)
+          .first&.postable&.mission_submission
+        is_fixed_payout = latest_submission&.payout_path == "static_prize" &&
+                          latest_submission&.mission&.fixed_stardust_payout&.positive?
+
+        ship_tour_text = if is_fixed_payout
+          "Your ship is now in review. Once it's approved, you'll earn the mission's prizes!"
+        else
+          "Yay congrats on your first ship! To get your payout, you need to vote at least #{Post::ShipEvent::VOTES_REQUIRED_FOR_PAYOUT} times on other people's projects."
+        end
+
         ship_tour_steps = [
           {
-            selector: "[data-onboarding-target='rate']",
-            text: "Yay congrats on your first ship! To get your payout, you need to vote at least #{Post::ShipEvent::VOTES_REQUIRED_FOR_PAYOUT} times on other people's projects.",
+            selector: is_fixed_payout ? "body" : "[data-onboarding-target='rate']",
+            text: ship_tour_text,
             padding: 12,
-            radius: 12
-          }
+            radius: 12,
+            position: is_fixed_payout ? "center" : nil
+          }.compact
         ]
       %>
       <div class="welcome-tour"

--- a/db/migrate/20260604185520_add_fixed_stardust_payout_to_missions.rb
+++ b/db/migrate/20260604185520_add_fixed_stardust_payout_to_missions.rb
@@ -1,0 +1,5 @@
+class AddFixedStardustPayoutToMissions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :missions, :fixed_stardust_payout, :integer
+  end
+end

--- a/db/migrate/20260605193930_add_guide_url_to_missions.rb
+++ b/db/migrate/20260605193930_add_guide_url_to_missions.rb
@@ -1,0 +1,5 @@
+class AddGuideUrlToMissions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :missions, :guide_url, :string
+  end
+end

--- a/db/migrate/20260605202538_create_mission_prerequisites.rb
+++ b/db/migrate/20260605202538_create_mission_prerequisites.rb
@@ -1,0 +1,12 @@
+class CreateMissionPrerequisites < ActiveRecord::Migration[8.1]
+  def change
+    create_table :mission_prerequisites do |t|
+      t.references :prerequisite_mission, null: false, foreign_key: { to_table: :missions }
+      t.references :dependent_mission, null: false, foreign_key: { to_table: :missions }
+      t.timestamps
+    end
+
+    add_index :mission_prerequisites, [ :prerequisite_mission_id, :dependent_mission_id ],
+              unique: true, name: "idx_mission_prereqs_unique"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -357,6 +357,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_05_203545) do
     t.index ["user_id"], name: "index_mission_memberships_on_user_id"
   end
 
+  create_table "mission_prerequisites", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "dependent_mission_id", null: false
+    t.bigint "prerequisite_mission_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dependent_mission_id"], name: "index_mission_prerequisites_on_dependent_mission_id"
+    t.index ["prerequisite_mission_id", "dependent_mission_id"], name: "idx_mission_prereqs_unique", unique: true
+    t.index ["prerequisite_mission_id"], name: "index_mission_prerequisites_on_prerequisite_mission_id"
+  end
+
   create_table "mission_prizes", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "deleted_at"
@@ -455,6 +465,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_05_203545) do
     t.datetime "end_at"
     t.integer "estimated_completion_minutes"
     t.datetime "featured_at"
+    t.integer "fixed_stardust_payout"
+    t.string "guide_url"
     t.string "name", null: false
     t.integer "prizes_count", default: 0, null: false
     t.string "slug", null: false
@@ -1279,6 +1291,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_05_203545) do
   add_foreign_key "mission_guide_variants", "missions"
   add_foreign_key "mission_memberships", "missions"
   add_foreign_key "mission_memberships", "users"
+  add_foreign_key "mission_prerequisites", "missions", column: "dependent_mission_id"
+  add_foreign_key "mission_prerequisites", "missions", column: "prerequisite_mission_id"
   add_foreign_key "mission_prizes", "missions"
   add_foreign_key "mission_prizes", "shop_items"
   add_foreign_key "mission_section_completions", "mission_steps", on_delete: :cascade
@@ -1310,8 +1324,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_05_203545) do
   add_foreign_key "projects", "users", column: "marked_fire_by_id"
   add_foreign_key "projects", "users", column: "nominated_fire_by_id"
   add_foreign_key "raffle_participants", "raffle_weeks", column: "signup_week_id"
+  add_foreign_key "raffle_participants", "users"
   add_foreign_key "raffle_referrals", "raffle_participants", column: "participant_id"
   add_foreign_key "raffle_referrals", "raffle_weeks", column: "credited_week_id"
+  add_foreign_key "raffle_referrals", "users", column: "referred_user_id"
   add_foreign_key "raffle_weeks", "raffle_participants", column: "winner_participant_id"
   add_foreign_key "report_review_tokens", "project_reports", column: "report_id"
   add_foreign_key "reviewer_payout_requests", "users"


### PR DESCRIPTION
## what's this do?

A few things:
- adding fixed stardust payouts to missions! - this will appear in the prizes section and allow mission owners to assign a direct stardust payout to all completed submissions
- supporting external guides - some missions may have an external guide. While they're being ported, this allows you to directly link to the guides
- mission prereqs - this many to many schema allows mission attachment to be locked behind completion of other missions, allowing you to create chained pathways of missions
- split mission page - this just helps you to easily see which missions you have completed and which ones you have yet to embark on!
- misc. bug fixes

## show it works

<img width="687" height="351" alt="image" src="https://github.com/user-attachments/assets/f92a219e-f9da-41fd-ae02-6b82c881b3dc" />

## ai?

lots of claude, all hand reviewed
