### PR TITLE
add feedback templates to the ship review form

### DIFF
--- a/app/assets/stylesheets/pages/certification/ships/_show.scss
+++ b/app/assets/stylesheets/pages/certification/ships/_show.scss
@@ -345,6 +345,46 @@
     cursor: pointer;
   }
 
+  &__template-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+    align-items: center;
+  }
+
+  &__templates,
+  &__template-action {
+    padding: var(--space-xs) var(--space-s);
+    font-family: inherit;
+    font-size: 0.85rem;
+    color: var(--color-space-text);
+    cursor: pointer;
+    background: var(--color-space-surface, rgba(255, 255, 255, 0.04));
+    border: 1px solid var(--color-space-border, rgba(255, 255, 255, 0.18));
+    border-radius: 8px;
+
+    &:focus-visible {
+      outline: 2px solid var(--color-brand-highlight);
+      outline-offset: 1px;
+    }
+  }
+
+  &__template-action {
+    color: var(--color-brand-mint);
+
+    &:hover {
+      background: rgba(129, 255, 255, 0.08);
+    }
+
+    &--danger {
+      color: var(--color-brand-salmon);
+
+      &:hover {
+        background: rgba(255, 141, 157, 0.08);
+      }
+    }
+  }
+
   &__field {
     display: flex;
     flex-direction: column;

--- a/app/javascript/controllers/certification/feedback_templates_controller.js
+++ b/app/javascript/controllers/certification/feedback_templates_controller.js
@@ -1,0 +1,127 @@
+import { Controller } from "@hotwired/stimulus";
+
+const STORAGE_KEY = "certification-feedback-templates";
+
+// Canned request-changes responses for the ship review form. Options carry
+// their text in data-body; built-ins live in the "Standard" optgroup, and
+// the Shipwright's own templates are kept in localStorage and rendered into
+// the personal optgroup, where they can be saved and deleted without
+// leaving the form.
+export default class extends Controller {
+  static targets = [
+    "picker",
+    "feedback",
+    "returnedRadio",
+    "personalGroup",
+    "deleteButton",
+  ];
+
+  connect() {
+    this.renderPersonal();
+  }
+
+  insert() {
+    const option = this.pickerTarget.selectedOptions[0];
+    this.syncDeleteButton();
+    const body = option?.dataset.body;
+    if (!body) return;
+
+    if (
+      this.feedbackTarget.value.trim() !== "" &&
+      this.feedbackTarget.value !== this.lastInsertedBody &&
+      !confirm("Replace your current feedback with the template?")
+    ) {
+      this.pickerTarget.value = "";
+      this.syncDeleteButton();
+      return;
+    }
+
+    this.feedbackTarget.value = body;
+    this.lastInsertedBody = body;
+    if (this.hasReturnedRadioTarget) this.returnedRadioTarget.checked = true;
+    this.selectFirstBullet(body);
+  }
+
+  save() {
+    const body = this.feedbackTarget.value.trim();
+    if (body === "") {
+      alert("Write the feedback you want to save first.");
+      return;
+    }
+    const label = prompt("Name this template:")?.trim();
+    if (!label) return;
+
+    const templates = this.personalTemplates().filter((t) => t.label !== label);
+    templates.push({ label, body });
+    templates.sort((a, b) => a.label.localeCompare(b.label));
+    this.storePersonal(templates);
+
+    this.renderPersonal();
+    this.selectPersonal(label);
+    this.lastInsertedBody = body;
+    this.syncDeleteButton();
+  }
+
+  delete() {
+    const option = this.pickerTarget.selectedOptions[0];
+    const label = option?.dataset.personal && option.textContent;
+    if (!label) return;
+    if (!confirm(`Delete your "${label}" template?`)) return;
+
+    this.storePersonal(
+      this.personalTemplates().filter((t) => t.label !== label),
+    );
+    this.renderPersonal();
+    this.pickerTarget.value = "";
+    this.syncDeleteButton();
+  }
+
+  renderPersonal() {
+    this.personalGroupTarget.replaceChildren(
+      ...this.personalTemplates().map((template) => {
+        const option = document.createElement("option");
+        option.textContent = template.label;
+        option.dataset.body = template.body;
+        option.dataset.personal = "true";
+        return option;
+      }),
+    );
+  }
+
+  selectPersonal(label) {
+    const option = [...this.personalGroupTarget.children].find(
+      (o) => o.textContent === label,
+    );
+    if (option) option.selected = true;
+  }
+
+  // Only the Shipwright's own templates can be deleted, so the button is
+  // hidden unless a personal one is selected.
+  syncDeleteButton() {
+    const option = this.pickerTarget.selectedOptions[0];
+    this.deleteButtonTarget.hidden = !option?.dataset.personal;
+  }
+
+  // Highlight the first bullet so the reviewer can type the actual change
+  // straight over the placeholder.
+  selectFirstBullet(body) {
+    this.feedbackTarget.focus();
+    const match = body.match(/^- (.+)$/m);
+    if (!match) return;
+    const start = match.index + 2;
+    this.feedbackTarget.setSelectionRange(start, start + match[1].length);
+  }
+
+  personalTemplates() {
+    try {
+      const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+      return parsed.filter((t) => t?.label && t?.body);
+    } catch {
+      return [];
+    }
+  }
+
+  storePersonal(templates) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(templates));
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -34,6 +34,12 @@ application.register(
   Certification__Ysws__DevlogTimeChartController,
 );
 
+import Certification__FeedbackTemplatesController from "./certification/feedback_templates_controller";
+application.register(
+  "certification--feedback-templates",
+  Certification__FeedbackTemplatesController,
+);
+
 import Certification__QueueController from "./certification/queue_controller";
 application.register("certification--queue", Certification__QueueController);
 

--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -53,6 +53,29 @@ module Certification
 
     ACCEPTED_VIDEO_TYPES = %w[video/mp4 video/webm video/quicktime].freeze
 
+    # Canned request-changes responses offered on the review form. The opener
+    # is the standard wording Shipwrights use for low-quality submissions;
+    # reviewers replace the bullets with the specific changes they want.
+    FEEDBACK_TEMPLATES = [
+      {
+        label: "Doesn't meet quality standards",
+        body: <<~TEXT.strip
+          Your project doesn't meet our quality standards. We're requesting the following changes to get it ready for voting!
+          - Change 1
+          - Change 2
+          - Change 3
+        TEXT
+      },
+      {
+        label: "AI-generated look & feel",
+        body: <<~TEXT.strip
+          Your project doesn't meet our quality standards. We're requesting the following changes to get it ready for voting!
+          - Rework the styling so it doesn't lean on generic AI-generated gradients, give the project a look of its own
+          - Add some creative features that make the project worth spending time on
+        TEXT
+      }
+    ].freeze
+
     validates :feedback, length: { maximum: 10_000 }, allow_blank: true
     validates :verdict_video,
               content_type: { in: ACCEPTED_VIDEO_TYPES, spoofing_protection: true }

--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -60,18 +60,20 @@ module Certification
       {
         label: "Doesn't meet quality standards",
         body: <<~TEXT.strip
-          Your project doesn't meet our quality standards. We're requesting the following changes to get it ready for voting!
+          Hey! Thanks for shipping your project. It's not quite ready for voting yet, so here's what we'd like you to change:
           - Change 1
           - Change 2
           - Change 3
+          Once you've made these, ship it again and we'll take another look!
         TEXT
       },
       {
         label: "AI-generated look & feel",
         body: <<~TEXT.strip
-          Your project doesn't meet our quality standards. We're requesting the following changes to get it ready for voting!
+          Hey! Thanks for shipping your project. It's not quite ready for voting yet, so here's what we'd like you to change:
           - Rework the CSS, right now it looks like every other AI-made site. Give it your own style.
           - Add a couple of features you came up with yourself to make it more fun to use.
+          Once you've made these, ship it again and we'll take another look!
         TEXT
       }
     ].freeze

--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -70,8 +70,8 @@ module Certification
         label: "AI-generated look & feel",
         body: <<~TEXT.strip
           Your project doesn't meet our quality standards. We're requesting the following changes to get it ready for voting!
-          - Rework the styling so it doesn't lean on generic AI-generated gradients, give the project a look of its own
-          - Add some creative features that make the project worth spending time on
+          - Rework the CSS, right now it looks like every other AI-made site. Give it your own style.
+          - Add a couple of features you came up with yourself to make it more fun to use.
         TEXT
       }
     ].freeze

--- a/app/views/admin/certification/ships/_form.html.erb
+++ b/app/views/admin/certification/ships/_form.html.erb
@@ -7,7 +7,7 @@
 <%# The video-drop controller sits on the form (not the drop zone) so its
     submitBtn target is in scope and it can block submits mid-upload. %>
 <%= form_with model: ship, url: admin_certification_ship_path(ship), method: :patch, class: "review-form",
-      data: { controller: "certification--video-drop",
+      data: { controller: "certification--video-drop certification--feedback-templates",
               action: "submit->certification--video-drop#guardSubmit",
               "certification--video-drop-over-class": "video-drop--over",
               "certification--video-drop-uploading-class": "video-drop--uploading",
@@ -39,14 +39,39 @@
       <span>Approve</span>
     </label>
     <label class="review-form__option">
-      <%= f.radio_button :status, "returned", required: true %>
+      <%= f.radio_button :status, "returned", required: true,
+            data: { "certification--feedback-templates-target": "returnedRadio" } %>
       <span>Reject</span>
     </label>
   </fieldset>
 
   <div class="review-form__field">
     <%= f.label :feedback, "Feedback for the user (visible to the project owner)" %>
-    <%= f.text_area :feedback, rows: 6, maxlength: 10_000 %>
+    <div class="review-form__template-bar">
+      <select class="review-form__templates" aria-label="Insert a feedback template"
+              data-certification--feedback-templates-target="picker"
+              data-action="certification--feedback-templates#insert">
+        <option value="" selected>Insert a template&hellip;</option>
+        <optgroup label="Standard">
+          <% Certification::Ship::FEEDBACK_TEMPLATES.each do |template| %>
+            <option data-body="<%= template[:body] %>"><%= template[:label] %></option>
+          <% end %>
+        </optgroup>
+        <%# Filled client-side from localStorage by the feedback-templates controller. %>
+        <optgroup label="Your templates" data-certification--feedback-templates-target="personalGroup"></optgroup>
+      </select>
+      <button type="button" class="review-form__template-action"
+              data-action="certification--feedback-templates#save">
+        Save feedback as template
+      </button>
+      <button type="button" class="review-form__template-action review-form__template-action--danger"
+              data-certification--feedback-templates-target="deleteButton"
+              data-action="certification--feedback-templates#delete" hidden>
+        Delete template
+      </button>
+    </div>
+    <%= f.text_area :feedback, rows: 6, maxlength: 10_000,
+          data: { "certification--feedback-templates-target": "feedback" } %>
   </div>
 
   <div class="review-form__field">


### PR DESCRIPTION
Follow-up to the review quality crackdown announcement, which promised templates in the reviewing dashboard. The ship review form now has a template picker above the feedback textarea with the standard request-changes wording from the announcement, plus an AI-slop variant with the styling and creative-features bullets prefilled.

Shipwrights can also save their own templates: write feedback, hit save, name it, and it shows up in a personal group in the picker with inline delete. Personal templates live in localStorage, so there's no migration or server state, the whole feature is one Stimulus controller plus form markup. Inserting a template flips the verdict to returned and highlights the first bullet so you can type the actual change straight over the placeholder.

The built-in bodies live as a constant on Certification::Ship next to the feedback validation, so adding a shared template later is a one-entry edit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side review UX only; verdict submission and feedback validation are unchanged, with no server persistence for personal templates.
> 
> **Overview**
> Adds **feedback templates** to the admin ship review form so Shipwrights can insert standard “request changes” wording and maintain personal snippets without leaving the page.
> 
> A template bar sits above the feedback textarea: a **Standard** optgroup is populated from new `Certification::Ship::FEEDBACK_TEMPLATES` (quality-standards and AI look-and-feel variants), plus **Your templates** filled client-side from **localStorage**. Choosing a template fills the textarea, checks **Reject**, and selects the first bullet placeholder for quick editing; save/delete personal templates use prompts/confirms. Styling for the bar and controls is added under `.review-form`, and a new Stimulus controller `certification--feedback-templates` is registered alongside the existing video-drop controller on the verdict form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7f5ba49bd46a388b899974e8fc38ea55b659c1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->