### PR TITLE
chore(project): drop unused project_categories column (follow-up to #360)

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -13,7 +13,6 @@
 #  marked_fire_at       :datetime
 #  memberships_count    :integer          default(0), not null
 #  nominated_fire_at    :datetime
-#  project_categories   :string           default([]), is an Array
 #  project_type         :string
 #  readme_url           :text
 #  repo_url             :text

--- a/db/migrate/20260615145040_drop_project_categories_from_projects.rb
+++ b/db/migrate/20260615145040_drop_project_categories_from_projects.rb
@@ -1,0 +1,5 @@
+class DropProjectCategoriesFromProjects < ActiveRecord::Migration[8.1]
+  def change
+    safety_assured { remove_column :projects, :project_categories, :string, array: true, default: [] }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_11_210539) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_15_145040) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
@@ -751,7 +751,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_210539) do
     t.integer "memberships_count", default: 0, null: false
     t.datetime "nominated_fire_at"
     t.bigint "nominated_fire_by_id"
-    t.string "project_categories", default: [], array: true
     t.string "project_type"
     t.text "readme_url"
     t.text "repo_url"

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -15,7 +15,6 @@
 #  marked_fire_at       :datetime
 #  memberships_count    :integer          default(0), not null
 #  nominated_fire_at    :datetime
-#  project_categories   :string           default([]), is an Array
 #  project_type         :string
 #  readme_url           :text
 #  repo_url             :text

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -13,7 +13,6 @@
 #  marked_fire_at       :datetime
 #  memberships_count    :integer          default(0), not null
 #  nominated_fire_at    :datetime
-#  project_categories   :string           default([]), is an Array
 #  project_type         :string
 #  readme_url           :text
 #  repo_url             :text


### PR DESCRIPTION
Follow-up to #360. Splitting the destructive migration out so the code ships first.

#360 removes every code reference to `project_categories` (the validation, the Gorse payloads, the admin and project views) but deliberately leaves the column in the database. This PR is the second half of that expand/contract: it drops the now-unused column.

Order matters. This must merge only after #360 is merged and deployed. Until #360 is live, `main` still reads `project_categories` at runtime (the project validation calls it on every save), so dropping the column before that would break project saves. After #360 lands, rebase this on main and merge.

The migration is irreversible in practice. `remove_column` is reversible at the schema level so a rollback re-adds the column definition, but the data in it is gone for good.

I left this as a draft on purpose so nobody merges it ahead of #360.
