### PR TITLE
show submitter history beside the ship review form

### DIFF
--- a/app/assets/stylesheets/pages/certification/ships/_show.scss
+++ b/app/assets/stylesheets/pages/certification/ships/_show.scss
@@ -280,6 +280,88 @@
   }
 }
 
+// Submitter track record in the review sidebar, after sw-dash's cert history:
+// one linked card per review with verdict pill, reviewer, and feedback. The
+// review being shown is highlighted as the "you're here" card.
+.submitter-history {
+  &__summary {
+    margin: 0 0 var(--space-m);
+    font-size: 0.875rem;
+    color: var(--muted);
+  }
+
+  &__cards {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-s);
+    max-height: 340px;
+    overflow-y: auto;
+  }
+
+  &__card {
+    display: block;
+    padding: var(--space-s) var(--space-m);
+    color: inherit;
+    text-decoration: none;
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid var(--card-border);
+    border-radius: 12px;
+    transition: border-color 120ms ease;
+
+    &:hover,
+    &:focus-visible {
+      border-color: var(--accent);
+    }
+
+    &--current {
+      background: rgba(129, 255, 255, 0.06);
+      border-color: rgba(129, 255, 255, 0.45);
+    }
+  }
+
+  &__card-head {
+    display: flex;
+    align-items: center;
+    gap: var(--space-s);
+  }
+
+  &__card-id {
+    font-size: 0.8rem;
+    font-variant-numeric: tabular-nums;
+    color: var(--muted);
+  }
+
+  &__card-here {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--accent);
+    white-space: nowrap;
+  }
+
+  &__card-date {
+    margin-left: auto;
+    font-size: 0.8rem;
+    color: var(--muted);
+    white-space: nowrap;
+  }
+
+  &__card-meta {
+    margin-top: var(--space-xs);
+    font-size: 0.875rem;
+    font-weight: 600;
+    overflow-wrap: anywhere;
+  }
+
+  &__card-feedback {
+    margin: var(--space-xs) 0 0;
+    font-size: 0.85rem;
+    line-height: var(--line-height-body);
+    color: var(--muted);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+}
+
 // Verdict form (_form.html.erb), shown in the review sidebar.
 .review-form {
   display: flex;

--- a/app/assets/stylesheets/pages/certification/ships/_show.scss
+++ b/app/assets/stylesheets/pages/certification/ships/_show.scss
@@ -149,6 +149,9 @@
   }
 
   &__sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-m);
     position: sticky;
     top: var(--space-l);
 

--- a/app/assets/stylesheets/pages/certification/ships/_show.scss
+++ b/app/assets/stylesheets/pages/certification/ships/_show.scss
@@ -352,6 +352,11 @@
     overflow-wrap: anywhere;
   }
 
+  &__card-deleted {
+    font-weight: 400;
+    color: var(--color-brand-salmon);
+  }
+
   &__card-feedback {
     margin: var(--space-xs) 0 0;
     font-size: 0.85rem;

--- a/app/controllers/admin/certification/ships_controller.rb
+++ b/app/controllers/admin/certification/ships_controller.rb
@@ -71,7 +71,7 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
   # Also loaded for update so the re-rendered show page keeps the submitter
   # panel when the verdict form fails validation.
   def set_submitter_context
-    @owner = @ship.project.memberships.find(&:owner?)&.user
+    @owner = @ship.owner
     @submitter_history = @owner && ::Certification::Ship.submitter_history(@owner)
   end
 

--- a/app/controllers/admin/certification/ships_controller.rb
+++ b/app/controllers/admin/certification/ships_controller.rb
@@ -1,6 +1,7 @@
 class Admin::Certification::ShipsController < Admin::Certification::ApplicationController
   before_action :release_other_claims, only: [ :next ]
   before_action :set_ship, only: [ :show, :update ]
+  before_action :set_submitter_context, only: [ :show, :update ]
   before_action :set_body_class, only: [ :index, :show, :update ]
 
   def index
@@ -66,6 +67,13 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
   end
 
   private
+
+  # Also loaded for update so the re-rendered show page keeps the submitter
+  # panel when the verdict form fails validation.
+  def set_submitter_context
+    @owner = @ship.project.memberships.find(&:owner?)&.user
+    @submitter_history = @owner && ::Certification::Ship.submitter_history(@owner)
+  end
 
   def set_ship
     @ship = ::Certification::Ship.find(params[:id])

--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -156,7 +156,7 @@ module Certification
         projects: scope.distinct.count(:project_id),
         approved: counts["approved"].to_i,
         returned: counts["returned"].to_i,
-        last_returned: scope.returned.order(decided_at: :desc).first
+        recent: scope.includes(:project, :reviewer, :returned_by).order(created_at: :desc).limit(6)
       }
     end
 

--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -56,6 +56,10 @@ module Certification
       super || project_with_deleted
     end
 
+    def owner
+      @owner ||= project.memberships.owner.first&.user
+    end
+
     enum :status, {
       pending: 0,
       approved: 1,
@@ -246,10 +250,6 @@ module Certification
         project: project,
         ship_cert_id: id
       ).call
-    end
-
-    def owner
-      @owner ||= project.memberships.owner.first&.user
     end
 
     def post_decision_to_timeline!

--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -144,6 +144,22 @@ module Certification
            .map { |name, count| { name: name, count: count } }
     end
 
+    # Verdict history across every project this user owns. Shown beside the
+    # review form so Shipwrights judging a gray-area project can see whether
+    # the submitter keeps getting returned for low quality.
+    def self.submitter_history(user)
+      scope = joins(project: :memberships)
+                .where(project_memberships: { user_id: user.id, role: :owner })
+      counts = scope.group(:status).count
+      {
+        total: counts.values.sum,
+        projects: scope.distinct.count(:project_id),
+        approved: counts["approved"].to_i,
+        returned: counts["returned"].to_i,
+        last_returned: scope.returned.order(decided_at: :desc).first
+      }
+    end
+
     # How many reviews this reviewer has decided today. Drives the momentum
     # counter on the review page, so it's scoped to the user, not the queue.
     def self.reviewed_today(user, now: Time.current)

--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -37,6 +37,10 @@ module Certification
     include Certification::Reviewable
 
     belongs_to :project
+    # Same record as :project but visible through soft deletion, so submitter
+    # history can still name projects deleted after a verdict.
+    belongs_to :project_with_deleted, -> { with_deleted }, class_name: "Project",
+               foreign_key: :project_id, optional: true
     belongs_to :reviewer, class_name: "User", optional: true
     belongs_to :returned_by, class_name: "User", optional: true
 
@@ -44,6 +48,13 @@ module Certification
 
     # The reviewer records a walkthrough and passes it along with the verdict.
     has_one_attached :verdict_video
+
+    # Admins can force-delete shipped projects; fall through to the deleted
+    # record so review pages (and submitter history cards linking to them)
+    # still render instead of crashing on a nil project.
+    def project
+      super || project_with_deleted
+    end
 
     enum :status, {
       pending: 0,
@@ -146,17 +157,20 @@ module Certification
 
     # Verdict history across every project this user owns. Shown beside the
     # review form so Shipwrights judging a gray-area project can see whether
-    # the submitter keeps getting returned for low quality.
+    # the submitter keeps getting returned for low quality. Goes through
+    # memberships rather than joining projects so reviews keep counting after
+    # their project is soft-deleted — deleting a returned project and
+    # resubmitting is exactly the pattern this panel exists to surface.
     def self.submitter_history(user)
-      scope = joins(project: :memberships)
-                .where(project_memberships: { user_id: user.id, role: :owner })
+      owned = Project::Membership.where(user_id: user.id, role: :owner).select(:project_id)
+      scope = where(project_id: owned)
       counts = scope.group(:status).count
       {
         total: counts.values.sum,
         projects: scope.distinct.count(:project_id),
         approved: counts["approved"].to_i,
         returned: counts["returned"].to_i,
-        recent: scope.includes(:project, :reviewer, :returned_by).order(created_at: :desc).limit(6)
+        recent: scope.includes(:project_with_deleted, :reviewer, :returned_by).order(created_at: :desc).limit(6)
       }
     end
 

--- a/app/views/admin/certification/ships/show.html.erb
+++ b/app/views/admin/certification/ships/show.html.erb
@@ -101,29 +101,45 @@
 
       <aside class="ship-review__sidebar">
         <% if @submitter_history %>
-          <div class="ship-review__panel">
+          <div class="ship-review__panel submitter-history">
             <h2 class="ship-review__panel-title">Submitter history</h2>
             <% if @submitter_history[:total] <= 1 %>
               <p class="ship-review__description">First submission from <%= @owner.display_name %>.</p>
             <% else %>
-              <dl class="ship-review__meta">
-                <dt>Submitted</dt>
-                <dd><%= pluralize(@submitter_history[:total], "review") %> across <%= pluralize(@submitter_history[:projects], "project") %></dd>
-                <dt>Verdicts</dt>
-                <dd>
-                  <span class="status-pill status-pill--approved"><%= @submitter_history[:approved] %> approved</span>
-                  <span class="status-pill status-pill--returned"><%= @submitter_history[:returned] %> returned</span>
-                </dd>
-                <% if (last_return = @submitter_history[:last_returned]) %>
-                  <dt>Last return</dt>
-                  <dd>
-                    <%= time_ago_in_words(last_return.decided_on) %> ago
-                    <% if last_return.feedback.present? %>
-                      <p class="ship-review__update-desc"><%= truncate(last_return.feedback, length: 240) %></p>
+              <p class="submitter-history__summary">
+                <%= pluralize(@submitter_history[:total], "review") %> across <%= pluralize(@submitter_history[:projects], "project") %>
+                &middot; <%= @submitter_history[:approved] %> approved
+                &middot; <%= @submitter_history[:returned] %> returned
+              </p>
+              <div class="submitter-history__cards">
+                <% @submitter_history[:recent].each do |review| %>
+                  <% current = review.id == @ship.id %>
+                  <%= link_to admin_certification_ship_path(review), target: "_blank", rel: "noopener",
+                        class: class_names("submitter-history__card", "submitter-history__card--current" => current) do %>
+                    <div class="submitter-history__card-head">
+                      <span class="status-pill status-pill--<%= review.status %>"><%= review.status %></span>
+                      <span class="submitter-history__card-id">#<%= review.id %></span>
+                      <% if current %>
+                        <span class="submitter-history__card-here">&larr; you're here</span>
+                      <% end %>
+                      <span class="submitter-history__card-date">
+                        <%= review.decided_at ? l(review.decided_at.to_date, format: :short) : "—" %>
+                      </span>
+                    </div>
+                    <div class="submitter-history__card-meta">
+                      <%= review.project.title %>
+                      <% if review.returned? && review.returned_by %>
+                        &middot; returned by <%= review.returned_by.display_name %>
+                      <% elsif review.decided_at && review.reviewer %>
+                        &middot; by <%= review.reviewer.display_name %>
+                      <% end %>
+                    </div>
+                    <% if review.feedback.present? %>
+                      <p class="submitter-history__card-feedback"><%= review.feedback %></p>
                     <% end %>
-                  </dd>
+                  <% end %>
                 <% end %>
-              </dl>
+              </div>
             <% end %>
           </div>
         <% end %>

--- a/app/views/admin/certification/ships/show.html.erb
+++ b/app/views/admin/certification/ships/show.html.erb
@@ -117,7 +117,7 @@
                   <%= link_to admin_certification_ship_path(review), target: "_blank", rel: "noopener",
                         class: class_names("submitter-history__card", "submitter-history__card--current" => current) do %>
                     <div class="submitter-history__card-head">
-                      <span class="status-pill status-pill--<%= review.status %>"><%= review.status %></span>
+                      <span class="status-pill status-pill--<%= review.status %>"><%= review.status.capitalize %></span>
                       <span class="submitter-history__card-id">#<%= review.id %></span>
                       <% if current %>
                         <span class="submitter-history__card-here">&larr; you're here</span>

--- a/app/views/admin/certification/ships/show.html.erb
+++ b/app/views/admin/certification/ships/show.html.erb
@@ -1,9 +1,6 @@
 <% content_for :title, "Review: #{@ship.project.title}" %>
 
-<%
-  owner = @ship.project.memberships.find(&:owner?)&.user
-  can_review = @ship.claim_held_by?(current_user) && @ship.pending?
-%>
+<% can_review = @ship.claim_held_by?(current_user) && @ship.pending? %>
 
 <div class="app-layout app-layout--wide"
      data-controller="certification--queue"
@@ -82,7 +79,7 @@
           <h2 class="ship-review__panel-title">Submission</h2>
           <dl class="ship-review__meta">
             <dt>Submitter</dt>
-            <dd><%= owner&.display_name || "—" %></dd>
+            <dd><%= @owner&.display_name || "—" %></dd>
             <dt>Submitted</dt>
             <dd><%= time_ago_in_words(@ship.project.shipped_at || @ship.created_at) %> ago</dd>
             <% if @ship.reviewer %>
@@ -103,6 +100,33 @@
       </section>
 
       <aside class="ship-review__sidebar">
+        <% if @submitter_history %>
+          <div class="ship-review__panel">
+            <h2 class="ship-review__panel-title">Submitter history</h2>
+            <% if @submitter_history[:total] <= 1 %>
+              <p class="ship-review__description">First submission from <%= @owner.display_name %>.</p>
+            <% else %>
+              <dl class="ship-review__meta">
+                <dt>Submitted</dt>
+                <dd><%= pluralize(@submitter_history[:total], "review") %> across <%= pluralize(@submitter_history[:projects], "project") %></dd>
+                <dt>Verdicts</dt>
+                <dd>
+                  <span class="status-pill status-pill--approved"><%= @submitter_history[:approved] %> approved</span>
+                  <span class="status-pill status-pill--returned"><%= @submitter_history[:returned] %> returned</span>
+                </dd>
+                <% if (last_return = @submitter_history[:last_returned]) %>
+                  <dt>Last return</dt>
+                  <dd>
+                    <%= time_ago_in_words(last_return.decided_on) %> ago
+                    <% if last_return.feedback.present? %>
+                      <p class="ship-review__update-desc"><%= truncate(last_return.feedback, length: 240) %></p>
+                    <% end %>
+                  </dd>
+                <% end %>
+              </dl>
+            <% end %>
+          </div>
+        <% end %>
         <% if can_review %>
           <%= render "form", ship: @ship %>
         <% else %>

--- a/app/views/admin/certification/ships/show.html.erb
+++ b/app/views/admin/certification/ships/show.html.erb
@@ -127,7 +127,10 @@
                       </span>
                     </div>
                     <div class="submitter-history__card-meta">
-                      <%= review.project.title %>
+                      <%= review.project_with_deleted.title %>
+                      <% if review.project_with_deleted.deleted? %>
+                        <span class="submitter-history__card-deleted">(deleted)</span>
+                      <% end %>
                       <% if review.returned? && review.returned_by %>
                         &middot; returned by <%= review.returned_by.display_name %>
                       <% elsif review.decided_at && review.reviewer %>

--- a/test/models/certification/ship_test.rb
+++ b/test/models/certification/ship_test.rb
@@ -134,4 +134,40 @@ class Certification::ShipTest < ActiveSupport::TestCase
       @project.ship_reviews.create!(status: :pending, reviewer: @reviewer)
     end
   end
+
+  test "submitter_history aggregates verdicts across the owner's projects" do
+    other = Project.create!(title: "Second Ship", description: "Another one", ship_status: "submitted")
+    other.memberships.create!(user: @owner, role: :owner)
+
+    returned = @project.ship_reviews.create!(status: :returned, feedback: "Fix the README.", reviewer: @reviewer)
+    approved = other.ship_reviews.create!(status: :approved, reviewer: @reviewer)
+    pending = other.ship_reviews.create!(status: :pending)
+
+    outsider_project = Project.create!(title: "Not Theirs", description: "Someone else's", ship_status: "submitted")
+    outsider_project.memberships.create!(user: @outsider, role: :owner)
+    outsider_project.ship_reviews.create!(status: :approved, reviewer: @reviewer)
+
+    history = Certification::Ship.submitter_history(@owner)
+
+    assert_equal 3, history[:total]
+    assert_equal 2, history[:projects]
+    assert_equal 1, history[:approved]
+    assert_equal 1, history[:returned]
+    assert_equal [ pending.id, approved.id, returned.id ], history[:recent].map(&:id)
+
+    assert_equal 0, Certification::Ship.submitter_history(@contributor)[:total]
+  end
+
+  test "submitter_history caps recent at six and keeps soft-deleted projects" do
+    reviews = 7.times.map { @project.ship_reviews.create!(status: :approved, reviewer: @reviewer) }
+    @project.soft_delete!(force: true)
+
+    history = Certification::Ship.submitter_history(@owner)
+
+    assert_equal 7, history[:total]
+    assert_equal 1, history[:projects]
+    assert_equal 6, history[:recent].size
+    assert_equal reviews.last.id, history[:recent].first.id
+    assert history[:recent].first.project_with_deleted.deleted?
+  end
 end


### PR DESCRIPTION
Part of the review quality push: when a Shipwright is judging a gray-area project, the sidebar now shows the submitter's track record above the verdict form. It lists how many reviews they've had across how many projects, the approved vs returned split, and quotes the feedback from their most recent return so you can see whether they were already told to fix the same things. First-time submitters get a simple "first submission" note instead.

Everything is derived from existing certification_ship_reviews rows joined through project ownership, so there are no migrations or new state, just a query method on Certification::Ship, two lines in the controller, and the panel markup and styles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Overriding `Certification::Ship#project` to include soft-deleted records changes behavior for all callers of `ship.project`, not only the new panel; otherwise read-only admin UI and queries on existing data.
> 
> **Overview**
> Adds a **Submitter history** panel in the ship certification review sidebar (above the verdict form) so reviewers can see the owner's prior reviews—totals, approved vs returned, and up to six linked cards with status, project title, reviewer, and feedback, with the current review highlighted.
> 
> **Backend:** `Certification::Ship.submitter_history` aggregates existing `certification_ship_reviews` via owner **memberships** (so history survives soft-deleted projects). The admin ships controller loads `@owner` and `@submitter_history` on **show** and **update** so the panel stays visible when the verdict form fails validation.
> 
> **Model tweak:** `project_with_deleted` and a `project` fallback keep review pages and history cards from breaking when a project is force-deleted; history cards label deleted projects explicitly.
> 
> **UI:** Sidebar layout uses a flex column; new `.submitter-history` styles for the scrollable card list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca1920a160e66e26ad1482ea6c9182da5c05b177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->