### PR TITLE
feat(profile): add button to open user in slack

### DIFF
--- a/app/assets/stylesheets/pages/user/_show.scss
+++ b/app/assets/stylesheets/pages/user/_show.scss
@@ -682,6 +682,18 @@ turbo-frame#profile_tabs {
       }
     }
   }
+
+  &--slack {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+}
+
+.profile__action-btn-icon {
+  width: 1em;
+  height: 1em;
+  vertical-align: -0.1em;
 }
 
 .profile__follow-form {

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -178,6 +178,14 @@
                     data-profile-edit-target="saveBtn"
                     hidden>Save</button>
           <% elsif current_user %>
+            <% if @user.slack_id.present? %>
+              <%= link_to "https://hackclub.slack.com/team/#{ERB::Util.url_encode(@user.slack_id)}",
+                          class: "profile__action-btn profile__action-btn--slack",
+                          target: "_blank",
+                          rel: "noopener noreferrer" do %>
+                <%= inline_svg_tag "icons/slack.svg", class: "profile__action-btn-icon" %> Open in Slack
+              <% end %>
+            <% end %>
             <%# link_to + data-turbo-method instead of button_to: button_to renders %>
             <%# its own <form>, which HTML5 parsing strips when nested inside the %>
             <%# profile-edit form_with — clicking it would otherwise submit the %>


### PR DESCRIPTION
add a button to profile to be able to open user in slack. only visible if you are logged in and user has slack id

<img width="357" height="80" alt="image" src="https://github.com/user-attachments/assets/22700b3c-b546-4d32-b4d5-7858d8a28c28" />
