### PR TITLE
Normalize devlog line endings before validation

### DIFF
--- a/app/models/post/devlog.rb
+++ b/app/models/post/devlog.rb
@@ -61,7 +61,18 @@ class Post::Devlog < ApplicationRecord
             },
             allow_nil: true,
             on: :create
+  
+  # Call normalizer prior to validation
+  before_validation :normalize_line_endings
+  
   validates :body, presence: true, length: { maximum: BODY_MAX_LENGTH }
+
+  private
+
+  # Normalize line endings (\r\n for now) to \n
+  def normalize_line_endings
+    self.body = body.gsub("\r\n", "\n") if body.present?
+  end
 
   after_create_commit :handle_post_creation
   after_update_commit :update_project_duration_if_changed

--- a/app/models/post/devlog.rb
+++ b/app/models/post/devlog.rb
@@ -61,10 +61,8 @@ class Post::Devlog < ApplicationRecord
             },
             allow_nil: true,
             on: :create
-  
   # Call normalizer prior to validation
   before_validation :normalize_line_endings
-  
   validates :body, presence: true, length: { maximum: BODY_MAX_LENGTH }
 
   private


### PR DESCRIPTION
## what's this do?

Normalizes devlog line endings before validation to prevent `\r\n` sequences from inflating the character count. This fixes an issue where devlogs under 4,000 characters were incorrectly rejected during form submission due to CRLF being used instead of LF.

## show it works

Added validation normalization that converts all CRLF line endings to LF before the length validator runs. Tested using `devlog_test` to ensure it worked

## ai?

N/A


## Error message on an 'ok' length:
<img width="2824" height="1342" alt="image" src="https://github.com/user-attachments/assets/a934e447-0ce7-4f44-bd36-fc89d8a980bd" />
<img width="916" height="138" alt="image" src="https://github.com/user-attachments/assets/69f8579f-d1f1-4c2b-9abc-9a91f3df9338" />
