### PR TITLE
feat(backfill): fix ship events stuck on pending after return

### DIFF
--- a/lib/tasks/backfill_returned_ship_events.rake
+++ b/lib/tasks/backfill_returned_ship_events.rake
@@ -1,0 +1,51 @@
+# Some projects got returned by shipwrights before recertification was there,
+# so their ship_event is stuck on "pending" even though the review is "returned".
+# This fixes that so the "Changes requested" badge shows up and they can resubmit.
+#
+# dry run:  bin/rails backfill:returned_ship_events
+# to apply: bin/rails backfill:returned_ship_events DRY_RUN=false
+
+namespace :backfill do
+  desc "Fix ship events stuck on 'pending' for projects that were already returned"
+  task returned_ship_events: :environment do
+    dry_run = ENV.fetch("DRY_RUN", "true") != "false"
+
+    puts dry_run ? "[DRY RUN] No changes will be written." : "Writing changes to the database."
+    puts
+
+    affected = Certification::Ship
+      .where(status: :returned)
+      .joins(:project)
+      .where(projects: { ship_status: "needs_changes" })
+      .includes(:project)
+
+    count = 0
+
+    affected.find_each do |ship_review|
+      project    = ship_review.project
+      ship_event = project.last_ship_event
+
+      unless ship_event
+        puts "  [SKIP] Project ##{project.id} \"#{project.title}\", no ship event found"
+        next
+      end
+
+      unless ship_event.certification_status == "pending"
+        puts "  [SKIP] Project ##{project.id} \"#{project.title}\", ship event already has status: #{ship_event.certification_status}"
+        next
+      end
+
+      puts "  [FIX] Project ##{project.id} \"#{project.title}\", ship event ##{ship_event.id}: pending → returned"
+
+      unless dry_run
+        ship_event.update!(certification_status: "returned")
+      end
+
+      count += 1
+    end
+
+    puts
+    puts "#{dry_run ? 'Would fix' : 'Fixed'} #{count} ship event(s)."
+    puts "Run with DRY_RUN=false to apply." if dry_run
+  end
+end


### PR DESCRIPTION
Before recertification was merged, some projects got returned by shipwrights but their ship_event.certification_status never got updated from "pending" to "returned". so the ship card kept showing "Pending review" with no way to reship.

this adds a backfill rake task to fix those :)

You can run it using
```
bin/rails backfill:returned_ship_events          # dry run
bin/rails backfill:returned_ship_events DRY_RUN=false
```
Results from my local db.
<img width="840" height="179" alt="image" src="https://github.com/user-attachments/assets/e68759c2-6e03-40ea-a56a-cabc2bc3aeb9" />
