### PR TITLE
fix(leaderboard): leaderboard numbering should start from 1 not 0

### DIFF
--- a/app/views/leaderboard/_row.html.erb
+++ b/app/views/leaderboard/_row.html.erb
@@ -1,5 +1,5 @@
 <%# locals: user:, user_counter:, value_method: %>
-<% rank = user_counter %>
+<% rank = user_counter + 1 %>
 <% is_current_user = current_user&.id == user.id %>
 <li class="leaderboard-row leaderboard-row--rank-<%= rank %> <%= 'leaderboard-row--current' if is_current_user %>">
   <span class="leaderboard-row__rank" aria-label="Rank <%= rank %>">#<%= rank %></span>


### PR DESCRIPTION
## what's this do?

Changes leaderboard numbering to start from 1 instead of 0 (which also ruined the CSS for top 3 ranks)

## show it works

Before:
<img width="713" height="658" alt="image" src="https://github.com/user-attachments/assets/108f8fea-b815-45a8-b952-c3dd21e89388" />

After:

<img width="712" height="652" alt="image" src="https://github.com/user-attachments/assets/8c540684-7132-4a90-9cb9-ffd9f023f541" />

## ai?

No
