### PR TITLE
fix(certification): redirect to queue dashboard after review

### DIFF
--- a/app/controllers/admin/certification/ships_controller.rb
+++ b/app/controllers/admin/certification/ships_controller.rb
@@ -50,7 +50,7 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
     if @ship.update(ship_params)
       verb = @ship.approved? ? "Approved" : "Returned"
       count = ::Certification::Ship.reviewed_today(current_user)
-      redirect_to next_admin_certification_ships_path,
+      redirect_to admin_certification_ships_path,
                   notice: "#{verb} “#{@ship.project.title}.” That's #{count} reviewed today. Keep going!"
     else
       render :show, status: :unprocessable_entity


### PR DESCRIPTION
## what's this do?

instead of automatically claiming and redirecting to the next oldest project in the queue which is very annoying, redirect the reviewer back to the main dashboard 
## show it works


https://github.com/user-attachments/assets/059fb64c-bc97-4c53-8d66-b740ff907ae7


## ai?
No