### PR TITLE
fix(rng): don't save rolls for anonymous users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,8 +103,7 @@ class ApplicationController < ActionController::Base
   def sign_in_user(user, auth_level: "guest")
     session[:user_id] = user.id
     session[:auth_level] = auth_level
-    # Keep a daily number they rolled while logged out (see AnonymousRoll).
-    AnonymousRoll.new(cookies).claim!(user)
+    AnonymousRoll.new(cookies).clear!
   end
 
   # https://stackoverflow.com/questions/70960161/ruby-on-rails-back-button-that-will-take-you-back-to-the-previous-page

--- a/app/controllers/daily_rolls_controller.rb
+++ b/app/controllers/daily_rolls_controller.rb
@@ -89,8 +89,8 @@ class DailyRollsController < ApplicationController
   end
 
   # Logged-out: one cookie-backed roll per day. It lives in a signed cookie
-  # (never the DB, so it stays off the leaderboard) and is claimed onto the
-  # account at sign-in — see AnonymousRoll.
+  # (never the DB, so it stays off the leaderboard) and is cleared on
+  # sign-in so the user gets a fresh real roll.
   def roll_for_anonymous
     anon = AnonymousRoll.new(cookies)
     roll = anon.today

--- a/app/policies/daily_roll_policy.rb
+++ b/app/policies/daily_roll_policy.rb
@@ -2,7 +2,7 @@
 
 class DailyRollPolicy < ApplicationPolicy
   # Anyone can roll: signed-in rolls save to the account, logged-out rolls go
-  # to a cookie (claimed on sign-in).
+  # to a cookie (cleared on sign-in so they re-roll fresh).
   def create?
     true
   end

--- a/app/services/anonymous_roll.rb
+++ b/app/services/anonymous_roll.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 # The logged-out visitor's daily roll, kept in a signed cookie instead of the
-# database — so it never touches the leaderboard — and claimed onto their
-# account when they sign in. Wraps the cookie jar so the cookie name and its
-# "value|date" encoding live in exactly one place.
+# database — so it never touches the leaderboard. On sign-in the cookie is
+# cleared so the user gets a fresh real roll. Wraps the cookie jar so the
+# cookie name and its "value|date" encoding live in exactly one place.
 class AnonymousRoll
   COOKIE = :rng_roll
 
@@ -30,15 +30,7 @@ class AnonymousRoll
     DailyRoll.new(value: value, rolled_on: Date.current)
   end
 
-  # Persist today's pending roll onto the user (once), then drop the cookie.
-  # No-op when nothing is pending or they've already rolled today.
-  def claim!(user)
-    pending = today
+  def clear!
     @cookies.delete(COOKIE)
-    return if pending.nil? || DailyRoll.exists?(user: user, rolled_on: Date.current)
-
-    DailyRoll.create!(user: user, value: pending.value, rolled_on: Date.current)
-  rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
-    nil
   end
 end

--- a/app/views/daily_rolls/_hero.html.erb
+++ b/app/views/daily_rolls/_hero.html.erb
@@ -1,7 +1,7 @@
 <%# The big moment on /rng.
     - Signed in, today: your roll (or the roll button); reveal plays on a fresh roll.
     - Signed in, past date: your roll for that day, static, no copy.
-    - Logged out (anonymous: true): a cookie-backed roll + a sign-up CTA to save it.
+    - Logged out (anonymous: true): a cookie-backed roll + a sign-up CTA (onboarding flow).
     Locals: roll:, just_rolled:, for_today: (default true), date_label:, anonymous: (default false). %>
 <%
   for_today = local_assigns.fetch(:for_today, true)
@@ -25,13 +25,13 @@
 
     <% if anonymous %>
       <div class="rng-hero__cta">
-        <p class="rng-hero__cta-text">create an account to save this roll! :)</p>
+        <p class="rng-hero__cta-text">join stardance to get on the leaderboard!</p>
         <%= form_with url: onboarding_start_path, method: :post, class: "rng-hero__signup" do |form| %>
           <%= form.email_field :email, placeholder: "you@email.com", required: true,
                                autocomplete: "email", class: "rng-hero__signup-input" %>
-          <%= form.submit "save it →", class: "action-btn action-btn--primary action-btn--large rng-hero__signup-submit" %>
+          <%= form.submit "join →", class: "action-btn action-btn--primary action-btn--large rng-hero__signup-submit" %>
         <% end %>
-        <p class="rng-hero__cta-note">join stardance and you're on the leaderboard tomorrow too.</p>
+        <p class="rng-hero__cta-note">sign up and roll for real — yours will count on the board.</p>
       </div>
     <% else %>
       <span class="rng-hero__rank">#<%= roll.rank %> <%= for_today ? "today" : "that day" %></span>
@@ -59,7 +59,7 @@
                   form: { data: { turbo: true } },
                   data: { turbo_submits_with: "rolling…" } %>
     <% if anonymous %>
-      <p class="rng-hero__hint">biggest number wins. sign up to keep yours.</p>
+      <p class="rng-hero__hint">biggest number wins. sign up to get on the board.</p>
     <% else %>
       <%= link_to "see history", rng_history_path, class: "rng-hero__history-link" %>
     <% end %>


### PR DESCRIPTION
previous behaviour: when ur in anonymous/not logged in, you can roll rng and then create an account to save it.

this does not happen any more!