### PR TITLE
fix(certification): fixing screenshots ysws airtable job

### DIFF
--- a/app/jobs/certification/ysws_airtable_sync_job.rb
+++ b/app/jobs/certification/ysws_airtable_sync_job.rb
@@ -212,10 +212,10 @@ module Certification
       posts_to_check = [ review.post_ship_event, *devlog_posts ].compact
       ship_event_screenshot_url = posts_to_check.lazy.filter_map { |p| screenshot_url_for_post(p) }.first
 
-      screenshot_attachments = [
-        ship_event_screenshot_url.present? ? { "url" => ship_event_screenshot_url } : nil,
-        banner_url.present? ? { "url" => banner_url } : nil
-      ].compact
+      # Prefer an actual ship/devlog screenshot; fall back to the project banner
+      # only when there is no screenshot — never send both.
+      selected_screenshot_url = ship_event_screenshot_url.presence || banner_url
+      screenshot_attachments = selected_screenshot_url.present? ? [ { "url" => selected_screenshot_url } ] : []
       log_screenshot_result(review, screenshot_attachments, ship_event_screenshot_url, banner_url, posts_to_check, project)
 
       {

--- a/app/jobs/certification/ysws_airtable_sync_job.rb
+++ b/app/jobs/certification/ysws_airtable_sync_job.rb
@@ -212,6 +212,12 @@ module Certification
       posts_to_check = [ review.post_ship_event, *devlog_posts ].compact
       ship_event_screenshot_url = posts_to_check.lazy.filter_map { |p| screenshot_url_for_post(p) }.first
 
+      screenshot_attachments = [
+        ship_event_screenshot_url.present? ? { "url" => ship_event_screenshot_url } : nil,
+        banner_url.present? ? { "url" => banner_url } : nil
+      ].compact
+      log_screenshot_result(review, screenshot_attachments, ship_event_screenshot_url, banner_url, posts_to_check, project)
+
       {
         # Identity
         "review_id" => review.id.to_s, # tik
@@ -242,10 +248,7 @@ module Certification
         "Playable URL" => project.demo_url, # tik
         "readme_url" => project.readme_url, # tik
         "Description" => project.description, # tik
-        "Screenshot" => [
-          ship_event_screenshot_url.present? ? { "url" => ship_event_screenshot_url } : nil,
-          banner_url.present? ? { "url" => banner_url } : nil
-        ].compact, # tik
+        "Screenshot" => screenshot_attachments, # tik
 
         # Review Data
         "reviewer" => review.reviewer&.display_name || review.reviewer&.email || "Unknown", # tik
@@ -359,31 +362,89 @@ module Certification
       hours > 0 ? "#{hours}h #{remaining_minutes}min" : "#{remaining_minutes}min"
     end
 
-    def banner_url_for_project(project)
-      return nil unless project.banner.attached?
+    # Active Storage URLs handed to Airtable must be ABSOLUTE and publicly
+    # fetchable: Airtable downloads the file from the URL server-side, some time
+    # after the upsert returns. If the URL is blank, points at a non-public host
+    # (e.g. a Codespaces dev forward), or uses the wrong scheme, Airtable just
+    # leaves the attachment cell empty — the upsert still returns 200 and every
+    # plain-text field saves fine. So we build URLs from the app's canonical
+    # public host (asset_host, set in every deployed env) and only fall back to
+    # APP_HOST for local dev. Returns {} when no host is configured.
+    def public_url_options
+      return @public_url_options if defined?(@public_url_options)
 
-      host = ENV["APP_HOST"]
-      return nil if host.blank?
+      raw = Rails.application.config.asset_host.presence || ENV["APP_HOST"].presence
+      @public_url_options =
+        if raw.blank?
+          {}
+        else
+          raw = "https://#{raw}" unless raw.match?(%r{\Ahttps?://})
+          uri = URI.parse(raw)
+          options = { host: uri.host, protocol: uri.scheme }
+          options[:port] = uri.port if uri.port && ![ 80, 443 ].include?(uri.port)
+          options
+        end
+    rescue URI::InvalidURIError => e
+      Rails.logger.error("[YswsAirtableSyncJob] invalid asset_host/APP_HOST (#{raw.inspect}): #{e.message}")
+      @public_url_options = {}
+    end
 
-      rails_blob_url(project.banner, host: host)
+    # Builds an absolute, single-hop proxy URL for an Active Storage attachment.
+    # We use the proxy route — matching production's
+    # resolve_model_to_route = :rails_storage_proxy and the url_for(attachment)
+    # used throughout the views — rather than rails_blob_url. rails_blob_url
+    # returns a redirect that 302s to a short-lived signed storage URL; Airtable
+    # fetches some time after the upsert, so it could land on an expired target.
+    # The proxy URL serves the bytes from our own host in one request and its
+    # signed id does not expire.
+    def blob_url(attachment)
+      return nil if attachment.nil?
+
+      options = public_url_options
+      if options[:host].blank?
+        Rails.logger.error("[YswsAirtableSyncJob] no public host configured (asset_host / APP_HOST) — attachment URL skipped")
+        return nil
+      end
+
+      rails_storage_proxy_url(attachment, **options)
     rescue StandardError => e
-      Rails.logger.error("[YswsAirtableSyncJob] banner_url error: #{e.message}")
+      Rails.logger.error("[YswsAirtableSyncJob] blob_url error (#{attachment.class}): #{e.class}: #{e.message}")
       nil
+    end
+
+    def banner_url_for_project(project)
+      banner = project.display_banner
+      return nil unless banner&.attached?
+
+      blob_url(banner)
     end
 
     def screenshot_url_for_post(post)
       return nil unless post
 
-      screenshot = post.attachments.find { |a| a.image? }
-      return nil unless screenshot
+      blob_url(post.attachments.find { |a| a.image? })
+    end
 
-      host = ENV["APP_HOST"]
-      return nil if host.blank?
+    # Screams when the Screenshot field comes out empty so the cause is visible
+    # in logs/Sentry instead of failing silently. An empty field with source
+    # images present is a real misconfiguration (host/scheme); empty with no
+    # source images is expected (some reviews genuinely have no media).
+    def log_screenshot_result(review, attachments, screenshot_url, banner_url, posts_to_check, project)
+      if attachments.any?
+        Rails.logger.info("[YswsAirtableSyncJob] review ##{review.id} Screenshot → #{attachments.map { |a| a['url'] }}")
+        return
+      end
 
-      rails_blob_url(screenshot, host: host)
-    rescue StandardError => e
-      Rails.logger.error("[YswsAirtableSyncJob] screenshot_url error: #{e.message}")
-      nil
+      had_source_image = posts_to_check.any? { |p| p.attachments.any?(&:image?) } || project.display_banner&.attached?
+      detail = "screenshot_url=#{screenshot_url.inspect} banner_url=#{banner_url.inspect} host=#{public_url_options.inspect}"
+
+      if had_source_image
+        message = "[YswsAirtableSyncJob] review ##{review.id}: source images exist but produced NO Screenshot URLs — #{detail}"
+        Rails.logger.error(message)
+        Sentry.capture_message(message, level: :warning, extra: { ysws_review_id: review.id })
+      else
+        Rails.logger.warn("[YswsAirtableSyncJob] review ##{review.id}: no Screenshot — no source images found. #{detail}")
+      end
     end
 
     UNIFIED_YSWS_BASE_ID  = "app3A5kJwYqxMLOgh"


### PR DESCRIPTION
This fixes screenshots within the syncing airtable job - in prod screenshots weren't getting synced - now they will:

<img width="820" height="68" alt="image" src="https://github.com/user-attachments/assets/71454f5e-a90d-4310-b406-d250a85c1e28" />


Proof^