### PR TITLE
feat(missions): client-side guide variables via var shortcodes

### DIFF
--- a/app/assets/stylesheets/components/_guide_content.scss
+++ b/app/assets/stylesheets/components/_guide_content.scss
@@ -274,3 +274,55 @@
   padding: 0.05em 0.25em;
   border-radius: 3px;
 }
+
+.guide-var {
+  display: block;
+  margin: var(--space-m) 0;
+  padding: var(--space-s) var(--space-m);
+  border: 1px solid var(--color-space-border);
+  border-left: 4px solid var(--color-brand-lilac);
+  border-radius: var(--profile-radius);
+  background: var(--color-space-surface-faint);
+
+  &__label {
+    display: block;
+    font-weight: 600;
+    font-size: var(--font-size-m);
+    color: var(--color-brand-off-white);
+    margin-bottom: var(--space-xs);
+  }
+
+  &__input {
+    width: 100%;
+    padding: var(--space-xs) var(--space-s);
+    border: 1px solid var(--color-space-border);
+    border-radius: 4px;
+    background: var(--color-space-bg-2);
+    color: var(--color-space-text);
+    font-family: var(--font-family-text);
+    font-size: var(--font-size-m);
+
+    &::placeholder {
+      color: var(--color-space-text-muted);
+    }
+
+    &:focus {
+      outline: none;
+      border-color: var(--color-brand-mint);
+    }
+  }
+}
+
+.guide-var-ref {
+  background: var(--color-brand-lilac-soft);
+  color: var(--color-brand-lilac);
+  padding: 0.05em 0.1em;
+  border-radius: 3px;
+
+  &--empty {
+    background: transparent;
+    color: var(--color-space-text-muted);
+    border-bottom: 1px dashed var(--color-space-text-muted);
+    font-style: italic;
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -166,6 +166,12 @@ application.register("mission-guide-language", MissionGuideLanguageController);
 import MissionGuideProgressController from "./mission_guide_progress_controller";
 application.register("mission-guide-progress", MissionGuideProgressController);
 
+import MissionGuideVariablesController from "./mission_guide_variables_controller";
+application.register(
+  "mission-guide-variables",
+  MissionGuideVariablesController,
+);
+
 import ModalController from "./modal_controller";
 application.register("modal", ModalController);
 

--- a/app/javascript/controllers/mission_guide_variables_controller.js
+++ b/app/javascript/controllers/mission_guide_variables_controller.js
@@ -1,0 +1,92 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Client-side-only guide variables. Authors declare an input with the
+// `:::var name="x"` block shortcode and reference it inline with
+// `::var-ref[x]` (verbatim) or `::var-slug[x]` (sluggified). Values never
+// leave the browser: they're stored per-mission in localStorage and painted
+// into the reference spans here, so the server-rendered guide HTML stays
+// cacheable per-content.
+export default class extends Controller {
+  static values = { missionSlug: String };
+
+  connect() {
+    this.variables = this.load();
+    this.hydrate();
+  }
+
+  update(event) {
+    const input = event.target;
+    const name = input.dataset.guideVarInput;
+    if (input.value.trim() === "") {
+      delete this.variables[name];
+    } else {
+      this.variables[name] = input.value;
+    }
+    this.persist();
+    this.syncInputs(name, input);
+    this.applyRefs(name);
+  }
+
+  hydrate() {
+    this.element.querySelectorAll("[data-guide-var-input]").forEach((input) => {
+      const value = this.variables[input.dataset.guideVarInput];
+      if (value !== undefined) input.value = value;
+    });
+    this.applyRefs();
+  }
+
+  // Same variable declared in more than one section — keep the inputs as one.
+  syncInputs(name, source) {
+    this.element
+      .querySelectorAll(`[data-guide-var-input="${CSS.escape(name)}"]`)
+      .forEach((input) => {
+        if (input !== source) input.value = source.value;
+      });
+  }
+
+  applyRefs(name = null) {
+    this.element.querySelectorAll("[data-guide-var-ref]").forEach((ref) => {
+      const refName = ref.dataset.guideVarRef;
+      if (name !== null && refName !== name) return;
+
+      const value = (this.variables[refName] || "").trim();
+      const display =
+        ref.dataset.guideVarMode === "slug" ? this.slugify(value) : value;
+      const empty = display === "";
+      ref.textContent = empty ? refName : display;
+      ref.classList.toggle("guide-var-ref--empty", empty);
+    });
+  }
+
+  // Lowercase, spaces to dashes, punctuation removed.
+  slugify(value) {
+    return value
+      .toLowerCase()
+      .replace(/\s+/g, "-")
+      .replace(/[^a-z0-9-]/g, "")
+      .replace(/-+/g, "-")
+      .replace(/^-+|-+$/g, "");
+  }
+
+  storageKey() {
+    return `stardance:v1:mission-guide-vars:${this.missionSlugValue}`;
+  }
+
+  load() {
+    try {
+      const parsed = JSON.parse(window.localStorage.getItem(this.storageKey()));
+      return parsed && typeof parsed === "object" ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+
+  persist() {
+    try {
+      window.localStorage.setItem(
+        this.storageKey(),
+        JSON.stringify(this.variables),
+      );
+    } catch {}
+  }
+}

--- a/app/services/guide_markdown_renderer.rb
+++ b/app/services/guide_markdown_renderer.rb
@@ -13,8 +13,13 @@ class GuideMarkdownRenderer
   ATTR_RE             = /([a-z][a-z0-9_-]*)=("[^"]*"|\S+)/
 
   CALLOUT_TYPES     = %w[info tip warning danger].freeze
-  BLOCK_SHORTCODES  = %w[callout collapse].freeze
-  INLINE_SHORTCODES = %w[kbd mark].freeze
+  BLOCK_SHORTCODES  = %w[callout collapse var].freeze
+  INLINE_SHORTCODES = %w[kbd mark var-ref var-slug].freeze
+
+  # Guide variables are client-side only: the renderer emits static inputs and
+  # reference spans, and mission_guide_variables_controller.js fills in the
+  # reader's value from localStorage — rendered HTML stays cacheable per-content.
+  VAR_NAME_RE = /\A[a-z][a-z0-9_-]*\z/
 
   # Rouge's lexer tags are by convention alphanumeric / underscore / dash, but
   # we filter defensively before interpolating into a class attribute.
@@ -196,7 +201,11 @@ class GuideMarkdownRenderer
   def render_code_block(entry)
     lexer = Rouge::Lexer.find(entry[:language])&.new || Rouge::Lexers::PlainText.new
     formatter = Rouge::Formatters::HTML.new
-    highlighted = formatter.format(lexer.lex(entry[:code]))
+    # Inline shortcode extraction runs on the raw markdown, so markers survive
+    # inside fenced code. Split on them and highlight the chunks in between.
+    highlighted = entry[:code].split(inline_marker_re).map.with_index { |part, i|
+      i.odd? ? expand_inline_entry(part.to_i) : formatter.format(lexer.lex(part))
+    }.join
     language_class = lexer.tag.to_s
     language_class = "plaintext" unless language_class.match?(LANGUAGE_CLASS_RE)
     %(<pre class="guide-code"><code class="language-#{language_class}">#{highlighted}</code></pre>)
@@ -240,9 +249,7 @@ class GuideMarkdownRenderer
       next unless node.content =~ inline_re
 
       new_content = node.content.gsub(inline_re) do
-        id = Regexp.last_match(1).to_i
-        entry = @inline_registry[id]
-        entry ? render_inline_shortcode(entry) : ""
+        expand_inline_entry(Regexp.last_match(1).to_i)
       end
       replacements << [ node, new_content ]
     end
@@ -297,15 +304,23 @@ class GuideMarkdownRenderer
     case entry[:name]
     when "callout"    then render_callout(entry, depth: depth)
     when "collapse"   then render_collapse(entry, depth: depth)
+    when "var"        then render_var(entry)
     else ""
     end
+  end
+
+  def expand_inline_entry(id)
+    entry = @inline_registry[id]
+    entry ? render_inline_shortcode(entry) : ""
   end
 
   def render_inline_shortcode(entry)
     content = ERB::Util.html_escape(entry[:content].to_s)
     case entry[:name]
-    when "kbd"  then %(<kbd class="guide-kbd">#{content}</kbd>)
-    when "mark" then %(<mark class="guide-mark">#{content}</mark>)
+    when "kbd"      then %(<kbd class="guide-kbd">#{content}</kbd>)
+    when "mark"     then %(<mark class="guide-mark">#{content}</mark>)
+    when "var-ref"  then render_var_ref(entry, slugged: false)
+    when "var-slug" then render_var_ref(entry, slugged: true)
     else content
     end
   end
@@ -335,5 +350,38 @@ class GuideMarkdownRenderer
         <div class="guide-collapse__body">#{inner_html}</div>
       </details>
     HTML
+  end
+
+  def render_var(entry)
+    name = entry[:attrs]["name"].to_s.strip
+    return "" unless name.match?(VAR_NAME_RE)
+
+    label = entry[:attrs]["label"].to_s
+    label = name.tr("_-", " ").upcase_first if label.empty?
+    placeholder = entry[:attrs]["placeholder"].to_s
+    <<~HTML
+      <label class="guide-var">
+        <span class="guide-var__label">#{ERB::Util.html_escape(label)}</span>
+        <input type="text"
+               class="guide-var__input"
+               maxlength="120"
+               autocomplete="off"
+               spellcheck="false"
+               placeholder="#{ERB::Util.html_escape(placeholder)}"
+               data-guide-var-input="#{name}"
+               data-action="input->mission-guide-variables#update">
+      </label>
+    HTML
+  end
+
+  # Until the reader types a value, the span shows the variable name as a
+  # muted placeholder (the --empty modifier); the Stimulus controller swaps in
+  # the real value and drops the modifier.
+  def render_var_ref(entry, slugged:)
+    name = entry[:content].to_s.strip
+    return "" unless name.match?(VAR_NAME_RE)
+
+    mode = slugged ? "slug" : "raw"
+    %(<span class="guide-var-ref guide-var-ref--empty" data-guide-var-ref="#{name}" data-guide-var-mode="#{mode}">#{name}</span>)
   end
 end

--- a/app/services/markdown_renderer.rb
+++ b/app/services/markdown_renderer.rb
@@ -6,7 +6,7 @@ class MarkdownRenderer
 
   # Bump on any rendered-output change (sanitizer, shortcodes, Rouge, link
   # hardening) — the cache key uses it to invalidate deployment-wide.
-  RENDERER_VERSION      = "v4".freeze
+  RENDERER_VERSION      = "v5".freeze
   CACHE_NAMESPACE       = "markdown".freeze
   GUIDE_CACHE_NAMESPACE = "guide-markdown".freeze
   CACHE_EXPIRES_IN      = 7.days

--- a/app/views/missions/guide.html.erb
+++ b/app/views/missions/guide.html.erb
@@ -5,7 +5,8 @@
 <div class="app-layout">
   <div class="app-layout__main">
     <article class="mission-guide"
-             data-controller="mission-guide-progress"
+             data-controller="mission-guide-progress mission-guide-variables"
+             data-mission-guide-variables-mission-slug-value="<%= @mission.slug %>"
              data-mission-guide-progress-section-count-value="<%= @guide_outline.length %>"
              data-mission-guide-progress-mission-slug-value="<%= @mission.slug %>"
              data-mission-guide-progress-mission-id-value="<%= @mission.id %>"

--- a/test/services/guide_markdown_renderer_test.rb
+++ b/test/services/guide_markdown_renderer_test.rb
@@ -190,6 +190,73 @@ class GuideMarkdownRendererTest < ActiveSupport::TestCase
     refute_includes result.html, "[x]"
   end
 
+  # --- guide variables --------------------------------------------------------
+
+  test "var block shortcode renders a labelled input" do
+    md = <<~MD
+      :::var name="project_name" label="What's your project called?" placeholder="my-cool-app"
+      :::
+    MD
+    html = render(md).html
+    assert_includes html, %(class="guide-var")
+    assert_includes html, "What's your project called?"
+    assert_includes html, %(placeholder="my-cool-app")
+    assert_includes html, %(data-guide-var-input="project_name")
+  end
+
+  test "var block humanizes the name when label is omitted" do
+    md = <<~MD
+      :::var name="project_name"
+      :::
+    MD
+    assert_includes render(md).html, "Project name"
+  end
+
+  test "var block with invalid name renders nothing" do
+    md = <<~MD
+      :::var name="<bad name>"
+      :::
+    MD
+    html = render(md).html
+    refute_includes html, "guide-var"
+    refute_includes html, "bad name"
+  end
+
+  test "var-ref inline shortcode renders a raw reference span" do
+    html = render("Open ::var-ref[project_name] in your editor").html
+    assert_includes html, %(data-guide-var-ref="project_name")
+    assert_includes html, %(data-guide-var-mode="raw")
+    assert_includes html, "guide-var-ref--empty"
+  end
+
+  test "var-slug inline shortcode renders a slug reference span" do
+    html = render("Run `cd` into ::var-slug[project_name]").html
+    assert_includes html, %(data-guide-var-mode="slug")
+  end
+
+  test "var-ref with invalid name is stripped" do
+    html = render("::var-ref[<script>]").html
+    refute_includes html, "guide-var-ref"
+    refute_includes html, "<script>"
+  end
+
+  test "var refs expand inside fenced code blocks" do
+    md = <<~MD
+      ```bash
+      npx create-app ::var-slug[project_name]
+      ```
+    MD
+    html = render(md).html
+    assert_includes html, %(data-guide-var-ref="project_name")
+    refute_includes html, "GUIDE_INLINE"
+  end
+
+  test "var refs expand inside inline code" do
+    html = render("Run `cd ::var-slug[project_name]` next").html
+    assert_includes html, %(data-guide-var-ref="project_name")
+    refute_includes html, "GUIDE_INLINE"
+  end
+
   test "unknown block shortcode is stripped" do
     md = <<~MD
       before


### PR DESCRIPTION
## what's this do?

a lot of people didn't understand that they needed a unique command. This adds variables that can be added to guides, which can be used to auto fill in future fields with the variable, allowing you to show users the exact command they'll need to put in.

## show it works

<img width="479" height="247" alt="image" src="https://github.com/user-attachments/assets/fa7884df-b6ae-4e9e-aecc-19f555144e80" />
<img width="456" height="76" alt="image" src="https://github.com/user-attachments/assets/64c63bd6-86ca-454a-92a3-092925f0feab" />
<img width="453" height="338" alt="image" src="https://github.com/user-attachments/assets/ca6f64fb-c49e-4ac8-9a30-e969c21734a1" />

## ai?

claude + pane
