### PR TITLE
fix(recertification): fixed the recertification modal not appearing for Hackpad projects

### DIFF
--- a/app/views/projects/_recert_modal.html.erb
+++ b/app/views/projects/_recert_modal.html.erb
@@ -1,0 +1,54 @@
+<% recert_review = project.ship_reviews.order(created_at: :desc).first %>
+<dialog id="recert-modal-<%= project.id %>"
+        class="recert-modal"
+        data-controller="modal"
+        aria-labelledby="recert-modal-<%= project.id %>-title">
+  <div class="recert-modal__panel">
+    <button type="button"
+            class="recert-modal__close"
+            onclick="document.getElementById(<%= "recert-modal-#{project.id}".to_json %>).close()"
+            aria-label="Close">
+      &times;
+    </button>
+
+    <h3 id="recert-modal-<%= project.id %>-title" class="recert-modal__title">Changes requested</h3>
+    <% if is_member %>
+      <p class="recert-modal__subtitle">Your reviewer left feedback below. Address it and then request re-certification.</p>
+    <% else %>
+      <p class="recert-modal__subtitle">Reviewer feedback and walkthrough left for this project.</p>
+    <% end %>
+
+    <% if recert_review&.verdict_video&.attached? %>
+      <div class="recert-modal__video-wrap">
+        <video class="recert-modal__video"
+               controls
+               preload="metadata"
+               src="<%= rails_blob_path(recert_review.verdict_video, disposition: :inline) %>">
+        </video>
+      </div>
+    <% end %>
+
+    <% if recert_review&.feedback.present? %>
+      <div class="recert-modal__feedback">
+        <h4 class="recert-modal__feedback-label">Reviewer feedback</h4>
+        <p class="recert-modal__feedback-body"><%= recert_review.feedback %></p>
+      </div>
+    <% end %>
+
+    <div class="recert-modal__actions">
+      <button type="button"
+              class="recert-modal__btn recert-modal__btn--secondary"
+              onclick="document.getElementById(<%= "recert-modal-#{project.id}".to_json %>).close()">
+        Close
+      </button>
+      <% if is_member || current_user&.can_review? %>
+        <% confirm_msg = is_member ? "Have you addressed the feedback? This will re-enter the review queue." : "This will request re-certification on behalf of the user. Continue?" %>
+        <%= button_to "Request re-certification",
+              project_recertification_path(project),
+              method: :post,
+              class: "recert-modal__btn recert-modal__btn--primary",
+              form: { data: { turbo_confirm: confirm_msg } } %>
+      <% end %>
+    </div>
+  </div>
+</dialog>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -686,60 +686,7 @@
   </div>
 
   <% if (is_member || current_user&.can_review?) && @project.needs_changes? %>
-    <% recert_review = @project.ship_reviews.order(created_at: :desc).first %>
-    <dialog id="recert-modal-<%= @project.id %>"
-            class="recert-modal"
-            data-controller="modal"
-            aria-labelledby="recert-modal-<%= @project.id %>-title">
-      <div class="recert-modal__panel">
-        <button type="button"
-                class="recert-modal__close"
-                onclick="document.getElementById(<%= "recert-modal-#{@project.id}".to_json %>).close()"
-                aria-label="Close">
-          &times;
-        </button>
-
-        <h3 id="recert-modal-<%= @project.id %>-title" class="recert-modal__title">Changes requested</h3>
-        <% if is_member %>
-          <p class="recert-modal__subtitle">Your reviewer left feedback below. Address it and then request re-certification.</p>
-        <% else %>
-          <p class="recert-modal__subtitle">Reviewer feedback and walkthrough left for this project.</p>
-        <% end %>
-
-        <% if recert_review&.verdict_video&.attached? %>
-          <div class="recert-modal__video-wrap">
-            <video class="recert-modal__video"
-                   controls
-                   preload="metadata"
-                   src="<%= rails_blob_path(recert_review.verdict_video, disposition: :inline) %>">
-            </video>
-          </div>
-        <% end %>
-
-        <% if recert_review&.feedback.present? %>
-          <div class="recert-modal__feedback">
-            <h4 class="recert-modal__feedback-label">Reviewer feedback</h4>
-            <p class="recert-modal__feedback-body"><%= recert_review.feedback %></p>
-          </div>
-        <% end %>
-
-        <div class="recert-modal__actions">
-          <button type="button"
-                  class="recert-modal__btn recert-modal__btn--secondary"
-                  onclick="document.getElementById(<%= "recert-modal-#{@project.id}".to_json %>).close()">
-            Close
-          </button>
-          <% if is_member || current_user&.can_review? %>
-            <% confirm_msg = is_member ? "Have you addressed the feedback? This will re-enter the review queue." : "This will request re-certification on behalf of the user. Continue?" %>
-            <%= button_to "Request re-certification",
-                  project_recertification_path(@project),
-                  method: :post,
-                  class: "recert-modal__btn recert-modal__btn--primary",
-                  form: { data: { turbo_confirm: confirm_msg } } %>
-          <% end %>
-        </div>
-      </div>
-    </dialog>
+    <%= render "projects/recert_modal", project: @project, is_member: is_member %>
   <% end %>
 
   <% if is_member && @composer_devlog && @composer_projects %>

--- a/app/views/projects/show_hackpad.html.erb
+++ b/app/views/projects/show_hackpad.html.erb
@@ -609,10 +609,12 @@
         <% @posts.each do |post| %>
           <% if post.postable_type == "Post::ShipEvent" %>
             <% ship_index += 1 %>
+            <% recert_id = ((is_member || current_user&.can_review?) && @project.needs_changes? && ship_index == 1) ? "recert-modal-#{@project.id}" : nil %>
             <%= render "projects/ship_card",
                        post: post,
                        project: @project,
-                       ship_number: ship_count - ship_index + 1 %>
+                       ship_number: ship_count - ship_index + 1,
+                       recert_modal_id: recert_id %>
           <% elsif post.postable_type == Post::PRIVATE_SHIP_DECISION_TYPE %>
             <%= render "users/ship_decision_card", post: post, decision: post.postable, project: @project %>
           <% else %>
@@ -665,6 +667,10 @@
     <% end %>
 
   </div>
+
+  <% if (is_member || current_user&.can_review?) && @project.needs_changes? %>
+    <%= render "projects/recert_modal", project: @project, is_member: is_member %>
+  <% end %>
 
   <% if is_member && @composer_devlog && @composer_projects %>
     <dialog id="composer-modal-<%= @project.id %>"


### PR DESCRIPTION

## what's this do?
This extracts the recertification modal to into a shared partial to make the templates DRY, and fixes a bug where hackpad projects had "changes requested" badge unclickable :)

## show it works
This screenshot from a hackpad project
<img width="1539" height="813" alt="image" src="https://github.com/user-attachments/assets/5f08edaf-91bc-4cd3-96a6-f6a3c1ed53e5" />

## ai?
Claude