### PR TITLE
Fix: removing a wishlisted item from the shop sidebar shows raw JSON

### DIFF
--- a/app/components/discover_rail/shop_wishlist_widget.html.erb
+++ b/app/components/discover_rail/shop_wishlist_widget.html.erb
@@ -4,7 +4,7 @@
     <div class="shop-goals__container">
       <div class="shop-goals__items">
         <% wishlisted_items.each do |item| %>
-          <div class="shop-goals__item">
+          <div class="shop-goals__item" id="shop_wishlist_item_<%= item.id %>">
             <%= button_to shop_wishlist_path(item.id), method: :delete, class: "shop-goals__remove", title: "Remove from wishlist" do %>
               &times;
             <% end %>

--- a/app/controllers/shop/wishlists_controller.rb
+++ b/app/controllers/shop/wishlists_controller.rb
@@ -10,6 +10,10 @@ class Shop::WishlistsController < Shop::BaseController
   def destroy
     authorize :shop
     current_user.shop_wishlists.where(shop_item_id: params[:id]).destroy_all
-    render json: { wishlisted: false }
+
+    respond_to do |format|
+      format.json { render json: { wishlisted: false } }
+      format.turbo_stream { render turbo_stream: turbo_stream.remove("shop_wishlist_item_#{params[:id]}") }
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #252.

Clicking the × on an item in the shop page's **WISHLIST** sidebar widget
(`app/components/discover_rail/shop_wishlist_widget.html.erb`) submits a
`button_to ... method: :delete` form. Turbo Drive intercepts this and expects
an HTML/Turbo Stream response, but `Shop::WishlistsController#destroy` only
ever rendered `render json: { wishlisted: false }`. Turbo can't process a bare
JSON response, so it ends up displaying the raw `{"wishlisted":false}` JSON
instead of removing the item from the list.

## Fix

- `Shop::WishlistsController#destroy` now responds to both formats:
  - `format.json` — unchanged, still returns `{ wishlisted: false }` for the
    `shop-wishlist` Stimulus controller's `fetch()` calls (used by the star
    toggle on item cards).
  - `format.turbo_stream` — new, renders
    `turbo_stream.remove("shop_wishlist_item_#{params[:id]}")`, which is what
    the sidebar widget's `button_to` form now receives via Turbo Drive.
- `discover_rail/shop_wishlist_widget.html.erb` — added
  `id="shop_wishlist_item_<%= item.id %>"` to each `.shop-goals__item` so the
  turbo stream `remove` action has a target to remove.

This is a small, additive change (`respond_to` + one `id` attribute) and
doesn't touch the existing JSON path used elsewhere.

## Testing

Ran the app locally via `docker compose` (Rails 8.1, dev env), signed in as
an existing user with an item wishlisted, and exercised the endpoint exactly
as the browser would.

**Before (on `main`)** — Turbo-driven DELETE returns raw JSON, which Turbo
shows as the page body:
```
{"wishlisted":false}
```

**After (this branch)** — same request now returns a turbo stream that
removes just that item:
```
$ curl -X DELETE /shop/wishlists/1 \
    -H "Accept: text/vnd.turbo-stream.html, text/html, application/xhtml+xml" \
    -H "X-CSRF-Token: ..."
status=200 content_type=text/vnd.turbo-stream.html; charset=utf-8

<turbo-stream action="remove" target="shop_wishlist_item_1"></turbo-stream>
```

- Confirmed the `ShopWishlist` row is deleted from the DB.
- Confirmed `/shop` falls back to the "Tap the star on any item to add it
  here." placeholder once the wishlist is empty.
- Confirmed the existing JSON path (item-card star toggle,
  `Accept: application/json`) is unaffected — still returns
  `{"wishlisted":true}` / `{"wishlisted":false}`.
- Probed double-removal and a non-existent item id — both return a clean
  `200` turbo-stream no-op (no errors).

## AI disclosure

This PR was implemented and verified by Claude Code (Anthropic): it
identified the root cause, wrote the fix, and ran the verification steps
above (boot the app via Docker, sign in, and exercise the endpoint) against
a local dev environment.