### PR TITLE
fix(brakeman): brakeman out-of-date + git brakeman warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       argon2-kdf (>= 1)
     bootsnap (1.24.6)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     browser (6.2.0)
     builder (3.3.0)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -88,7 +88,30 @@
         79
       ],
       "note": ""
+    },
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "afd46b7b61f1a5de4583920dedb365d30d8286afdeb70a759bf74bea1b3ea30e",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/services/git_host/git_cli.rb",
+      "line": 89,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "Open3.capture2(\"git\", \"-C\", clone_path, \"log\", \"--format=#{\"%H%n%s%n%b%n%an%n%ae%n%aI%n---COMMIT_END---\"}\", \"--since=#{since.iso8601}\", \"--until=#{before.iso8601}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "GitHost::GitCli",
+        "method": "parse_git_log"
+      },
+      "user_input": "since.iso8601",
+      "confidence": "Medium",
+      "cwe_id": [
+        77
+      ],
+      "note": "False positive: Open3.capture2(*cmd) uses the multi-arg array form (no shell); the interpolated values are a frozen format string and iso8601 timestamps, each a single --flag=value arg"
     }
   ],
-  "brakeman_version": "8.0.4"
+  "brakeman_version": "8.0.5"
 }


### PR DESCRIPTION
## what's this do?

Update Brakeman to 8.0.5 and fix CI checks

## show it works

<img width="449" height="65" alt="image" src="https://github.com/user-attachments/assets/07907a58-807d-4e21-ba7d-9aabcf429b66" />

## ai?

No lol