### PR TITLE
Add admin Super Star review dashboard

### DIFF
--- a/app/controllers/admin/super_stars_controller.rb
+++ b/app/controllers/admin/super_stars_controller.rb
@@ -1,0 +1,17 @@
+class Admin::SuperStarsController < Admin::ApplicationController
+  def show
+    authorize :super_star_dashboard
+
+    @pending_pagy, @pending_projects = pagy(
+      :offset,
+      ::Project.fire_nomination_pending.includes(:nominated_fire_by).order(nominated_fire_at: :asc),
+      page_key: "pending_page", limit: 25
+    )
+
+    @stars_pagy, @super_star_projects = pagy(
+      :offset,
+      ::Project.fire.includes(:marked_fire_by).order(marked_fire_at: :desc),
+      page_key: "stars_page", limit: 25
+    )
+  end
+end

--- a/app/controllers/projects/fire_nominations_controller.rb
+++ b/app/controllers/projects/fire_nominations_controller.rb
@@ -6,9 +6,9 @@ class Projects::FireNominationsController < ApplicationController
     authorize magic, :nominate?
 
     if magic.nominate(current_user)
-      redirect_to project_path(@project), notice: "Project nominated for Super Star."
+      redirect_back_or_to project_path(@project), notice: "Project nominated for Super Star."
     else
-      redirect_to project_path(@project), alert: magic.errors.full_messages.to_sentence
+      redirect_back_or_to project_path(@project), alert: magic.errors.full_messages.to_sentence
     end
   end
 
@@ -17,9 +17,9 @@ class Projects::FireNominationsController < ApplicationController
     authorize magic, :withdraw_nomination?
 
     if magic.withdraw_nomination(current_user)
-      redirect_to project_path(@project), notice: "Nomination withdrawn."
+      redirect_back_or_to project_path(@project), notice: "Nomination withdrawn."
     else
-      redirect_to project_path(@project), alert: magic.errors.full_messages.to_sentence
+      redirect_back_or_to project_path(@project), alert: magic.errors.full_messages.to_sentence
     end
   end
 

--- a/app/controllers/projects/magic_controller.rb
+++ b/app/controllers/projects/magic_controller.rb
@@ -6,9 +6,9 @@ class Projects::MagicController < ApplicationController
     authorize magic
 
     if magic.grant(current_user)
-      redirect_to project_path(@project), notice: "Project marked as Super Star."
+      redirect_back_or_to project_path(@project), notice: "Project marked as Super Star."
     else
-      redirect_to project_path(@project), alert: magic.errors.full_messages.to_sentence
+      redirect_back_or_to project_path(@project), alert: magic.errors.full_messages.to_sentence
     end
   end
 
@@ -17,9 +17,9 @@ class Projects::MagicController < ApplicationController
     authorize magic
 
     if magic.revoke(current_user)
-      redirect_to project_path(@project), notice: "Project unmarked as Super Star."
+      redirect_back_or_to project_path(@project), notice: "Project unmarked as Super Star."
     else
-      redirect_to project_path(@project), alert: magic.errors.full_messages.to_sentence
+      redirect_back_or_to project_path(@project), alert: magic.errors.full_messages.to_sentence
     end
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -67,6 +67,7 @@ class Project < ApplicationRecord
     user ? where.not(id: user.projects) : all
   }
   scope :fire, -> { where.not(marked_fire_at: nil) }
+  scope :fire_nomination_pending, -> { where.not(nominated_fire_at: nil).where(marked_fire_at: nil) }
   scope :with_ship_events, -> { joins(:ship_events).distinct }
   scope :with_ship_events_between, ->(start_date, end_date) {
     joins(:posts)

--- a/app/policies/admin/super_star_dashboard_policy.rb
+++ b/app/policies/admin/super_star_dashboard_policy.rb
@@ -1,0 +1,5 @@
+class Admin::SuperStarDashboardPolicy < ApplicationPolicy
+  def show?
+    user&.admin?
+  end
+end

--- a/app/views/admin/projects/index.html.erb
+++ b/app/views/admin/projects/index.html.erb
@@ -1,6 +1,8 @@
 <% content_for :title, "Project Search" %>
 <h1>Project Search</h1>
 
+<p><%= link_to "→ Super Stars", admin_super_stars_path %></p>
+
 <div>
   <%= link_to "Active", admin_projects_path(filter: "active", query: params[:query]) %>
   <%= link_to "Deleted", admin_projects_path(filter: "deleted", query: params[:query]) %>

--- a/app/views/admin/projects/index.html.erb
+++ b/app/views/admin/projects/index.html.erb
@@ -1,7 +1,9 @@
 <% content_for :title, "Project Search" %>
 <h1>Project Search</h1>
 
-<p><%= link_to "→ Super Stars", admin_super_stars_path %></p>
+<% if policy(:super_star_dashboard).show? %>
+  <p><%= link_to "→ Super Stars", admin_super_stars_path %></p>
+<% end %>
 
 <div>
   <%= link_to "Active", admin_projects_path(filter: "active", query: params[:query]) %>

--- a/app/views/admin/super_stars/show.html.erb
+++ b/app/views/admin/super_stars/show.html.erb
@@ -1,0 +1,77 @@
+<% content_for :title, "Super Stars" %>
+<h1>Super Stars</h1>
+
+<h2>Pending nominations (<%= @pending_pagy.count %>)</h2>
+<% if @pending_projects.any? %>
+  <table>
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Project</th>
+        <th>Nominated by</th>
+        <th>Nominated at</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @pending_projects.each do |project| %>
+        <tr>
+          <td><%= project.id %></td>
+          <td><%= link_to project.title, project_path(project) %></td>
+          <td><%= project.nominated_fire_by&.display_name %></td>
+          <td><%= project.nominated_fire_at.strftime("%Y-%m-%d %H:%M") %></td>
+          <td>
+            <%= button_to "Approve", project_magic_path(project), method: :post %>
+            <%= button_to "Reject", project_fire_nomination_path(project), method: :delete,
+                  data: { confirm: "Reject this Super Star nomination?" } %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  <% if @pending_pagy.pages > 1 %>
+    <div>
+      <%== @pending_pagy.series_nav %>
+    </div>
+  <% end %>
+<% else %>
+  <p>No pending nominations.</p>
+<% end %>
+
+<h2>Current Super Stars (<%= @stars_pagy.count %>)</h2>
+<% if @super_star_projects.any? %>
+  <table>
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Project</th>
+        <th>Marked by</th>
+        <th>Marked at</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @super_star_projects.each do |project| %>
+        <tr>
+          <td><%= project.id %></td>
+          <td><%= link_to project.title, project_path(project) %></td>
+          <td><%= project.marked_fire_by&.display_name %></td>
+          <td><%= project.marked_fire_at.strftime("%Y-%m-%d %H:%M") %></td>
+          <td>
+            <%= button_to "Remove", project_magic_path(project), method: :delete,
+                  data: { confirm: "Remove Super Star from this project?" } %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  <% if @stars_pagy.pages > 1 %>
+    <div>
+      <%== @stars_pagy.series_nav %>
+    </div>
+  <% end %>
+<% else %>
+  <p>No Super Star projects yet.</p>
+<% end %>
+
+<%= link_to "Go back", admin_projects_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -609,6 +609,7 @@ Rails.application.routes.draw do
         get  :votes
       end
     end
+    get "super_stars", to: "super_stars#show", as: :super_stars
     get "user-perms", to: "users#user_perms"
     resource :support, only: [ :show ], controller: "support/dashboards"
     resource :fraud, only: [ :show ], controller: "fraud/dashboards"

--- a/test/controllers/admin/super_stars_controller_test.rb
+++ b/test/controllers/admin/super_stars_controller_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class Admin::SuperStarsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = User.create!(slack_id: "U_SS_ADMIN", display_name: "ss_admin", email: "ss_admin@example.test")
+    @admin.grant_role!(:admin)
+    @nominator = User.create!(slack_id: "U_SS_NOM", display_name: "ss_nominator", email: "ss_nominator@example.test")
+
+    @pending = Project.create!(title: "Pending Nominee", nominated_fire_at: 1.day.ago, nominated_fire_by: @nominator)
+    @starred = Project.create!(title: "Already Starred", marked_fire_at: 2.days.ago, marked_fire_by: @admin)
+  end
+
+  test "admin sees pending nominations and current super stars" do
+    sign_in @admin
+
+    get admin_super_stars_path
+
+    assert_response :success
+    assert_select "td", text: "Pending Nominee"
+    assert_select "td", text: "Already Starred"
+  end
+
+  test "non-admin cannot access the page" do
+    sign_in @nominator
+
+    get admin_super_stars_path
+
+    assert_response :not_found
+  end
+end

--- a/test/controllers/admin/super_stars_controller_test.rb
+++ b/test/controllers/admin/super_stars_controller_test.rb
@@ -20,6 +20,20 @@ class Admin::SuperStarsControllerTest < ActionDispatch::IntegrationTest
     assert_select "td", text: "Already Starred"
   end
 
+  test "project search links to the dashboard for admins only" do
+    helper = User.create!(slack_id: "U_SS_HELPER", display_name: "ss_helper", email: "ss_helper@example.test")
+    helper.grant_role!(:helper)
+
+    sign_in @admin
+    get admin_projects_path
+    assert_select "a[href=?]", admin_super_stars_path
+
+    sign_in helper
+    get admin_projects_path
+    assert_response :success
+    assert_select "a[href=?]", admin_super_stars_path, count: 0
+  end
+
   test "non-admin cannot access the page" do
     sign_in @nominator
 


### PR DESCRIPTION
There was no page to see Super Star nominations waiting for review, you had to already know which project page to visit. This adds /admin/super_stars with a table of pending nominations (approve/reject inline) and a table of current Super Stars (remove). Both paginate separately at 25 a page.

The buttons post to the existing magic/fire_nomination routes so the policy checks and the papertrail auditing in Project::Magic stay the only pathway. Those controllers now redirect back instead of always going to the project page, so approving from the queue keeps you on the queue.

Tested: controller test for the admin view and the non-admin 404, plus clicked through approve/reject/remove and the pagination locally with 28 seeded nominations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Admin-gated UI reusing existing Super Star routes and policies; redirect behavior change is limited to those controllers.
> 
> **Overview**
> Adds an **admin-only** `/admin/super_stars` page so reviewers can work through Super Star nominations without visiting individual project pages.
> 
> The dashboard shows **pending nominations** and **current Super Stars** in separate paginated tables (25 per list, independent page keys). Inline actions post to the existing `project_magic` and `project_fire_nomination` routes (approve, reject/withdraw nomination, remove star). A `Project.fire_nomination_pending` scope backs the pending queue, and `Admin::SuperStarDashboardPolicy` gates access; project search shows a **→ Super Stars** link for admins only.
> 
> `Projects::MagicController` and `Projects::FireNominationsController` now use **`redirect_back_or_to`** instead of always redirecting to the project show page, so actions from the queue return to the dashboard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d9bbe94e0e351d1218d1c629632aa8e13e9ced0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->