### PR TITLE
fix(homepage): composer fails to fetch hackatime when switching project without focus

### DIFF
--- a/app/javascript/controllers/composer_controller.js
+++ b/app/javascript/controllers/composer_controller.js
@@ -230,7 +230,7 @@ export default class extends Controller {
       if (editUrl) this.warnTarget.href = editUrl;
     }
 
-    if (this.#composerOpen) this.#loadPreviewTime();
+    this.#loadPreviewTime();
     this.#updateSubmit();
   }
 


### PR DESCRIPTION
previous behavior:
homepage devlog composer would only work when you switch a project if you click into the text writing area. otherwise, if you switch a project without clicking into the text writing area, it would show Loading time... indefinitely

<img width="661" height="156" alt="image" src="https://github.com/user-attachments/assets/28a119e6-ecac-4a77-873c-8e8fcebe8802" />



new behavior:

it now shows you the time immediately. yay!

<img width="750" height="212" alt="image" src="https://github.com/user-attachments/assets/b6de1167-df79-4495-8967-f78f80e2b5b5" />
