### PR TITLE
feat(rating): improve copy and add clearer info about giving ratings

### DIFF
--- a/app/assets/stylesheets/pages/_votes.scss
+++ b/app/assets/stylesheets/pages/_votes.scss
@@ -20,12 +20,125 @@
 
 .vote-page__toolbar {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-m);
+  flex-direction: column;
+  gap: var(--space-s);
   padding: 20px 24px;
   border-radius: var(--profile-radius);
   background: var(--color-set-3-bg);
+}
+
+.vote-page__toolbar-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-m);
+}
+
+.vote-page__past-ratings {
+  flex-shrink: 0;
+  padding: 6px var(--space-m);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  font-size: var(--font-size-s);
+  color: var(--color-space-text);
+  text-decoration: none;
+  white-space: nowrap;
+  transition:
+    background 150ms ease,
+    border-color 150ms ease;
+
+  &:hover,
+  &:focus-visible {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(255, 255, 255, 0.4);
+    outline: none;
+  }
+}
+
+.vote-page__info-bar {
+  padding: var(--space-s) var(--space-m);
+  border-radius: var(--profile-radius);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.vote-page__info-votes {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+}
+
+.vote-page__info-votes-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-s);
+}
+
+.vote-page__info-right {
+  display: flex;
+  align-items: center;
+  gap: var(--space-m);
+}
+
+.vote-page__info-hint {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  margin-left: 4px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--color-space-text);
+  opacity: 0.6;
+  cursor: help;
+  vertical-align: middle;
+
+  &:hover,
+  &:focus-visible {
+    opacity: 1;
+    border-color: rgba(255, 255, 255, 0.6);
+    outline: none;
+  }
+}
+
+.vote-page__info-label {
+  font-size: var(--font-size-s);
+  font-weight: 600;
+  opacity: 0.7;
+}
+
+.vote-page__info-count {
+  font-size: var(--font-size-s);
+  font-weight: 700;
+  color: var(--color-brand-cream);
+}
+
+.vote-page__info-progress {
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  appearance: none;
+
+  &::-webkit-progress-bar {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 3px;
+  }
+
+  &::-webkit-progress-value {
+    background: var(--color-brand-mint);
+    border-radius: 3px;
+    transition: width 300ms ease;
+  }
+
+  &::-moz-progress-bar {
+    background: var(--color-brand-mint);
+    border-radius: 3px;
+  }
 }
 
 .vote-page__title {
@@ -276,6 +389,18 @@
   &:focus {
     border-color: var(--color-border-input-focus);
     outline: none;
+  }
+}
+
+.vote-scorecard__warning {
+  margin: 0;
+  font-size: var(--font-size-s);
+  line-height: 1.4;
+  opacity: 0.6;
+
+  strong {
+    color: var(--color-brand-cream);
+    opacity: 1;
   }
 }
 
@@ -553,13 +678,20 @@
   }
 
   .vote-page__toolbar {
+    padding: var(--space-m);
+  }
+
+  .vote-page__toolbar-top {
     align-items: flex-start;
     flex-direction: column;
-    padding: var(--space-m);
   }
 
   .vote-page__skip {
     width: 100%;
+  }
+
+  .vote-page__info-right {
+    flex-wrap: wrap;
   }
 
   .vote-scorecard__title {

--- a/app/assets/stylesheets/pages/projects/_show.scss
+++ b/app/assets/stylesheets/pages/projects/_show.scss
@@ -7,7 +7,7 @@
 .project-show__feed,
 .project-show__notice,
 .project-show__onboarding,
-.project-show__payout-votes,
+.payout-checklist,
 turbo-frame#project_hero {
   width: min(100%, 922px);
   align-self: center;
@@ -1209,65 +1209,128 @@ turbo-frame#project_hero {
 }
 
 // Payout votes panel — same set-1 surface as the notice.
-.project-show__payout-votes {
-  // Match the mission module's tile (.mission-panel).
-  padding: var(--space-m);
-  border-radius: 14px;
-  border: 1px solid var(--color-space-border, rgba(255, 255, 255, 0.12));
-  background: var(--color-space-card, rgba(255, 255, 255, 0.04));
+.payout-checklist {
+  background: rgba(217, 217, 217, 0.1);
+  border: 2px solid var(--color-brand-highlight);
+  border-radius: 16px;
+  padding: 1.25rem 1.25rem 1rem;
   color: var(--color-space-text);
 }
 
-.project-show__payout-votes-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-m);
-  flex-wrap: wrap;
-  margin-bottom: var(--space-s);
+.payout-checklist__title {
+  color: var(--color-brand-highlight);
+  font-family: var(--font-family-text);
+  font-size: 1.15rem;
+  font-weight: 800;
+  margin: 0 0 1rem;
 }
 
-.project-show__payout-votes-cta {
-  display: inline-flex;
-  flex: 0 0 auto;
-}
-
-.project-show__payout-votes-title {
+.payout-checklist__steps {
+  list-style: none;
   margin: 0;
-  // Branding §2.1 Body size, bold.
-  font-size: 1.1875rem;
-  font-weight: 700;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
-.project-show__payout-votes-info {
-  cursor: help;
+.payout-checklist__step {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+
+  &--done {
+    opacity: 0.5;
+  }
 }
 
-.project-show__payout-votes-row {
+.payout-checklist__icon {
+  flex-shrink: 0;
   display: flex;
   align-items: center;
-  gap: var(--space-m);
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  font-size: 0.8rem;
+  font-weight: 700;
+  line-height: 1;
+
+  .payout-checklist__step--done & {
+    background: var(--color-brand-highlight);
+    color: var(--color-set-1-bg);
+  }
 }
 
-.project-show__payout-votes-progress {
+.payout-checklist__body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
   flex: 1;
-  height: 14px;
+  min-width: 0;
+}
+
+.payout-checklist__label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 24px;
+}
+
+.payout-checklist__progress-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.payout-checklist__bar {
+  flex: 1;
+  height: 6px;
+  border-radius: 3px;
   appearance: none;
 
   &::-webkit-progress-bar {
-    background: var(--color-overlay-light);
-    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 3px;
   }
 
   &::-webkit-progress-value {
-    background: var(--color-space-accent);
-    border-radius: 999px;
+    background: var(--color-brand-highlight);
+    border-radius: 3px;
+  }
+
+  &::-moz-progress-bar {
+    background: var(--color-brand-highlight);
+    border-radius: 3px;
   }
 }
 
-.project-show__payout-votes-text {
-  font-size: 1rem;
-  white-space: nowrap;
+.payout-checklist__count {
+  flex-shrink: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  opacity: 0.6;
+}
+
+.payout-checklist__hint {
+  font-size: 0.8rem;
+  opacity: 0.7;
+  line-height: 1.35;
+}
+
+.payout-checklist__action {
+  display: inline-block;
+  margin-top: 2px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-brand-highlight);
+  text-decoration: underline;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    color: var(--color-brand-cream);
+  }
 }
 
 // Mobile

--- a/app/components/discover_rail/payout_votes_widget.html.erb
+++ b/app/components/discover_rail/payout_votes_widget.html.erb
@@ -1,26 +1,68 @@
-<section class="project-show__payout-votes" aria-label="Votes needed to unlock payout">
-  <div class="project-show__payout-votes-header">
-    <h3 class="project-show__payout-votes-title">Votes needed to unlock payout <span class="project-show__payout-votes-info"
-          tabindex="0"
-          aria-label="What does this mean?"
-          data-controller="tooltip"
-          data-tooltip-title-value="Votes needed to unlock payout"
-          data-tooltip-message-value="This shows the number of times other people need to vote for your project!"
-          data-tooltip-position-value="top">ⓘ</span></h3>
-    <%= link_to "Go rate projects! →",
-                helpers.new_vote_path,
-                class: "action-btn action-btn--small action-btn--primary project-show__payout-votes-cta",
-                data: { turbo_frame: "_top" } %>
-  </div>
-  <div class="project-show__payout-votes-row">
-    <progress class="project-show__payout-votes-progress"
-              value="<%= votes[:current] %>"
-              max="<%= votes[:required] %>"></progress>
-    <div class="project-show__payout-votes-text">
-      <strong><%= votes[:current] %></strong> / <%= votes[:required] %>
-      <% if votes[:remaining] <= 0 %>
-        (ready!)
-      <% end %>
-    </div>
-  </div>
+<section class="payout-checklist" aria-label="Payout progress">
+  <h3 class="payout-checklist__title">Payout progress</h3>
+
+  <% if votes[:static_prize] %>
+    <ol class="payout-checklist__steps">
+      <li class="payout-checklist__step payout-checklist__step--done">
+        <span class="payout-checklist__icon">✓</span>
+        <div class="payout-checklist__body">
+          <span class="payout-checklist__label">Ship approved</span>
+        </div>
+      </li>
+
+      <li class="payout-checklist__step">
+        <span class="payout-checklist__icon">2</span>
+        <div class="payout-checklist__body">
+          <span class="payout-checklist__label">Get stardust!</span>
+          <span class="payout-checklist__hint">This project has a fixed payout. You'll receive stardust once payouts open!</span>
+        </div>
+      </li>
+    </ol>
+  <% else %>
+    <ol class="payout-checklist__steps">
+      <% ratings_done = votes[:ratings_given] >= votes[:ratings_total] %>
+      <li class="payout-checklist__step <%= 'payout-checklist__step--done' if ratings_done %>">
+        <span class="payout-checklist__icon"><%= ratings_done ? '✓' : '1' %></span>
+        <div class="payout-checklist__body">
+          <span class="payout-checklist__label">Rate <%= votes[:ratings_total] %> projects</span>
+          <div class="payout-checklist__progress-row">
+            <progress class="payout-checklist__bar"
+                      value="<%= votes[:ratings_given] %>"
+                      max="<%= votes[:ratings_total] %>"></progress>
+            <span class="payout-checklist__count"><%= votes[:ratings_given] %>/<%= votes[:ratings_total] %></span>
+          </div>
+          <% unless ratings_done %>
+            <%= link_to "Go rate →", helpers.new_vote_path,
+                        class: "payout-checklist__action",
+                        data: { turbo_frame: "_top" } %>
+          <% end %>
+        </div>
+      </li>
+
+      <% votes_done = votes[:remaining] <= 0 %>
+      <li class="payout-checklist__step <%= 'payout-checklist__step--done' if votes_done %>">
+        <span class="payout-checklist__icon"><%= votes_done ? '✓' : '2' %></span>
+        <div class="payout-checklist__body">
+          <span class="payout-checklist__label">Get <%= votes[:required] %> ratings on your project</span>
+          <div class="payout-checklist__progress-row">
+            <progress class="payout-checklist__bar"
+                      value="<%= votes[:current] %>"
+                      max="<%= votes[:required] %>"></progress>
+            <span class="payout-checklist__count"><%= votes[:current] %>/<%= votes[:required] %></span>
+          </div>
+          <% unless votes_done %>
+            <span class="payout-checklist__hint">Others are assigned your project automatically</span>
+          <% end %>
+        </div>
+      </li>
+
+      <li class="payout-checklist__step">
+        <span class="payout-checklist__icon">3</span>
+        <div class="payout-checklist__body">
+          <span class="payout-checklist__label">Get stardust!</span>
+          <span class="payout-checklist__hint">Payouts will open soon. Once they do, you'll get stardust paid out!</span>
+        </div>
+      </li>
+    </ol>
+  <% end %>
 </section>

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -165,17 +165,25 @@ class ProjectsController < ApplicationController
           latest_ship_event.present? &&
           latest_ship_event.certification_status == "approved" &&
           latest_ship_event.payout.blank? &&
-          latest_ship_event.mission_submission&.payout_path != "static_prize" &&
           !latest_ship_event.mission_submission&.rejected?
+
+        is_static = latest_ship_event.mission_submission&.payout_path == "static_prize"
 
         required = Post::ShipEvent::VOTES_REQUIRED_FOR_PAYOUT
         current = latest_ship_event.votes.payout_countable.count
         remaining = [ required - current, 0 ].max
 
+        ratings_total = Post::ShipEvent::VOTE_COST_PER_SHIP
+        ratings_remaining = [ -current_user.vote_balance, 0 ].max
+        ratings_given = ratings_total - ratings_remaining
+
         @votes_for_payout = {
           current: current,
           required: required,
-          remaining: remaining
+          remaining: remaining,
+          ratings_given: ratings_given,
+          ratings_total: ratings_total,
+          static_prize: is_static
         }
       end
     end

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -9,6 +9,10 @@ class VotesController < ApplicationController
       load_assignment
       track_assignment_view if @assignment
     end
+
+    @ratings_total = Post::ShipEvent::VOTE_COST_PER_SHIP
+    remaining = current_user ? [ -current_user.vote_balance, 0 ].max : 0
+    @ratings_given = @ratings_total - remaining
   end
 
   def create
@@ -30,7 +34,7 @@ class VotesController < ApplicationController
                        properties: submit_timing_properties(@assignment)
                          .merge(score_properties(@vote))
                          .merge(feedback_stats(@vote.reason)))
-      redirect_to new_rate_path, notice: "Vote submitted."
+      redirect_to new_rate_path, notice: "Rating submitted."
     else
       @ship_event = @assignment.ship_event
       @project = @ship_event.project

--- a/app/views/votes/_score_input.html.erb
+++ b/app/views/votes/_score_input.html.erb
@@ -1,3 +1,10 @@
+<%
+  score_hints = {
+    (1..3) => "For projects that need major work",
+    (4..6) => "Most projects fall in this range",
+    (7..9) => "For exceptionally good projects"
+  }
+%>
 <fieldset class="vote-score">
   <legend class="vote-score__legend">
     <span class="vote-score__name"><%= category.to_s.humanize %></span>
@@ -7,12 +14,19 @@
   <div class="vote-score__options">
     <% (Vote::MIN_SCORE..Vote::MAX_SCORE).each do |score| %>
       <% input_id = "vote_#{column}_#{score}" %>
+      <% hint = score_hints.find { |range, _| range.include?(score) }&.last %>
       <%= form.radio_button column,
                             score,
                             id: input_id,
                             class: "vote-score__input",
                             checked: vote.public_send(column) == score %>
-      <%= form.label column, score, for: input_id, class: "vote-score__star" do %>
+      <%= form.label column, score, for: input_id,
+                     class: "vote-score__star",
+                     data: {
+                       controller: "tooltip",
+                       tooltip_message_value: hint,
+                       tooltip_position_value: "top"
+                     } do %>
         <%= inline_svg_tag "icons/star_fill.svg", class: "vote-score__star-icon", aria_hidden: true %>
         <span class="vote-score__star-text"><%= score %></span>
       <% end %>

--- a/app/views/votes/_scorecard.html.erb
+++ b/app/views/votes/_scorecard.html.erb
@@ -22,7 +22,7 @@
 
     <% if vote.errors.any? %>
       <div class="vote-scorecard__errors" role="alert">
-        <p class="vote-scorecard__errors-title">Check your vote</p>
+        <p class="vote-scorecard__errors-title">Check your rating</p>
         <ul class="vote-scorecard__errors-list">
           <% vote.errors.full_messages.each do |message| %>
             <li><%= message %></li>
@@ -53,8 +53,15 @@
                          class: "vote-scorecard__textarea" %>
     </div>
 
+    <p class="vote-scorecard__warning">
+      Ratings are reviewed. Thoughtful ratings earn a
+      <strong>1.2× payout blessing</strong>.
+      Spam or low-effort ratings will get your
+      <strong>payout halved</strong>.
+    </p>
+
     <%= render ActionButtonComponent.new(
-          text: "Submit vote",
+          text: "Submit rating",
           disabled: true,
           class: "vote-scorecard__submit",
           data: { vote_scorecard_target: "submit" }

--- a/app/views/votes/_toolbar.html.erb
+++ b/app/views/votes/_toolbar.html.erb
@@ -1,11 +1,38 @@
 <header class="vote-page__toolbar">
-  <h1 id="vote-page-title" class="vote-page__title">Rate this project</h1>
+  <div class="vote-page__toolbar-top">
+    <h1 id="vote-page-title" class="vote-page__title">Rate this project</h1>
 
-  <%= button_to votes_skip_path,
-                method: :post,
-                params: { vote_assignment_id: assignment.id },
-                class: "vote-page__skip" do %>
-    <span>Skip</span>
-    <span aria-hidden="true">→</span>
-  <% end %>
+    <%= button_to votes_skip_path,
+                  method: :post,
+                  params: { vote_assignment_id: assignment.id },
+                  class: "vote-page__skip" do %>
+      <span>Skip</span>
+      <span aria-hidden="true">→</span>
+    <% end %>
+  </div>
+
+  <div class="vote-page__info-bar">
+    <div class="vote-page__info-votes">
+      <div class="vote-page__info-votes-header">
+        <span class="vote-page__info-label">
+          Ratings given
+          <span class="vote-page__info-hint"
+                data-controller="tooltip"
+                data-tooltip-message-value="Rate <%= @ratings_total %> projects per ship to unlock your payout."
+                data-tooltip-position-value="bottom"
+                tabindex="0"
+                aria-label="What does this mean?">?</span>
+        </span>
+        <div class="vote-page__info-right">
+          <span class="vote-page__info-count"><%= @ratings_given %> / <%= @ratings_total %></span>
+          <%= link_to "#", class: "vote-page__past-ratings" do %>
+            Past ratings →
+          <% end %>
+        </div>
+      </div>
+      <progress class="vote-page__info-progress"
+                value="<%= @ratings_given %>"
+                max="<%= @ratings_total %>"></progress>
+    </div>
+  </div>
 </header>


### PR DESCRIPTION
NO MORE HELP CHANNEL QUESTIONS YAY!


change project sidebar to be like this
<img width="338" height="392" alt="image" src="https://github.com/user-attachments/assets/b55d65e9-d562-42f4-ab4d-c4c5714e90ad" />


like this for fixed-payout projects
<img width="271" height="199" alt="image" src="https://github.com/user-attachments/assets/f97c77ac-d84e-4b1d-88cb-8716ec982173" />


progress for rating
<img width="603" height="94" alt="image" src="https://github.com/user-attachments/assets/4757a87c-e985-4916-ba65-13aecef68770" />


tooltip in scorecard
<img width="445" height="145" alt="image" src="https://github.com/user-attachments/assets/a6c13382-80f8-45e3-bc51-ae2e93e0e147" />


things that i haven't figured out yet
- should people who haven't shipped be able to access rating page? if not, they should get a warning right?
- same w fixed payout people
