### PR TITLE
use the brand palette and tighter panels on the ship review page

### DIFF
--- a/app/assets/stylesheets/pages/certification/ships/_show.scss
+++ b/app/assets/stylesheets/pages/certification/ships/_show.scss
@@ -44,9 +44,9 @@
     }
   }
 
-  // Progress banner, styled after .top-banner--beta but green to read as
-  // momentum rather than a warning. Re-renders on every page load, so the
-  // count pops as it ticks up after each verdict.
+  // Progress banner, mint like the claim banner so it reads as momentum
+  // without leaving the brand palette. Re-renders on every page load, so
+  // the count pops as it ticks up after each verdict.
   &__momentum {
     display: flex;
     flex-wrap: wrap;
@@ -55,13 +55,12 @@
     gap: var(--space-xs);
     margin-bottom: var(--space-l);
     padding: 0.6rem 1rem;
-    color: #fff;
+    color: var(--color-brand-mint);
     font-size: 1rem;
     font-weight: 600;
     text-align: center;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
-    background: linear-gradient(135deg, #22c55e 0%, #15803d 100%);
-    border: 1px solid rgba(255, 255, 255, 0.18);
+    background: rgba(129, 255, 255, 0.08);
+    border: 1px solid rgba(129, 255, 255, 0.2);
     border-radius: 10px;
   }
 
@@ -101,14 +100,14 @@
   }
 
   &__panel {
-    padding: var(--space-l);
+    padding: var(--space-m) var(--space-l);
     background: var(--card-bg);
     border: 1px solid var(--card-border);
     border-radius: 12px;
   }
 
   &__panel-title {
-    margin: 0 0 var(--space-s);
+    margin: 0 0 var(--space-xs);
     font-size: var(--font-size-l);
   }
 
@@ -461,7 +460,7 @@
 
   &--accepted {
     border-style: solid;
-    border-color: #22c55e;
+    border-color: var(--color-brand-mint);
   }
 
   &--error {
@@ -537,7 +536,7 @@
     color: var(--color-space-text-muted, rgba(255, 255, 255, 0.7));
 
     .video-drop--done & {
-      color: #22c55e;
+      color: var(--color-brand-mint);
     }
 
     .video-drop--error & {
@@ -576,7 +575,7 @@
 
   &--done {
     border-style: solid;
-    border-color: #22c55e;
+    border-color: var(--color-brand-mint);
   }
 }
 


### PR DESCRIPTION
Two visual fixes on the Shipwright review page. The momentum banner was a saturated green gradient that isn't in the Stardance palette and stuck out badly against the space theme; it now uses the same translucent mint treatment as the claim banner right below it, and the video-drop done states drop their hardcoded green for brand mint too. The detail panels (Description, AI Declaration, Links, Submission) also had a lot of dead vertical space around one-line content, so panel padding tightens from 24px to 16px vertically and the title margin shrinks a step.

Net negative diff: 11 added, 12 removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only SCSS on the admin ship review page; no logic, auth, or data changes.
> 
> **Overview**
> On the Shipwright certification **ship review** page (`_show.scss`), the **momentum** progress banner no longer uses a saturated green gradient and white text; it now matches the verdict form’s **claim banner** with mint text, translucent mint background, and a light mint border.
> 
> **Detail panels** get tighter vertical rhythm: panel padding is `var(--space-m)` top/bottom (was uniform `var(--space-l)`), and panel title bottom margin steps down to `var(--space-xs)`.
> 
> **Video upload** success styling swaps hardcoded `#22c55e` for `var(--color-brand-mint)` on accepted/done borders and on status text when upload is complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6d9511c8fe171a1ecb6fb6757c98a53279d9493. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->