### PR TITLE
feat(review): adding migrations for ship cert returns

### DIFF
--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -9,11 +9,13 @@
 #  feedback         :text
 #  internal_reason  :text
 #  lock_version     :integer          default(0), not null
+#  recert_reason    :text
 #  stardust_earned  :integer
 #  status           :integer          default("pending"), not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  project_id       :bigint           not null
+#  returned_by_id   :bigint
 #  reviewer_id      :bigint
 #
 # Indexes

--- a/app/models/certification/ysws.rb
+++ b/app/models/certification/ysws.rb
@@ -9,6 +9,7 @@
 #  in_unified_db         :string
 #  original_minutes      :integer
 #  repo_checked_at       :datetime
+#  returned_at           :datetime
 #  reviewed_at           :datetime
 #  spotchecked_at        :datetime
 #  summary_justification :text

--- a/app/models/post/ship_decision.rb
+++ b/app/models/post/ship_decision.rb
@@ -11,11 +11,13 @@
 #  feedback         :text
 #  internal_reason  :text
 #  lock_version     :integer          default(0), not null
+#  recert_reason    :text
 #  stardust_earned  :integer
 #  status           :integer          default("pending"), not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  project_id       :bigint           not null
+#  returned_by_id   :bigint
 #  reviewer_id      :bigint
 #
 # Indexes

--- a/db/migrate/20260609150518_add_recert_fields_to_certification_ship_reviews.rb
+++ b/db/migrate/20260609150518_add_recert_fields_to_certification_ship_reviews.rb
@@ -1,0 +1,6 @@
+class AddRecertFieldsToCertificationShipReviews < ActiveRecord::Migration[8.1]
+  def change
+    add_column :certification_ship_reviews, :recert_reason, :text
+    add_column :certification_ship_reviews, :returned_by_id, :bigint
+  end
+end

--- a/db/migrate/20260609150529_add_returned_at_to_certification_ysws_reviews.rb
+++ b/db/migrate/20260609150529_add_returned_at_to_certification_ysws_reviews.rb
@@ -1,0 +1,5 @@
+class AddReturnedAtToCertificationYswsReviews < ActiveRecord::Migration[8.1]
+  def change
+    add_column :certification_ysws_reviews, :returned_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_08_175849) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_09_150529) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
@@ -175,6 +175,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_175849) do
     t.text "internal_reason"
     t.integer "lock_version", default: 0, null: false
     t.bigint "project_id", null: false
+    t.text "recert_reason"
+    t.bigint "returned_by_id"
     t.bigint "reviewer_id"
     t.integer "stardust_earned"
     t.integer "status", default: 0, null: false
@@ -195,6 +197,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_175849) do
     t.bigint "post_ship_event_id", null: false
     t.bigint "project_id", null: false
     t.datetime "repo_checked_at", precision: nil
+    t.datetime "returned_at"
     t.datetime "reviewed_at", precision: nil
     t.bigint "reviewer_id"
     t.bigint "ship_cert_id"

--- a/test/models/certification/ship_test.rb
+++ b/test/models/certification/ship_test.rb
@@ -11,11 +11,13 @@
 #  feedback         :text
 #  internal_reason  :text
 #  lock_version     :integer          default(0), not null
+#  recert_reason    :text
 #  stardust_earned  :integer
 #  status           :integer          default("pending"), not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  project_id       :bigint           not null
+#  returned_by_id   :bigint
 #  reviewer_id      :bigint
 #
 # Indexes


### PR DESCRIPTION
This adds in columns used to mark ysws reviews as a "Returned to Shipwrights" - also adds in columns to ship certifications to allow them to be returned to shipwrights.