### PR TITLE
Remove Flipper gate from hardware guides

### DIFF
--- a/app/controllers/admin/certification/funding_requests/claims_controller.rb
+++ b/app/controllers/admin/certification/funding_requests/claims_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::Certification::FundingRequests::ClaimsController < Admin::Certification::ApplicationController
-  before_action -> { head :not_found unless Project.hardware_flow_enabled? }
+  before_action -> { head :not_found unless Project.hardware_flow_enabled?(current_user) }
   before_action :set_funding_request
 
   # POST /admin/certification/funding/:funding_request_id/claim

--- a/app/controllers/admin/certification/funding_requests/claims_controller.rb
+++ b/app/controllers/admin/certification/funding_requests/claims_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::Certification::FundingRequests::ClaimsController < Admin::Certification::ApplicationController
-  before_action -> { head :not_found unless Project.hardware_flow_enabled?(current_user) }
+  before_action -> { head :not_found unless Flipper.enabled?(:hardware_flow, current_user) }
   before_action :set_funding_request
 
   # POST /admin/certification/funding/:funding_request_id/claim

--- a/app/controllers/admin/certification/funding_requests_controller.rb
+++ b/app/controllers/admin/certification/funding_requests_controller.rb
@@ -1,5 +1,5 @@
 class Admin::Certification::FundingRequestsController < Admin::Certification::ApplicationController
-  before_action -> { head :not_found unless Project.hardware_flow_enabled? }
+  before_action -> { head :not_found unless Project.hardware_flow_enabled?(current_user) }
   before_action :release_other_claims, only: [ :next ]
   before_action :set_funding_request, only: [ :show, :update ]
   before_action :set_body_class, only: [ :index, :show, :update ]

--- a/app/controllers/admin/certification/funding_requests_controller.rb
+++ b/app/controllers/admin/certification/funding_requests_controller.rb
@@ -1,5 +1,5 @@
 class Admin::Certification::FundingRequestsController < Admin::Certification::ApplicationController
-  before_action -> { head :not_found unless Project.hardware_flow_enabled?(current_user) }
+  before_action -> { head :not_found unless Flipper.enabled?(:hardware_flow, current_user) }
   before_action :release_other_claims, only: [ :next ]
   before_action :set_funding_request, only: [ :show, :update ]
   before_action :set_body_class, only: [ :index, :show, :update ]

--- a/app/controllers/admin/users/presentable_hardware_flags_controller.rb
+++ b/app/controllers/admin/users/presentable_hardware_flags_controller.rb
@@ -1,5 +1,5 @@
 class Admin::Users::PresentableHardwareFlagsController < Admin::ApplicationController
-  before_action -> { head :not_found unless Project.hardware_flow_enabled? }
+  before_action -> { head :not_found unless Project.hardware_flow_enabled?(current_user) }
   before_action :set_user
 
   # Granted after a showcase project (forms.hackclub.com/submit-showcase-project)

--- a/app/controllers/admin/users/presentable_hardware_flags_controller.rb
+++ b/app/controllers/admin/users/presentable_hardware_flags_controller.rb
@@ -1,5 +1,5 @@
 class Admin::Users::PresentableHardwareFlagsController < Admin::ApplicationController
-  before_action -> { head :not_found unless Project.hardware_flow_enabled?(current_user) }
+  before_action -> { head :not_found unless Flipper.enabled?(:hardware_flow, current_user) }
   before_action :set_user
 
   # Granted after a showcase project (forms.hackclub.com/submit-showcase-project)

--- a/app/controllers/projects/funding_requests_controller.rb
+++ b/app/controllers/projects/funding_requests_controller.rb
@@ -1,5 +1,5 @@
 class Projects::FundingRequestsController < ApplicationController
-  before_action -> { head :not_found unless Project.hardware_flow_enabled? }
+  before_action -> { head :not_found unless Project.hardware_flow_enabled?(current_user) }
   before_action :set_project
 
   # Submitted from the "Submit Design to Get Project Funding" popup on the

--- a/app/controllers/projects/funding_requests_controller.rb
+++ b/app/controllers/projects/funding_requests_controller.rb
@@ -1,5 +1,5 @@
 class Projects::FundingRequestsController < ApplicationController
-  before_action -> { head :not_found unless Project.hardware_flow_enabled?(current_user) }
+  before_action -> { head :not_found unless Flipper.enabled?(:hardware_flow, current_user) }
   before_action :set_project
 
   # Submitted from the "Submit Design to Get Project Funding" popup on the

--- a/app/controllers/projects/lookout_sessions_controller.rb
+++ b/app/controllers/projects/lookout_sessions_controller.rb
@@ -1,5 +1,5 @@
 class Projects::LookoutSessionsController < ApplicationController
-  before_action -> { head :not_found unless Project.hardware_flow_enabled? }
+  before_action -> { head :not_found unless Project.hardware_flow_enabled?(current_user) }
   before_action :set_project
   before_action :set_lookout_session, only: %i[show record stop set_mode forward_heartbeats]
 

--- a/app/controllers/projects/lookout_sessions_controller.rb
+++ b/app/controllers/projects/lookout_sessions_controller.rb
@@ -1,5 +1,5 @@
 class Projects::LookoutSessionsController < ApplicationController
-  before_action -> { head :not_found unless Project.hardware_flow_enabled?(current_user) }
+  before_action -> { head :not_found unless Flipper.enabled?(:hardware_flow, current_user) }
   before_action :set_project
   before_action :set_lookout_session, only: %i[show record stop set_mode forward_heartbeats]
 

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -161,11 +161,7 @@ Guide = Data.define(:slug, :title, :description, :category, :icon, :reading_minu
 
   class << self
     def all
-      if Flipper.enabled?(:hardware_flow)
-        self::ALL
-      else
-        self::ALL.reject { |g| g.category == :outpost || g.slug == :tiers }
-      end
+      self::ALL
     end
     def find(s)
       guide = self::SLUGGED[s.to_sym] or raise ActiveRecord::RecordNotFound, "Unknown guide: #{s}"

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -312,8 +312,12 @@ class Project < ApplicationRecord
     shipped_at.present? || !draft?
   end
 
-  def self.hardware_flow_enabled?
-    Flipper.enabled?(:hardware_flow)
+  def self.hardware_flow_enabled?(user = nil)
+    if user
+      Flipper.enabled?(:hardware_flow, user)
+    else
+      Flipper.enabled?(:hardware_flow)
+    end
   end
 
   # Hardware projects are the ones with a stage set; software projects leave it

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -312,26 +312,16 @@ class Project < ApplicationRecord
     shipped_at.present? || !draft?
   end
 
-  def self.hardware_flow_enabled?(user = nil)
-    if user
-      Flipper.enabled?(:hardware_flow, user)
-    else
-      Flipper.enabled?(:hardware_flow)
-    end
-  end
-
-  # Hardware projects are the ones with a stage set; software projects leave it
-  # nil. Gates the Lookout recorder UI on the project page.
   def hardware?
-    self.class.hardware_flow_enabled? && hardware_stage.present?
+    hardware_stage.present?
   end
 
   def design_stage?
-    self.class.hardware_flow_enabled? && hardware_stage == "design"
+    hardware_stage == "design"
   end
 
   def build_stage?
-    self.class.hardware_flow_enabled? && hardware_stage == "build"
+    hardware_stage == "build"
   end
 
   # True while a funding request for this project is awaiting reviewer decision.

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -97,7 +97,7 @@
       <% end %>
     </div>
   </div>
-  <% if Flipper.enabled?(:hardware_flow) %>
+  <% if Flipper.enabled?(:hardware_flow, current_user) %>
   <div>
     <h2>Hardware</h2>
     <div>

--- a/app/views/my/balance.html.erb
+++ b/app/views/my/balance.html.erb
@@ -3,7 +3,7 @@
   <div class="balance-history">
     <div class="balance-history__header">
       <h1>My Balance: <span><%= image_tag "icons/stardust.png", alt: "Stardust", class: "currency-icon" %></span> <%= current_user.balance %></h1>
-      <% if Flipper.enabled?(:hardware_flow) && current_user.outpost_discount_stardust.to_i > 0 %>
+      <% if Flipper.enabled?(:hardware_flow, current_user) && current_user.outpost_discount_stardust.to_i > 0 %>
         <p class="balance-history__outpost">
           Outpost Ticket discount: <%= image_tag "icons/stardust.png", alt: "Stardust", class: "currency-icon" %> <%= current_user.outpost_discount_stardust %>
           <% if current_user.outpost_flight_stipend > 0 %>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -87,7 +87,7 @@
           <% end %>
         <% end %>
 
-        <% if Flipper.enabled?(:hardware_flow) %>
+        <% if Flipper.enabled?(:hardware_flow, current_user) %>
         <button type="button"
                 class="project-creation__blank-btn project-creation__blank-btn--hardware"
                 data-action="project-builder#toggle"
@@ -99,7 +99,7 @@
         <% end %>
       </div>
 
-      <% if Flipper.enabled?(:hardware_flow) %>
+      <% if Flipper.enabled?(:hardware_flow, current_user) %>
       <div id="project-creation-stage-chooser"
            class="project-creation__stage-chooser"
            data-project-builder-target="chooser"

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -468,7 +468,7 @@
           devlog_modifier_class = devlog_primary ? "project-show__action--primary" : "project-show__action--secondary"
         %>
         <nav class="project-show__actions" aria-label="Project actions">
-          <% if Flipper.enabled?(:hardware_flow) && @project.hardware? %>
+          <% if Flipper.enabled?(:hardware_flow, current_user) && @project.hardware? %>
             <%= render "projects/record_timelapse_button",
                        project: @project,
                        disabled_message: (@hackatime_linked ? nil : "Link your Hackatime account to start recording") %>
@@ -539,7 +539,7 @@
               <% end %>
             <% end %>
           <% end %>
-          <% if Flipper.enabled?(:hardware_flow) && is_member && @project.design_stage? %>
+          <% if Flipper.enabled?(:hardware_flow, current_user) && is_member && @project.design_stage? %>
             <% if @project.has_pending_funding_request? %>
               <%= render ActionButtonComponent.new(
                     text: "Funding request under review",
@@ -616,7 +616,7 @@
         </nav>
       <% else %>
         <nav class="project-show__actions" aria-label="Project actions">
-          <% if Flipper.enabled?(:hardware_flow) && @project.hardware? %>
+          <% if Flipper.enabled?(:hardware_flow, current_user) && @project.hardware? %>
             <%= render "projects/record_timelapse_button",
                        project: @project,
                        disabled_message: "Link your Hackatime account to start recording" %>
@@ -1015,7 +1015,7 @@
 
     <%# Funding request popup — design-stage hardware only. Mirrors the ship
         post modal but collects a complexity tier + requested amount. %>
-    <% if Flipper.enabled?(:hardware_flow) && @project.design_stage? %>
+    <% if Flipper.enabled?(:hardware_flow, current_user) && @project.design_stage? %>
       <dialog id="funding-request-modal-<%= @project.id %>"
               class="ship-modal ship-modal--post funding-modal--outpost"
               data-controller="modal"

--- a/app/views/shop/items/category.html.erb
+++ b/app/views/shop/items/category.html.erb
@@ -72,7 +72,7 @@
 
     <%= turbo_frame_tag "shop_items" do %>
       <div class="shop-category__items">
-        <% if @slug == "experiences" && !Flipper.enabled?(:hardware_flow) %>
+        <% if @slug == "experiences" && !Flipper.enabled?(:hardware_flow, current_user) %>
           <%= render "shop/items/outpost_ticket" %>
         <% end %>
         <% @shop_items.each do |item| %>

--- a/app/views/shop/items/index.html.erb
+++ b/app/views/shop/items/index.html.erb
@@ -154,7 +154,7 @@
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"> <polyline points="15 18 9 12 15 6" /> </svg>
             </button>
             <ul class="shop-hub__items-grid" data-horizontal-scroll-target="track">
-              <% unless Flipper.enabled?(:hardware_flow) %>
+              <% unless Flipper.enabled?(:hardware_flow, current_user) %>
               <li class="shop-hub__items-card">
                 <%= render "shop/items/outpost_ticket" %>
               </li>


### PR DESCRIPTION
## Summary
- Removes the  Flipper flag from , so outpost/tiers guides are always visible
- Made Flipper flags able to be enabled for specific user
