### PR TITLE
adding in handling for delted projects

### DIFF
--- a/app/controllers/admin/certification/ysws_controller.rb
+++ b/app/controllers/admin/certification/ysws_controller.rb
@@ -14,6 +14,11 @@ class Admin::Certification::YswsController < Admin::Certification::ApplicationCo
       .find(params[:id])
     authorize @review
 
+    if @review.project.nil?
+      redirect_to admin_certification_ysws_reviews_path, alert: "Review ##{@review.id} has no associated project."
+      return
+    end
+
     # Check if review is already in unified DB
     @review.check_and_update_unified_db_status!
 
@@ -50,6 +55,8 @@ class Admin::Certification::YswsController < Admin::Certification::ApplicationCo
   def commits
     @review = ::Certification::Ysws.includes(:project).find(params[:id])
     authorize @review, :show?
+
+    return render json: { by_devlog: {}, repo_url: nil } if @review.project.nil?
 
     windows = devlog_windows_for_review(@review)
     commits_by_devlog = load_commits_with_stats(windows, @review.project)

--- a/app/jobs/certification/ysws_airtable_sync_job.rb
+++ b/app/jobs/certification/ysws_airtable_sync_job.rb
@@ -205,7 +205,12 @@ module Certification
 
       # Get media URLs
       banner_url = banner_url_for_project(project)
-      ship_event_screenshot_url = screenshot_url_for_ship_event(review.post_ship_event)
+      devlog_posts = review.devlog_reviews
+        .filter_map(&:post_devlog)
+        .sort_by(&:created_at)
+        .reverse
+      posts_to_check = [ review.post_ship_event, *devlog_posts ].compact
+      ship_event_screenshot_url = posts_to_check.lazy.filter_map { |p| screenshot_url_for_post(p) }.first
 
       {
         # Identity
@@ -366,10 +371,10 @@ module Certification
       nil
     end
 
-    def screenshot_url_for_ship_event(ship_event)
-      return nil unless ship_event
+    def screenshot_url_for_post(post)
+      return nil unless post
 
-      screenshot = ship_event.attachments.find { |a| a.image? }
+      screenshot = post.attachments.find { |a| a.image? }
       return nil unless screenshot
 
       host = ENV["APP_HOST"]

--- a/app/models/certification/ysws.rb
+++ b/app/models/certification/ysws.rb
@@ -45,7 +45,7 @@ module Certification
 
     belongs_to :reviewer, class_name: "User", optional: true
     belongs_to :user
-    belongs_to :project
+    belongs_to :project, -> { with_deleted }, optional: true
     belongs_to :ship_cert, class_name: "Certification::Ship", optional: true
     belongs_to :post_ship_event, class_name: "Post::ShipEvent"
     belongs_to :spotchecked_by, class_name: "User", optional: true


### PR DESCRIPTION
Adds handling for deleted projects. - page no longer crashing for them:

<img width="1279" height="725" alt="image" src="https://github.com/user-attachments/assets/1cd98bbf-eb3d-43ce-b64d-443d45038330" />
