### PR TITLE
Fix mission prize redemption

### DIFF
--- a/app/controllers/shop/base_controller.rb
+++ b/app/controllers/shop/base_controller.rb
@@ -65,13 +65,17 @@ class Shop::BaseController < ApplicationController
     }
   end
 
-  def load_redeemable_submission(shop_item)
+  def load_redeemable_submission(shop_item, lock: false)
     return nil unless current_user
     submission_id = params[:mission_submission_id]
     return nil if submission_id.blank?
 
-    submission = Mission::Submission
+    scope = Mission::Submission
       .includes(mission: :prizes, ship_event: { post: :user })
+
+    scope = scope.lock if lock
+
+    submission = scope
       .find_by(id: submission_id)
     return nil unless submission
     return nil unless submission.approved?

--- a/app/controllers/shop/orders_controller.rb
+++ b/app/controllers/shop/orders_controller.rb
@@ -97,6 +97,14 @@ class Shop::OrdersController < Shop::BaseController
         current_user.lock!
         @shop_item.lock! if @shop_item.limited?
 
+        if @mission_submission
+          @mission_submission = load_redeemable_submission(@shop_item, lock: true)
+          unless @mission_submission
+            redirect_to shop_path, alert: "This mission prize has already been redeemed."
+            return
+          end
+        end
+
         if @mission_submission.nil?
           user_balance = current_user.balance
           if total_cost > user_balance

--- a/app/views/shop/items/show.html.erb
+++ b/app/views/shop/items/show.html.erb
@@ -78,6 +78,9 @@
         <div class="shop-order__details" data-controller="order-form" data-order-form-has-addresses-value="<%= current_user.addresses.any? %>" data-order-form-base-ticket-cost-value="<%= @sale_price || @shop_item.ticket_cost || 0 %>" data-order-form-user-balance-value="<%= current_user.balance || 0 %>" data-order-form-addresses-value="<%= current_user.addresses.to_json %>" data-order-form-blocked-countries-value="<%= @shop_item.blocked_countries.to_json %>" data-order-form-stardust-icon-url-value="<%= image_path('icons/stardust.png') %>" data-action="address-select:change@document->order-form#addressChanged">
             <h2>Complete your order:</h2>
             <%= form_with url: shop_orders_path(shop_item_id: @shop_item.id), method: :post, local: true, id: "order-form" do |form| %>
+                <% if @mission_submission %>
+                    <%= form.hidden_field :mission_submission_id, value: @mission_submission.id %>
+                <% end %>
                 <% if not @shop_item.one_per_person_ever %>
                     <div class="shop-order__quantity">
                         <label class="shop-order__quantity-label" for="shop-order__quantity-input">Quantity</label>

--- a/test/controllers/shop/orders_controller_test.rb
+++ b/test/controllers/shop/orders_controller_test.rb
@@ -1,0 +1,153 @@
+require "test_helper"
+require "base64"
+require "stringio"
+
+class Shop::OrdersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create_user(
+      slack_id: "U_MISSION_PRIZE_#{SecureRandom.hex(6)}",
+      display_name: "mission-prize-#{SecureRandom.hex(4)}"
+    )
+    @user.update!(verification_status: "verified", ysws_eligible: true, has_gotten_free_stickers: true)
+
+    @shop_item = ShopItem.new(
+      name: "Mission Prize #{SecureRandom.hex(4)}",
+      description: "Mission-only prize",
+      ticket_cost: 0,
+      type: "ShopItem::ThirdPartyPhysical",
+      enabled: true,
+      enabled_us: true,
+      mission_prize_only: true
+    )
+    @shop_item.image.attach(
+      io: StringIO.new(Base64.decode64(test_png)),
+      filename: "mission_prize.png",
+      content_type: "image/png"
+    )
+    @shop_item.save!
+    @mission = Mission.create!(
+      slug: "mission-prize-#{SecureRandom.hex(6)}",
+      name: "Mission Prize",
+      description: "Complete the mission"
+    )
+    @prize = @mission.prizes.create!(shop_item: @shop_item)
+    @submission = create_approved_submission(@user, @mission)
+
+    sign_in @user
+  end
+
+  test "mission redemption form keeps submission id" do
+    with_identity_payload do
+      get shop_item_path(@shop_item, mission_submission_id: @submission.id)
+    end
+
+    assert_response :success
+    assert_select "input[type=hidden][name=mission_submission_id][value=?]", @submission.id.to_s
+  end
+
+  test "approved mission submission redeems mission-only prize" do
+    with_identity_payload do
+      assert_difference("ShopOrder.count", 1) do
+        post shop_orders_path(shop_item_id: @shop_item.id), params: order_params(@submission)
+      end
+    end
+
+    assert_redirected_to shop_orders_path
+    @submission.reload
+    assert_not_nil @submission.shop_order_id
+    assert_equal @prize.id, @submission.chosen_prize_id
+
+    order = ShopOrder.find(@submission.shop_order_id)
+    assert_equal @user.id, order.user_id
+    assert_equal @shop_item.id, order.shop_item_id
+    assert_equal 1, order.quantity
+  end
+
+  test "already redeemed mission submission cannot create another order" do
+    with_identity_payload do
+      post shop_orders_path(shop_item_id: @shop_item.id), params: order_params(@submission)
+    end
+
+    order_id = @submission.reload.shop_order_id
+
+    with_identity_payload do
+      assert_no_difference("ShopOrder.count") do
+        post shop_orders_path(shop_item_id: @shop_item.id), params: order_params(@submission)
+      end
+    end
+
+    assert_redirected_to shop_path
+    assert_equal order_id, @submission.reload.shop_order_id
+  end
+
+  private
+
+  def create_approved_submission(user, mission)
+    project = Project.create!(
+      title: "Mission Project #{SecureRandom.hex(4)}",
+      description: "Built for a mission"
+    )
+    project.memberships.create!(user: user, role: :owner)
+
+    ship_event = Post::ShipEvent.new(
+      body: "Finished the mission",
+      certification_status: "approved"
+    )
+    ship_event.attachments.attach(
+      io: StringIO.new(Base64.decode64(test_png)),
+      filename: "ship.png",
+      content_type: "image/png"
+    )
+    ship_event.save!
+    project.posts.create!(user: user, postable: ship_event)
+
+    submission = Mission::Submission.create!(
+      mission: mission,
+      ship_event: ship_event,
+      payout_path: "static_prize"
+    )
+    submission.certify!
+    submission.approve!
+    submission
+  end
+
+  def order_params(submission)
+    {
+      mission_submission_id: submission.id,
+      quantity: 3,
+      address_id: address_payload.fetch("id")
+    }
+  end
+
+  def with_identity_payload(&block)
+    original = HCAService.method(:identity)
+    payload = hca_payload
+    HCAService.define_singleton_method(:identity) { |*_args| payload }
+    block.call
+  ensure
+    HCAService.define_singleton_method(:identity, original)
+  end
+
+  def hca_payload
+    {
+      "addresses" => [ address_payload ],
+      "phone_number" => "+15555555555"
+    }
+  end
+
+  def address_payload
+    {
+      "id" => "addr_1",
+      "primary" => true,
+      "country" => "US",
+      "line1" => "1 Test St",
+      "city" => "New York",
+      "state" => "NY",
+      "postal_code" => "10001"
+    }
+  end
+
+  def test_png
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+  end
+end


### PR DESCRIPTION
## What changed

- Kept `mission_submission_id` in the mission prize checkout form.
- Revalidated the mission submission inside the order transaction with a row lock.
- Added controller tests for the redemption form, a successful claim, and a repeated claim attempt.

## Why

Mission prize redemption starts from a link that includes `mission_submission_id`, but the shop order form was not sending that value through to `Shop::OrdersController#create`. As a result, mission-only prizes could be treated like normal shop orders instead of being attached to the approved mission submission.

The order action also checked `shop_order_id: nil` before opening the transaction. This PR checks the submission again under lock before creating the order, so a stale or repeated request cannot claim the same submission twice.

## Validation

- `bundle exec rails test test/controllers/shop/orders_controller_test.rb`
- `bundle exec rails test test/models/shop_item_test.rb test/models/project_shop_tutorial_requirement_test.rb`
- `bundle exec ruby -c app/controllers/shop/base_controller.rb`
- `bundle exec ruby -c app/controllers/shop/orders_controller.rb`
- `bundle exec ruby -c test/controllers/shop/orders_controller_test.rb`

I also tried the related ship/shop test files. `test/models/post/ship_event_test.rb` and `test/jobs/shop/refresh_verification_status_job_test.rb` currently fail before reaching this change because their setup creates