### PR TITLE
feat(guides): add markdown-backed Outpost guides

### DIFF
--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -1,19 +1,24 @@
-Guide = Data.define(:slug, :title, :description, :category, :icon, :reading_minutes, :related) do
+Guide = Data.define(:slug, :title, :description, :category, :icon, :reading_minutes, :related, :markdown) do
   include ActiveModel::Conversion
   extend ActiveModel::Naming
 
-  self::CATEGORY_ORDER = %i[shipping craft program].freeze
+  self::CATEGORY_ORDER = %i[shipping craft program outpost].freeze
 
   self::CATEGORY_LABELS = {
     shipping: "Shipping",
     craft: "Craft",
-    program: "Program"
+    program: "Program",
+    outpost: "Hardware | Outpost"
   }.freeze
+
+  # Root directory that `markdown:` paths are resolved against.
+  self::TOPICS_ROOT = "app/views/guides/topics".freeze
 
   def initialize(params = {})
     params[:related] ||= []
     params[:icon] ||= "info"
     params[:reading_minutes] ||= 5
+    params[:markdown] ||= nil
     super(**params)
   end
 
@@ -80,6 +85,66 @@ Guide = Data.define(:slug, :title, :description, :category, :icon, :reading_minu
       icon: "info",
       reading_minutes: 3,
       related: []
+    ),
+    new(
+      slug: :outpost,
+      title: "Outpost",
+      description: "Stardance's hardware track — a 6-day hardware hackathon and expo with Open Sauce in San Francisco.",
+      category: :outpost,
+      icon: "rocket",
+      reading_minutes: 5,
+      related: %i[starting-hardware shipping-hardware outpost-tiers outpost-faq],
+      markdown: "outpost/outpost.md"
+    ),
+    new(
+      slug: :"starting-hardware",
+      title: "Starting your hardware project",
+      description: "How to get started with your hardware project — coming up with an idea and advice for working on it.",
+      category: :outpost,
+      icon: "compass_fill",
+      reading_minutes: 5,
+      related: %i[outpost shipping-hardware outpost-tiers],
+      markdown: "outpost/starting-hardware.md"
+    ),
+    new(
+      slug: :"shipping-hardware",
+      title: "Shipping your hardware project",
+      description: "Get your project ready to ship — required files, repository structure, and the step-by-step.",
+      category: :outpost,
+      icon: "ship",
+      reading_minutes: 5,
+      related: %i[starting-hardware outpost outpost-tiers],
+      markdown: "outpost/shipping-hardware.md"
+    ),
+    new(
+      slug: :"outpost-tiers",
+      title: "Project tier examples",
+      description: "What the different Outpost project tiers look like, with budgets, points, and examples for each.",
+      category: :outpost,
+      icon: "code",
+      reading_minutes: 4,
+      related: %i[outpost starting-hardware],
+      markdown: "outpost/tiers.md"
+    ),
+    new(
+      slug: :"outpost-faq",
+      title: "Outpost FAQ",
+      description: "Frequently asked questions about Outpost — channels, logistics, and more.",
+      category: :outpost,
+      icon: "info",
+      reading_minutes: 4,
+      related: %i[outpost starting-hardware shipping-hardware],
+      markdown: "outpost/faq.md"
+    ),
+    new(
+      slug: :"super-hardware-builder",
+      title: "Becoming a Super Hardware Builder",
+      description: "How to earn Super Hardware Builder status — the requirement to qualify for Outpost.",
+      category: :outpost,
+      icon: "rocket",
+      reading_minutes: 4,
+      related: %i[outpost starting-hardware],
+      markdown: "outpost/super-hardware-builder.md"
     )
   ].freeze
 
@@ -102,4 +167,20 @@ Guide = Data.define(:slug, :title, :description, :category, :icon, :reading_minu
   def related_guides = related.map { |s| Guide.find_by_slug(s) }.compact
 
   def partial_path = "guides/topics/#{slug}"
+
+  # A guide renders from a markdown file when `markdown:` points at one;
+  # otherwise it falls back to its `_<slug>.html.erb` partial (see show.html.erb).
+  def markdown? = markdown.present?
+
+  def markdown_path = markdown && Rails.root.join(self.class::TOPICS_ROOT, markdown)
+
+  # Raw markdown source for the body; nil for partial-backed guides. The view
+  # feeds this to MarkdownContentComponent (flavor: :guide), which renders via
+  # MarkdownRenderer.render_guide and wraps the output in .guide-content for
+  # styling. Read fresh each request; render_guide caches by content hash, so
+  # edits to the .md file appear immediately without a server restart.
+  def markdown_source
+    return nil unless markdown?
+    File.read(markdown_path)
+  end
 end

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -16,7 +16,11 @@
       </header>
 
       <div class="guide-article__body">
-        <%= render @guide.partial_path %>
+        <% if @guide.markdown? %>
+          <%= render MarkdownContentComponent.new(markdown: @guide.markdown_source, flavor: :guide) %>
+        <% else %>
+          <%= render @guide.partial_path %>
+        <% end %>
       </div>
 
       <% if @guide.related_guides.any? %>

--- a/app/views/guides/topics/outpost/faq.md
+++ b/app/views/guides/topics/outpost/faq.md
@@ -1,0 +1,28 @@
+# Outpost FAQ
+
+Join [#outpost](https://hackclub.enterprise.slack.com/archives/C0B04RP43TQ) if you have anything not answered!
+
+### There's a lot of channels! Which one do I use?
+
+tl;dr:
+
+- [#outpost](https://hackclub.enterprise.slack.com/archives/C0B04RP43TQ) - general discussion!
+- [#outpost-experts](https://hackclub.enterprise.slack.com/archives/C0B0CADUV3P) - get design help, or get your project reviewed!
+- [#outpost-idea-pool](https://hackclub.enterprise.slack.com/archives/C0B1MBF96GZ) - share ideas!
+- [#outpost-projects](https://hackclub.enterprise.slack.com/archives/C0B09B5UBV1) - post your project ships!
+
+### I bought Open Sauce tickets from Flavortown/Stasis/Etc! Is it valid for this event?
+
+Nope! Those are general admission tickets. You will be able to attend the main expo but you will not be able to participate in the Sauceathon or demo your project at the booths
+
+### Can I transfer my projects from Stasis/Fallout/Blueprint/etc?
+
+Yes, if you can no longer attend those events!
+
+## I have existing hardware and don't need funding!
+
+Awesome! You can collect points by submitting your build [here]
+
+### Can I pay visa fees with the travel stipend?
+
+Yes, after qualifying!

--- a/app/views/guides/topics/outpost/outpost.md
+++ b/app/views/guides/topics/outpost/outpost.md
@@ -1,0 +1,58 @@
+# Outpost
+
+Outpost is a 6-day hardware hackathon + expo we're hosting with [Open Sauce](https://opensauce.com)!
+
+First, after arriving in San Francisco with the projects you built, you'll team up with 2-3 other Hack Clubbers for a 4-day hardware hackathon to build out your demo booths.
+
+A booth is an 8x8 feet area that you'll share with your teammates to actually demo what you put! Here's some examples:
+
+![image](https://cdn.hackclub.com/019e45c8-371b-701c-af2f-c88daf56ea25/paste-1779287202837.png)
+
+At the hackathon, there'll be
+There'll be scrap wood, cardboard, hot glue, and electronics to throw together whatever crazy things you can. This is also the time to fix anything that might've broken on the way there!
+
+After that, you'll transport your hackathon projects + qualifier projects to Open Sauce and set it up to exhibit, where you'll be showcasing your projects to 35,000+ people that weekend with your fellow Hack Clubbers!
+
+## Qualifying
+
+To qualify, you will need:
+
+- [Super hardware builder status](/guides/super-hardware-builder)
+- ~30h worth of stardust (final amount will be released soonTM)
+    - You can earn discounts on this price by designing hardware projects! Check out [tiers](/guides/outpost-tiers)
+
+## What's provided:
+
+- Lodging during the hackathon on-site, and dorm rooms from
+- Breakfast, Lunch, and Dinner for the full event
+- $75 USD base flight stipend, where you can earn more through making more projects!
+- Funding for public transit between locations
+- Awesome swag (including jackets & t-shirts!)
+
+## Details:
+
+### Key locations:
+
+- **SFO**: San Francisco National Airport. This is the primary airport that you should be flying into, and the cheapest flight most likely flies into here.
+- **OAK**: Oakland San Francisco Bay Airport. A secondary airport that may _potentially_ have cheaper flights.
+- **San Mateo County Event Center**: This is the primary location that Open Sauce is hosted during the day
+- **Housing during Open Sauce**: This is where everybody will be staying during the nights between exhibit days!
+- **Hackathon Venue**: This is where the hackathon will be hosted! The exact location is currently TBD, but it will be in San Francisco
+
+### Schedule
+
+- **July 14th:** Arrive at SFO/OAK and get to the hackathon venue
+- **July 15th** Hacking day 1
+- **July 16th** Hacking day 2
+- **July 17th** Travel to Open Sauce venue, set up final booths
+- **July 18th** Day 1 of Open Sauce expo
+- **July 19th:** Day 2 of Open Sauce expo + teardown + travel back home
+- **July 20th:** Travel back home day 2, if needed!
+
+### Other logistics:
+
+Our safeguarding policies can be found here: https://hackclub.com/safeguarding
+
+## Contact:
+
+For any questions, please email Alex at alexren[at]hackclub.com

--- a/app/views/guides/topics/outpost/shipping-hardware.md
+++ b/app/views/guides/topics/outpost/shipping-hardware.md
@@ -1,0 +1,38 @@
+# Shipping your Hardware Projects
+
+Now that you have the design files, it's time to actually submit your project. Here's the step-by-step on how to do that.
+
+## 1. Make sure you have all of your project files!
+
+First off - check that all your project's files are actually in the repository! This includes a full CAD assembly in .STEP format, your PCB source files, and your firmware!
+
+Your directory structure should look something like this:
+
+```
+
+
+```
+
+## 2. Organize the different files!
+
+Next, you should organize all your different files!
+
+I recommend making 3 folders - one called "CAD", one called "PCB", and one called "firmware"
+
+Drag and drop your files into their respective folders
+
+## 3. Make a BOM.csv file!
+
+Now, write a BOM.csv so that everyone can see where to get parts for your project! It'll also help you order all the parts once you actually get your grant.
+
+There's a template [here](https://docs.google.com/spreadsheets/d/1maI6o3gMH7iFf2YkcOIJNg3B32JRLoNRscTOKz6hCpg/edit?usp=sharing)
+
+## 4. Write a README.md about your project!
+
+A README.md file is what ties your project together! It should include a short description of your project (what it does, how it works, why you made it), and also screenshots of your project!
+
+Make sure to include a screenshot of your PCB(s)/wiring diagram if applicable - it makes reviewing way easier for us and cuts down on time!
+
+## 5. Submit!
+
+If you're done your project, you can submit it by filling out [this form](https://forms.hackclub.com/opensauce2026-design)

--- a/app/views/guides/topics/outpost/starting-hardware.md
+++ b/app/views/guides/topics/outpost/starting-hardware.md
@@ -1,0 +1,47 @@
+# Starting your hardware project
+
+Hey there! This page covers how to get started with your hardware project and some advice for working on it
+
+_Hardware support is currently in development on the platform, but you can get started right now by following these steps!_
+
+## 1. Coming up with an idea
+
+First thing to do is to come up with an idea for your project!
+
+A good source of inspiration is [Adafruit Learn](https://learn.adafruit.com/)
+
+Drawing sketches at this stage helps a ton! Here's one I did for bitski, an LED keychain I'm working on:
+
+![image](https://cdn.hackclub.com/019e9a77-6da9-7745-953a-f195132b2cd8/paste-1780707978107.png)
+
+I highly recommend watching the [2025 Open Sauce recap video](https://www.youtube.com/watch?v=Cb_pny1DxlQ) to get an idea of what people usually make!
+
+## 2. Setting up your project
+
+Next step is creating your project!
+
+You'll need to create a GitHub repository. This is a place where you can store your project files online & manage the different versions! Here's what it looks like:
+
+![image](https://cdn.hackclub.com/019e9a79-de93-7e08-aabb-dacbb22af364/paste-1780708138037.png)
+
+You can find instructions on how to to make one [here](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository)
+
+Support for adding it to the Stardance platform will come soon! You won't lose any progress if you start now.
+
+## 3. Working on your design
+
+Once you've got everything set up, start working away!
+
+To track your time, you can use [Lapse](https://lapse.hackclub.com), our timelapsing tool.
+
+![image](https://cdn.hackclub.com/019e99b8-10ab-7d8c-bb5d-b70963131f05/paste-1780695436889.png)
+
+_here's what lapse looks like!_
+
+If you're having issues with lapse (i.e using Firefox, which is currently unsupported), you can write a markdown journal instead - you can find out more about that [here](https://codex.hackclub.com/shipping/journaling/)
+
+One resource you should definitely check out is the [Hardware Codex](https://codex.hackclub.com) - it's a collection of design resources to help you along your journey making projects!
+
+Make sure to ask tons of questions in [#outpost](https://hackclub.enterprise.slack.com/archives/C0B04RP43TQ) - the best source of advice is from your fellow hardware hackers!
+
+Once think you've finished your design, head on over to [Hardware Shipping](/guides/shipping-hardware) to get your project ready for shipping!

--- a/app/views/guides/topics/outpost/super-hardware-builder.md
+++ b/app/views/guides/topics/outpost/super-hardware-builder.md
@@ -1,0 +1,17 @@
+# Becoming a Super Hardware Builder
+
+To qualify for [Outpost](https://outpost.hackclub.com), you'll need to get Super Hardware Builder status!
+
+You can get Super Hardware Builder status by sharing the projects you've finshed building! The main question we ask ourselves when reviewing is whether or not your project would be interesting to share! Here's some examples
+
+| Yes                                                 | No                                  |
+| --------------------------------------------------- | ----------------------------------- |
+| 2-4 smaller projects                                | A single hackpad                    |
+| Custom 3D printer                                   | A generic RP2040 devboard           |
+| [Wacky Keyboard](http://hack.club/biblicalkeyboard) | generic drone (you can't fly this!) |
+
+The general rule of thumb is don't make anything generic! Want to make a keyboard? Add a slider! Have an idea for a unique project? Go for it!
+
+_If you're stuck for ideas I recommend checking this [recap of Open Sauce](https://www.youtube.com/watch?v=Cb_pny1DxlQ) and seeing what people made!_
+
+**Submit your projects [here!](https://forms.hackclub.com/submit-showcase-project)**

--- a/app/views/guides/topics/outpost/tiers.md
+++ b/app/views/guides/topics/outpost/tiers.md
@@ -1,0 +1,36 @@
+# Project tiers!
+
+Here are the different tiers of projects! If you're unsure, ask around in [#outpost](https://hackclub.enterprise.slack.com/archives/C0B04RP43TQ)
+
+## B tier ($25 funding, 30% Stardust off Outpost ticket)
+
+This is the most basic tier! For small stuff like macropads, basic PCBs, etc!
+
+## A tier ($120 funding, 50% Stardust off Outpost ticket)
+
+This is the next tier up! This is for more complex things like awesome custom devboards, gadgets, etc!
+
+Some examples are:
+
+- [@Tomas' Lora Travel Buddy](https://github.com/Tomas-Kuchta-FPV/Travel-Buddy)
+- [Hack Club's Orpheus Pico 2!](https://github.com/hackclub/orpheus-pico)
+- Drones!
+
+## S tier ($180 funding, 100% Stardust off Outpost ticket)
+
+This is for more complex projects or particularly demoable ones!
+
+Some examples are:
+
+- [@egg_splats biblically accurate keyboard!](https://www.reddit.com/r/MechanicalKeyboards/comments/1mf0fmm/the_biblically_accurate_keyboard/)
+- [@Kai Peireira's Cheetah MX4](https://github.com/KaiPereira/Cheetah-MX4-Mini/tree/master)
+- [@ConfusedHello's USB Mic](https://github.com/ConfusedHello/USB-Mic/)
+
+---
+
+## X tier
+
+Have a big idea you want to work on? This is the place! Comes with Outpost ticket + extra travel stipend. DM @alexren if you have an idea
+
+- [@Allen D's Ender-X4](https://github.com/ading2210/ender-x4)
+- [@koeg's Meko MP3 Player](https://github.com/KOEGlike/meko)


### PR DESCRIPTION


## what's this do?

Guides can now render their body from a .md file instead of a _<slug>.html.erb partial. When a registry entry sets `markdown:`, the show view renders it via MarkdownContentComponent (flavor: :guide) for proper .guide-content styling; partial-backed guides are unchanged.

Adds the Outpost / Hardware category with overview, starting-hardware, shipping-hardware, tiers, faq, and super-hardware-builder guides.

## show it works

<img width="937" height="877" alt="image" src="https://github.com/user-attachments/assets/1c46cd53-4261-47bb-8d66-b29e4a79fa5c" />

<img width="809" height="828" alt="image" src="https://github.com/user-attachments/assets/ebc60542-d733-4d25-bd60-2e0f0ae13a14" />


## ai?

yup used ts claude code
