### PR TITLE
fix(videos): videos playback on ysws review page

### DIFF
--- a/app/assets/stylesheets/pages/admin/_ysws_reviews.scss
+++ b/app/assets/stylesheets/pages/admin/_ysws_reviews.scss
@@ -1163,12 +1163,22 @@ body:has(.certification-ysws) {
 
   // Video Card
   .video-card {
+    position: relative;
+    z-index: 1;
+
     h3 {
       color: var(--color-brand-lilac);
       font-size: var(--font-size-l);
       font-weight: 700;
       margin-bottom: var(--space-m);
       font-family: var(--font-family-sans);
+    }
+
+    &__player {
+      position: relative;
+      z-index: 2;
+      pointer-events: auto;
+      background: #000;
     }
 
     .video-placeholder {
@@ -2296,6 +2306,9 @@ body:has(.certification-ysws) {
       object-fit: contain;
       border-radius: var(--border-radius);
       box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+      position: relative;
+      z-index: 1;
+      pointer-events: auto;
 
       &.hidden {
         display: none;


### PR DESCRIPTION
## what's this do?

Playback videos were broken on ysws review page (for pending ships) , the issue was that there's a "Complete Review" placeholder that takes the full page width and overlapping the playback because of it's z-index, I added z-index to the video_player to prioritize it

## show it works


https://github.com/user-attachments/assets/00a820f9-dd6b-4597-9b70-d2858b4e18f5



## ai?

No

closes #470 
