### PR TITLE
Add Instagram to user_ref options

### DIFF
--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -32,6 +32,7 @@ class Rsvp < ApplicationRecord
     "AMD",
     "GitHub",
     "Linus Tech Tips",
+    "Instagram",
     "Teacher",
     "Friend"
   ].freeze


### PR DESCRIPTION
Shows up after Linus Tech Tips in both the onboarding referral step and the landing-page RSVP modal.

## what's this do?

Add Instagram as a source people can attribute their sign-up to

## show it works

<img width="1440" height="810" alt="Screenshot 2026-06-10 at 5 20 23 PM" src="https://github.com/user-attachments/assets/15c72b5f-b1fc-4013-adca-a6b75f3b7362" />

## ai?

Claude Code