### PR TITLE
fix(hardware): remove global Flipper route constraints for hardware features

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -591,9 +591,7 @@ Rails.application.routes.draw do
         resource  :ban,                 only: [ :create, :destroy ]
         resource  :impersonation,       only: [ :create ]
         resources :feature_flags,       only: [ :create, :destroy ], param: :feature
-        constraints ->(_) { Flipper.enabled?(:hardware_flow) } do
-          resource  :presentable_hardware_flag, only: [ :create, :destroy ]
-        end
+        resource  :presentable_hardware_flag, only: [ :create, :destroy ]
         resource  :hackatime_sync,      only: [ :create ]
         resource  :order_rejection,     only: [ :create ]
         resources :balance_adjustments, only: [ :create ]
@@ -748,14 +746,12 @@ Rails.application.routes.draw do
         end
       end
 
-      constraints ->(_) { Flipper.enabled?(:hardware_flow) } do
-        resources :funding_requests, path: "funding", only: [ :index, :show, :update ] do
-          collection do
-            get :next
-          end
-          scope module: :funding_requests do
-            resource :claim, only: [ :create, :destroy ]
-          end
+      resources :funding_requests, path: "funding", only: [ :index, :show, :update ] do
+        collection do
+          get :next
+        end
+        scope module: :funding_requests do
+          resource :claim, only: [ :create, :destroy ]
         end
       end
 
@@ -820,21 +816,17 @@ Rails.application.routes.draw do
       end
     end
     resources :reports, only: [ :create ], module: :projects
-    constraints ->(_) { Flipper.enabled?(:hardware_flow) } do
-      resources :lookout_sessions, only: %i[create show], module: :projects, shallow: false do
-        get  :record, on: :member
-        post :stop, on: :member
-        post :set_mode, on: :member
-        post :forward_heartbeats, on: :member
-        get  :status, on: :collection
-      end
+    resources :lookout_sessions, only: %i[create show], module: :projects, shallow: false do
+      get  :record, on: :member
+      post :stop, on: :member
+      post :set_mode, on: :member
+      post :forward_heartbeats, on: :member
+      get  :status, on: :collection
     end
     resource :og_image, only: [ :show ], module: :projects, defaults: { format: :png }
     resource :ships, only: [ :create ], module: :projects
     resource :recertification, only: [ :create ], module: :projects
-    constraints ->(_) { Flipper.enabled?(:hardware_flow) } do
-      resource :funding_request, only: [ :create ], module: :projects
-    end
+    resource :funding_request, only: [ :create ], module: :projects
     resource :mission, only: [ :create, :destroy ], module: :projects, controller: "missions"
     resource :magic, only: [ :create, :destroy ], module: :projects, controller: "magic"
     resource :fire_nomination, only: [ :create, :destroy ], module: :projects


### PR DESCRIPTION
## Summary
- Route-level `constraints` checked `Flipper.enabled?(:hardware_flow)` **globally** (no user), so they always failed when the flag is only enabled per-user — returning 404 before the controller is ever hit.
- Removed the constraints from all 4 hardware route groups (lookout sessions, presentable hardware flags, admin funding requests, user funding requests).
- Access control is already handled by per-user `Flipper.enabled?(:hardware_flow, current_user)` checks in each controller's `before_action`.

// generated with claude