### PR TITLE
feat(ship): include reviewer feedback and video walkthrough in slack notifications

### DIFF
--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -239,13 +239,40 @@ module Certification
     def notify_owner!
       return unless owner&.slack_id.present?
 
+      routes = Rails.application.routes.url_helpers
+      url_opts = Rails.application.config.action_controller.default_url_options
+                      .reverse_merge(host: "stardance.hackclub.com", protocol: "https")
+
+      locals = {
+        project_title: project.title,
+        project_url: routes.project_url(project, **url_opts),
+        feedback: feedback.to_s,
+        video_url: verdict_video.attached? ? routes.rails_blob_url(verdict_video, **url_opts) : nil
+      }
+
       case status.to_sym
       when :approved
-        owner.dm_user("Your project '#{project.title}' was approved. It's out for voting now.")
+        msg = "Your project '#{project.title}' was approved. It's out for voting now."
+        msg += "\n\nFeedback: #{feedback}" if feedback.present?
+
+        SendSlackDmJob.perform_later(
+          owner.slack_id,
+          msg,
+          blocks_path: "notifications/projects/approved",
+          locals: locals,
+          sent_by_id: reviewer_id
+        )
       when :returned
         msg = "Your project '#{project.title}' needs changes before it can ship."
-        msg += "\n\n#{feedback}" if feedback.present?
-        owner.dm_user(msg)
+        msg += "\n\nFeedback: #{feedback}" if feedback.present?
+
+        SendSlackDmJob.perform_later(
+          owner.slack_id,
+          msg,
+          blocks_path: "notifications/projects/returned",
+          locals: locals,
+          sent_by_id: reviewer_id
+        )
       end
     end
   end

--- a/app/views/notifications/projects/approved.slack_message.slocks
+++ b/app/views/notifications/projects/approved.slack_message.slocks
@@ -1,0 +1,22 @@
+header ":sparkles: Your project was approved!"
+
+section "Your project *<#{project_url}|#{project_title}>* has been approved and is now out for voting.", markdown: true
+
+if feedback.present?
+  section "*Feedback:* #{feedback}", markdown: true
+end
+
+if video_url.present?
+  section "*Walkthrough Video:* <#{video_url}|Click here to watch>", markdown: true
+end
+
+if video_url.present?
+  actions [
+    button("View project", "view_project", url: project_url),
+    button("Watch review video", "watch_video", url: video_url)
+  ]
+else
+  actions [
+    button("View project", "view_project", url: project_url)
+  ]
+end

--- a/app/views/notifications/projects/returned.slack_message.slocks
+++ b/app/views/notifications/projects/returned.slack_message.slocks
@@ -1,0 +1,22 @@
+header ":x: Changes requested for your project"
+
+section "Your project *<#{project_url}|#{project_title}>* needs changes before it can ship.", markdown: true
+
+if feedback.present?
+  section "*Feedback:* #{feedback}", markdown: true
+end
+
+if video_url.present?
+  section "*Walkthrough Video:* <#{video_url}|Click here to watch>", markdown: true
+end
+
+if video_url.present?
+  actions [
+    button("View project", "view_project", url: project_url),
+    button("Watch review video", "watch_video", url: video_url)
+  ]
+else
+  actions [
+    button("View project", "view_project", url: project_url)
+  ]
+end


### PR DESCRIPTION


## what's this do?
Including reviewer feedback/video in both approval/rejection messages in slack

## show it works

<img width="1561" height="751" alt="image" src="https://github.com/user-attachments/assets/9fffe5cd-088d-4bc6-8efe-676ba935bd85" />

## ai?
Gemini