### PR TITLE
fix(lookout): chunk heartbeats

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       argon2-kdf (>= 1)
     bootsnap (1.24.6)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     browser (6.2.0)
     builder (3.3.0)

--- a/app/services/hackatime_service.rb
+++ b/app/services/hackatime_service.rb
@@ -105,15 +105,20 @@ class HackatimeService
     def push_heartbeats(api_key:, heartbeats:)
       return false if api_key.blank? || heartbeats.blank?
 
-      response = heartbeat_connection.post("users/current/heartbeats.bulk") do |req|
-        req.headers["Authorization"] = "Bearer #{api_key}"
-        req.body = heartbeats.to_json
+      all_success = true
+      heartbeats.each_slice(100) do |slice|
+        response = heartbeat_connection.post("users/current/heartbeats.bulk") do |req|
+          req.headers["Authorization"] = "Bearer #{api_key}"
+          req.body = slice.to_json
+        end
+
+        unless response.success?
+          Rails.logger.error "HackatimeService push_heartbeats error: #{response.status} - #{response.body}"
+          all_success = false
+        end
       end
 
-      return true if response.success?
-
-      Rails.logger.error "HackatimeService push_heartbeats error: #{response.status} - #{response.body}"
-      false
+      all_success
     rescue => e
       Rails.logger.error "HackatimeService push_heartbeats exception: #{e.message}"
       false


### PR DESCRIPTION
## what's this do?

Lookout timelapses previously would fail to sync their heartbeats to hackatime as `heartbeats.bulk` limits to 100 per request. This chunks them across multiple requests to fix that.

## show it works

<img width="1641" height="797" alt="image" src="https://github.com/user-attachments/assets/f9a99f50-772e-412e-85d9-5f40edd4394d" />

Screenshot from the hackatime dashboard showcasing that one of of the sessions was 27m, which previously would fail to sync.

## ai?

asked ChatGPT to convert my pseudocode into Ruby since I don't know the syntax. Copilot might also try to review this PR since I can't find the button to tell it not to do that--sorry!
