### PR TITLE
chore(dependabot): add cooldown for new package versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,14 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7
+    semver-major-days: 14
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7
+    semver-major-days: 14


### PR DESCRIPTION
After adding a cooldown in https://github.com/hackclub/stardance/pull/407, this is how we can configure dependabot to follow a similar upgrade strategy

based on the [config in this](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates#setting-up-a-cooldown-period-for-dependency-updates)