### PR TITLE
Fix formatting of sign-up message in hero section

### DIFF
--- a/app/views/landing/sections/_hero.html.erb
+++ b/app/views/landing/sections/_hero.html.erb
@@ -10,7 +10,7 @@
     </h1>
     <p class="hero__subhead">The largest STEM event of the summer:<br class="hero__subhead-break">make anything you want and earn free prizes.
       <br><br>
-      Sign up to get free Stardance stickers and a chance<br class="hero__subhead-break">to get an AMD GPU every week! <%= link_to "19 or older?", "https://docs.google.com/document/d/e/2PACX-1vQu3H0kYWgFTZ4080k-kqzwLObJ2zJe_QMDO8XQcDf8UH9AwDtG31oURSGBQ9nEJ3kExbSKnDYAx1-E/pub", target: "_blank", rel: "noopener" %></p>
+      Sign up to get free Stardance stickers and a chance <br class="hero__subhead-break">to get an AMD GPU every week! <%= link_to "19 or older?", "https://docs.google.com/document/d/e/2PACX-1vQu3H0kYWgFTZ4080k-kqzwLObJ2zJe_QMDO8XQcDf8UH9AwDtG31oURSGBQ9nEJ3kExbSKnDYAx1-E/pub", target: "_blank", rel: "noopener" %></p>
 
     <%= render "landing/sections/rsvp_form",
                new_onboarding: true,


### PR DESCRIPTION


## what's this do?

there was a typo which made it so that there was no space between chance and to "chanceto". Fixed it to add that space

## ai?

No AI was used. 

FIXES #534 