### PR TITLE
chore: cleanup raffle admin dashboard duplicate code

### DIFF
--- a/app/controllers/admin/raffles/fraud_controller.rb
+++ b/app/controllers/admin/raffles/fraud_controller.rb
@@ -90,7 +90,7 @@ module Admin
       SQL
 
       def build_flagged_list
-        signals = Hash.new { |h, k| h[k] = { signals: [], total: 0 } }
+        signals = Hash.new { |h, k| h[k] = { signals: [] } }
 
         add_referred_ip_signals(signals)
         add_referrer_ip_signals(signals)

--- a/app/controllers/admin/raffles/participants_controller.rb
+++ b/app/controllers/admin/raffles/participants_controller.rb
@@ -30,19 +30,12 @@ module Admin
                                  .order(created_at: :desc)
       end
 
-      # ── Bulk actions (redirect back to wherever you came from) ─────────
+      # ── Bulk actions ──────────────────────────────────────────────────
 
       def reject_referrals
         authorize :admin, :access_raffles?
 
-        count = 0
-        ::PaperTrail.request(whodunnit: current_user.id) do
-          @participant.referrals.where.not(status: [ :self_referral, :rejected ]).find_each do |referral|
-            referral.paper_trail_event = "fraud_bulk_reject"
-            referral.update!(status: :rejected, credited_week: nil)
-            count += 1
-          end
-        end
+        count = reject_referrals_for(@participant.referrals.where.not(status: [ :self_referral, :rejected ]))
 
         redirect_back fallback_location: admin_raffles_participant_path(@participant),
                       allow_other_host: false,
@@ -66,26 +59,11 @@ module Admin
         authorize :admin, :access_raffles?
 
         user = @participant.user
-        unless user
-          return redirect_back fallback_location: admin_raffles_participant_path(@participant),
-                               allow_other_host: false,
-                               alert: "No linked platform user."
-        end
+        return redirect_back_with_alert("No linked platform user.") unless user
+        return redirect_back_with_alert("#{user.display_name} is already banned.") if user.banned?
 
-        if user.banned?
-          return redirect_back fallback_location: admin_raffles_participant_path(@participant),
-                               allow_other_host: false,
-                               alert: "#{user.display_name} is already banned."
-        end
-
-        reason = "Raffle referral fraud"
         ::PaperTrail.request(whodunnit: current_user.id) do
-          user.ban!(reason: reason)
-          ::PaperTrail::Version.create!(
-            item_type: "User", item_id: user.id, event: "banned",
-            whodunnit: current_user.id.to_s,
-            object_changes: { banned: [ false, true ], banned_reason: [ nil, reason ] }.to_json
-          )
+          ban_platform_user!(user, reason: "Raffle referral fraud")
           @participant.paper_trail_event = "fraud_ban_participant"
           @participant.update!(eligible: false)
         end
@@ -98,34 +76,15 @@ module Admin
       def ban_referred_users
         authorize :admin, :access_raffles?
 
-        reason = "Raffle referral fraud (referred by #{@participant.display_name})"
-        banned = 0
-        rejected = 0
-
-        ::PaperTrail.request(whodunnit: current_user.id) do
-          @participant.referrals.where.not(status: [ :self_referral, :rejected ]).find_each do |referral|
-            referral.paper_trail_event = "fraud_bulk_reject"
-            referral.update!(status: :rejected, credited_week: nil)
-            rejected += 1
-
-            user = referral.referred_user
-            next unless user && !user.banned?
-            user.ban!(reason: reason)
-            ::PaperTrail::Version.create!(
-              item_type: "User", item_id: user.id, event: "banned",
-              whodunnit: current_user.id.to_s,
-              object_changes: { banned: [ false, true ], banned_reason: [ nil, reason ] }.to_json
-            )
-            banned += 1
-          end
-        end
+        referrals = @participant.referrals.where.not(status: [ :self_referral, :rejected ])
+        rejected, banned = reject_and_ban_referrals(referrals)
 
         redirect_back fallback_location: admin_raffles_participant_path(@participant),
                       allow_other_host: false,
                       notice: "Rejected #{rejected} referral(s), banned #{banned} user(s)."
       end
 
-      # ── Checkbox bulk actions ──────────────────────────────────────────
+      # ── Checkbox actions ──────────────────────────────────────────────
 
       def reject_selected
         authorize :admin, :access_raffles?
@@ -133,14 +92,7 @@ module Admin
         referrals = selected_referrals
         return redirect_to admin_raffles_participant_path(@participant), alert: "Nothing selected." if referrals.empty?
 
-        count = 0
-        ::PaperTrail.request(whodunnit: current_user.id) do
-          referrals.each do |referral|
-            referral.paper_trail_event = "fraud_bulk_reject"
-            referral.update!(status: :rejected, credited_week: nil)
-            count += 1
-          end
-        end
+        count = reject_referrals_for(referrals)
 
         redirect_to admin_raffles_participant_path(@participant), notice: "Rejected #{count} referral(s)."
       end
@@ -151,33 +103,13 @@ module Admin
         referrals = selected_referrals
         return redirect_to admin_raffles_participant_path(@participant), alert: "Nothing selected." if referrals.empty?
 
-        reason = "Raffle referral fraud (referred by #{@participant.display_name})"
-        rejected = 0
-        banned = 0
-
-        ::PaperTrail.request(whodunnit: current_user.id) do
-          referrals.each do |referral|
-            referral.paper_trail_event = "fraud_bulk_reject"
-            referral.update!(status: :rejected, credited_week: nil)
-            rejected += 1
-
-            user = referral.referred_user
-            next unless user && !user.banned?
-            user.ban!(reason: reason)
-            ::PaperTrail::Version.create!(
-              item_type: "User", item_id: user.id, event: "banned",
-              whodunnit: current_user.id.to_s,
-              object_changes: { banned: [ false, true ], banned_reason: [ nil, reason ] }.to_json
-            )
-            banned += 1
-          end
-        end
+        rejected, banned = reject_and_ban_referrals(referrals)
 
         redirect_to admin_raffles_participant_path(@participant),
                     notice: "Rejected #{rejected} referral(s), banned #{banned} user(s)."
       end
 
-      # ── Per-referral actions (stay on participant page) ────────────────
+      # ── Single-referral actions ───────────────────────────────────────
 
       def reject_referral
         authorize :admin, :access_raffles?
@@ -197,21 +129,13 @@ module Admin
         referral = @participant.referrals.find(params[:referral_id])
         user = referral.referred_user
 
-        unless user && !user.banned?
-          return redirect_to admin_raffles_participant_path(@participant),
-                             alert: user&.banned? ? "Already banned." : "No linked user."
-        end
+        return redirect_to admin_raffles_participant_path(@participant), alert: "Already banned." if user&.banned?
+        return redirect_to admin_raffles_participant_path(@participant), alert: "No linked user." unless user
 
-        reason = "Raffle referral fraud"
         ::PaperTrail.request(whodunnit: current_user.id) do
           referral.paper_trail_event = "fraud_reject"
           referral.update!(status: :rejected, credited_week: nil) unless referral.status_rejected?
-          user.ban!(reason: reason)
-          ::PaperTrail::Version.create!(
-            item_type: "User", item_id: user.id, event: "banned",
-            whodunnit: current_user.id.to_s,
-            object_changes: { banned: [ false, true ], banned_reason: [ nil, reason ] }.to_json
-          )
+          ban_platform_user!(user, reason: "Raffle referral fraud")
         end
 
         redirect_to admin_raffles_participant_path(@participant),
@@ -258,6 +182,54 @@ module Admin
         @participant.referrals
                     .where(id: ids.map(&:to_i))
                     .where.not(status: [ :self_referral, :rejected ])
+      end
+
+      def reject_referrals_for(scope)
+        count = 0
+        ::PaperTrail.request(whodunnit: current_user.id) do
+          scope.find_each do |referral|
+            referral.paper_trail_event = "fraud_bulk_reject"
+            referral.update!(status: :rejected, credited_week: nil)
+            count += 1
+          end
+        end
+        count
+      end
+
+      def reject_and_ban_referrals(scope)
+        reason = "Raffle referral fraud (referred by #{@participant.display_name})"
+        rejected = 0
+        banned = 0
+
+        ::PaperTrail.request(whodunnit: current_user.id) do
+          scope.includes(:referred_user).find_each do |referral|
+            referral.paper_trail_event = "fraud_bulk_reject"
+            referral.update!(status: :rejected, credited_week: nil)
+            rejected += 1
+
+            user = referral.referred_user
+            next unless user && !user.banned?
+            ban_platform_user!(user, reason: reason)
+            banned += 1
+          end
+        end
+
+        [ rejected, banned ]
+      end
+
+      def ban_platform_user!(user, reason:)
+        user.ban!(reason: reason)
+        ::PaperTrail::Version.create!(
+          item_type: "User", item_id: user.id, event: "banned",
+          whodunnit: current_user.id.to_s,
+          object_changes: { banned: [ false, true ], banned_reason: [ nil, reason ] }.to_json
+        )
+      end
+
+      def redirect_back_with_alert(message)
+        redirect_back fallback_location: admin_raffles_participant_path(@participant),
+                      allow_other_host: false,
+                      alert: message
       end
 
       def participants_scope

--- a/engines/raffle/app/models/raffle/week.rb
+++ b/engines/raffle/app/models/raffle/week.rb
@@ -25,25 +25,23 @@ module Raffle
     # 20 per verified referral credited to this week.
     # Teens without HCA linked get 0 entries (excluded entirely).
     def standings
-      hca_linked_user_ids = ::User::Identity.where(provider: "hack_club").pluck(:user_id)
+      hca_linked_user_ids = ::User::Identity.where(provider: "hack_club").pluck(:user_id).to_set
+      banned_user_ids = ::User.where(banned: true).pluck(:id).to_set
+      eligible_participants = Raffle::Participant.where(eligible: true).index_by(&:id)
 
-      claimed_pids = weekly_claims.pluck(:participant_id)
-      claimed_participants = Raffle::Participant.where(id: claimed_pids, eligible: true)
-      base = claimed_participants.each_with_object({}) do |p, h|
-        next if p.age_group_teen? && !hca_linked_user_ids.include?(p.user_id)
-        h[p.id] = 1
+      can_enter = ->(pid) {
+        p = eligible_participants[pid]
+        p && !(p.user_id && banned_user_ids.include?(p.user_id)) &&
+          !(p.age_group_teen? && !hca_linked_user_ids.include?(p.user_id))
+      }
+
+      base = weekly_claims.pluck(:participant_id).each_with_object({}) do |pid, h|
+        h[pid] = 1 if can_enter.call(pid)
       end
 
-      referral_counts = credited_referrals.status_verified
-                                          .group(:participant_id)
-                                          .count
-
-      activated_pids = Raffle::Participant.where(id: referral_counts.keys).select do |p|
-        p.age_group_adult? || hca_linked_user_ids.include?(p.user_id)
-      end.map(&:id)
-
-      activated_pids.each do |pid|
-        base[pid] = (base[pid] || 0) + (referral_counts[pid] * 20)
+      credited_referrals.status_verified.group(:participant_id).count.each do |pid, count|
+        next unless can_enter.call(pid)
+        base[pid] = (base[pid] || 0) + (count * 20)
       end
 
       base


### PR DESCRIPTION
removes useless duplicate code from raffle admin fraud dashboard

also remove banned user count from the leaderboard and such