### PR TITLE
improve meta tags and ogimg preview

### DIFF
--- a/app/controllers/og_image_previews_controller.rb
+++ b/app/controllers/og_image_previews_controller.rb
@@ -18,13 +18,20 @@ class OgImagePreviewsController < ApplicationController
       return
     end
 
+    @preview_meta = OgImage::Preview.meta_for(@preview_name)
+
     respond_to do |format|
       format.html do
+        @has_og_image = !preview_class.to_png.nil?
         @previews = grouped_previews
       end
       format.png do
         png_data = preview_class.to_png
-        send_data png_data, type: "image/png", disposition: "inline"
+        if png_data
+          send_data png_data, type: "image/png", disposition: "inline"
+        else
+          head :no_content
+        end
       end
     end
   end

--- a/app/controllers/users/og_images_controller.rb
+++ b/app/controllers/users/og_images_controller.rb
@@ -5,7 +5,14 @@ class Users::OgImagesController < ApplicationController
   def show
     skip_authorization
 
-    png_data = OgImage::User.new(@user).to_png
+    counts = Post.where(user_id: @user.id).group(:postable_type).count
+    stats = {
+      projects_count: @user.projects.count,
+      ships_count: counts["Post::ShipEvent"] || 0,
+      devlogs_count: counts["Post::Devlog"] || 0
+    }
+
+    png_data = OgImage::User.new(@user, stats: stats).to_png
 
     expires_in 1.hour, public: true
     send_data png_data, type: "image/png", disposition: "inline"

--- a/app/services/og_image/devlog.rb
+++ b/app/services/og_image/devlog.rb
@@ -1,0 +1,39 @@
+module OgImage
+  class Devlog
+    PLACEHOLDER_PATH = Rails.root.join("app", "assets", "images", "profile", "default-banner.png").to_s
+
+    PREVIEWS = {
+      "default" => -> { new(has_image: true) },
+      "no_image" => -> { new(has_image: false) }
+    }.freeze
+
+    PREVIEW_META = {
+      "default" => {
+        title: "@hackclub_dev on LED Matrix | Stardance",
+        description: "Just finished wiring up the LED matrix! The colors are finally syncing with the music.",
+        url: "https://stardance.hackclub.com/projects/123/devlogs/456",
+        site_name: "Stardance - Hack Club",
+        twitter_card: "summary_large_image"
+      },
+      "no_image" => {
+        title: "@hackclub_dev on Power Supply v2 | Stardance",
+        description: "Spent 2 hours debugging a power issue. Turned out the ground wire was loose.",
+        url: "https://stardance.hackclub.com/projects/123/devlogs/789",
+        site_name: "Stardance - Hack Club",
+        twitter_card: "summary"
+      }
+    }.freeze
+
+    def initialize(has_image: true)
+      @has_image = has_image
+    end
+
+    def to_png
+      if @has_image && File.exist?(PLACEHOLDER_PATH)
+        File.read(PLACEHOLDER_PATH, mode: "rb")
+      else
+        nil
+      end
+    end
+  end
+end

--- a/app/services/og_image/home.rb
+++ b/app/services/og_image/home.rb
@@ -4,6 +4,16 @@ module OgImage
       "default" => -> { new }
     }.freeze
 
+    PREVIEW_META = {
+      "default" => {
+        title: "Stardance - Hack Club",
+        description: "The largest STEM event of the summer: make anything you want and earn free prizes.",
+        url: "https://stardance.hackclub.com",
+        site_name: "Stardance - Hack Club",
+        twitter_card: "summary_large_image"
+      }
+    }.freeze
+
     IMAGE_PATH = Rails.root.join("app", "assets", "images", "landing", "space", "og-default.png").to_s
 
     def render

--- a/app/services/og_image/preview.rb
+++ b/app/services/og_image/preview.rb
@@ -8,7 +8,8 @@ module OgImage
       OgImage::Extensions,
       OgImage::Shop,
       OgImage::User,
-      OgImage::Missions
+      OgImage::Missions,
+      OgImage::Devlog
     ].freeze
 
     class << self
@@ -26,6 +27,17 @@ module OgImage
         return nil unless klass
 
         klass::PREVIEWS[variant]&.call
+      end
+
+      def meta_for(name)
+        class_name, variant = name.to_s.split("/", 2)
+        variant ||= "default"
+
+        klass = VIEW_CLASSES.find { |k| k.name.demodulize.underscore == class_name }
+        return nil unless klass
+        return nil unless klass.const_defined?(:PREVIEW_META)
+
+        klass::PREVIEW_META[variant]
       end
     end
   end

--- a/app/services/og_image/preview.rb
+++ b/app/services/og_image/preview.rb
@@ -1,15 +1,12 @@
 module OgImage
   module Preview
     VIEW_CLASSES = [
-      OgImage::Project,
-      OgImage::Start,
       OgImage::Home,
-      OgImage::Gallery,
-      OgImage::Extensions,
-      OgImage::Shop,
+      OgImage::Project,
       OgImage::User,
+      OgImage::Devlog,
       OgImage::Missions,
-      OgImage::Devlog
+      OgImage::Shop
     ].freeze
 
     class << self

--- a/app/services/og_image/project.rb
+++ b/app/services/og_image/project.rb
@@ -7,14 +7,45 @@ module OgImage
       "no_devlogs" => -> { new(sample_project(devlogs_count: 0)) }
     }.freeze
 
+    PREVIEW_META = {
+      "default" => {
+        title: "floob by @hackclub_dev | Stardance",
+        description: "A voice-controlled LED matrix that reacts to music beats in real time.",
+        url: "https://stardance.hackclub.com/projects/123",
+        site_name: "Stardance - Hack Club",
+        twitter_card: "summary_large_image"
+      },
+      "long_title" => {
+        title: "This Is A Really Long Project Title by @hackclub_dev | Stardance",
+        description: "12 devlogs · 42 hours worked",
+        url: "https://stardance.hackclub.com/projects/456",
+        site_name: "Stardance - Hack Club",
+        twitter_card: "summary_large_image"
+      },
+      "no_banner" => {
+        title: "floob by @hackclub_dev | Stardance",
+        description: "12 devlogs · 42 hours worked",
+        url: "https://stardance.hackclub.com/projects/789",
+        site_name: "Stardance - Hack Club",
+        twitter_card: "summary_large_image"
+      },
+      "no_devlogs" => {
+        title: "floob by @hackclub_dev | Stardance",
+        description: "A brand new project on Stardance.",
+        url: "https://stardance.hackclub.com/projects/101",
+        site_name: "Stardance - Hack Club",
+        twitter_card: "summary_large_image"
+      }
+    }.freeze
+
     class << self
-      def sample_project(title: "floob", devlogs_count: 12, banner: true, owner: "hackclub_dev", hours: 42)
+      def sample_project(title: "floob", devlogs_count: 12, banner: true, owner: "hackclub_dev", duration_seconds: 151_200)
         OpenStruct.new(
           title: title,
           devlogs_count: devlogs_count,
+          duration_seconds: duration_seconds,
           banner: MockAttachment.new(attached: banner),
-          memberships: MockMemberships.new(owner_name: owner),
-          total_hackatime_hours: hours
+          memberships: MockMemberships.new(owner_name: owner)
         )
       end
     end
@@ -26,11 +57,14 @@ module OgImage
 
     def render
       create_stardance_canvas
+      draw_diagonal_scrim(opacity: 0.3)
 
       draw_thumbnail
       place_stardance_logo(x: 80, y: 60, width: 240, height: 68)
       draw_title
-      draw_subtitle
+      draw_author
+      draw_stats
+      place_star_character(x: 30, y: 20, width: 140, height: 140, gravity: "SouthWest")
     end
 
     private
@@ -52,44 +86,43 @@ module OgImage
       @title_end_y = 170 + (lines_drawn * 72 * 1.3).to_i
     end
 
-    def draw_subtitle
+    def draw_author
+      owner = @project.memberships.find_by(role: :owner)&.user
+      return unless owner
+
+      draw_text(
+        "by @#{owner.display_name}",
+        x: 80,
+        y: @title_end_y + 10,
+        size: 38,
+        color: "#c9c9c9"
+      )
+      @author_end_y = @title_end_y + 60
+    end
+
+    def draw_stats
       stats = build_stats
       return if stats.empty?
 
-      start_y = @title_end_y + 20
-      author = stats.shift
-
-      if author && author[:text]
-        draw_text(
-          author[:text],
-          x: 80,
-          y: start_y,
-          size: 42,
-          color: "#c9c9c9"
-        )
-      end
-
-      stats_start_y = start_y + 80
+      start_y = (@author_end_y || @title_end_y) + 20
       stats.each_with_index do |stat, index|
         icon_x = 80
-        icon_y = stats_start_y + (index * 52)
+        icon_y = start_y + (index * 52)
         text_x = icon_x + 50
 
-        if stat[:icon]
-          icon_path = Rails.root.join("app", "assets", "images", "icons", stat[:icon])
-          place_image(
-            icon_path.to_s,
-            x: icon_x,
-            y: icon_y,
-            width: 42,
-            height: 42
-          )
-        end
+        icon_path = Rails.root.join("app", "assets", "images", "icons", stat[:icon])
+        place_image(
+          icon_path.to_s,
+          x: icon_x,
+          y: icon_y,
+          width: 42,
+          height: 42
+        )
 
         draw_text(
           stat[:text],
           x: text_x,
-          y: stats_start_y + (index * 52),
+          y: icon_y,
           size: 42,
           color: "#c9c9c9"
         )
@@ -100,7 +133,7 @@ module OgImage
       image_source = if @project.banner.attached?
         @project.banner
       else
-        logo_path
+        STAR_CHARACTER_PATH
       end
 
       place_image(
@@ -115,25 +148,15 @@ module OgImage
       )
     end
 
-    def logo_path
-      STAR_CHARACTER_PATH
-    end
-
     def build_stats
       stats = []
-      owner = @project.memberships.find_by(role: :owner)&.user
-      stats << { text: "by @#{owner.display_name}", icon: nil } if owner
-      stats << { text: "#{@project.devlogs_count} #{"devlog".pluralize @project.devlogs_count}", icon: "paper.png" } if @project.devlogs_count.positive?
-      stats << { text: "#{hours_logged} #{"hour".pluralize hours_logged} worked", icon: "time.png" } if hours_logged > 0
+      stats << { text: "#{@project.devlogs_count} #{"devlog".pluralize(@project.devlogs_count)}", icon: "paper.png" } if @project.devlogs_count.positive?
+      stats << { text: "#{hours_logged} #{"hour".pluralize(hours_logged)} worked", icon: "time.png" } if hours_logged > 0
       stats
     end
 
     def hours_logged
-      if @project.respond_to?(:total_hackatime_hours)
-        @project.total_hackatime_hours.to_i
-      else
-        0
-      end
+      (@project.duration_seconds.to_i / 3600.0).round
     end
   end
 end

--- a/app/services/og_image/user.rb
+++ b/app/services/og_image/user.rb
@@ -1,25 +1,15 @@
 module OgImage
   class MockUser
-    def initialize(display_name:, projects_count:, stardust_earned:, hours_logged:, joined_at: nil)
+    def initialize(display_name:, bio: nil)
       @display_name = display_name
-      @projects_count = projects_count
-      @stardust_earned = stardust_earned
-      @hours_logged = hours_logged
-      @created_at = joined_at || 3.months.ago
+      @bio = bio
+      @created_at = 3.months.ago
     end
 
-    attr_reader :display_name, :projects_count, :stardust_earned, :hours_logged, :created_at
+    attr_reader :display_name, :bio, :created_at
 
     def avatar
       MockAvatar.new
-    end
-
-    def balance
-      @stardust_earned
-    end
-
-    def devlog_seconds_total
-      @hours_logged * 3600
     end
   end
 
@@ -38,35 +28,64 @@ module OgImage
 
   class User < Base
     PREVIEWS = {
-      "default" => -> { new(sample_user) },
-      "new_user" => -> { new(sample_user(display_name: "New Member", projects_count: 0, stardust_earned: 0, hours_logged: 0)) },
-      "prolific" => -> { new(sample_user(display_name: "Super Builder", projects_count: 50, stardust_earned: 2500, hours_logged: 150)) }
+      "default" => -> { new(sample_user, stats: { projects_count: 5, ships_count: 2, devlogs_count: 12 }) },
+      "new_user" => -> { new(sample_user(display_name: "New Member"), stats: { projects_count: 0, ships_count: 0, devlogs_count: 0 }) },
+      "with_bio" => -> { new(sample_user(display_name: "hackclub_dev", bio: "Building cool stuff with LEDs and microcontrollers"), stats: { projects_count: 3, ships_count: 1, devlogs_count: 8 }) },
+      "long_name" => -> { new(sample_user(display_name: "superlongusername123"), stats: { projects_count: 42, ships_count: 10, devlogs_count: 200 }) }
+    }.freeze
+
+    PREVIEW_META = {
+      "default" => {
+        title: "@hackclub_dev | Stardance",
+        description: "5 projects · 2 ships · 12 devlogs",
+        url: "https://stardance.hackclub.com/users/hackclub_dev",
+        site_name: "Stardance - Hack Club",
+        twitter_card: "summary_large_image"
+      },
+      "new_user" => {
+        title: "@New Member | Stardance",
+        description: "0 projects · 0 ships · 0 devlogs",
+        url: "https://stardance.hackclub.com/users/new_member",
+        site_name: "Stardance - Hack Club",
+        twitter_card: "summary_large_image"
+      },
+      "with_bio" => {
+        title: "@hackclub_dev | Stardance",
+        description: "Building cool stuff with LEDs and microcontrollers",
+        url: "https://stardance.hackclub.com/users/hackclub_dev",
+        site_name: "Stardance - Hack Club",
+        twitter_card: "summary_large_image"
+      },
+      "long_name" => {
+        title: "@superlongusername123 | Stardance",
+        description: "42 projects · 10 ships · 200 devlogs",
+        url: "https://stardance.hackclub.com/users/superlongusername123",
+        site_name: "Stardance - Hack Club",
+        twitter_card: "summary_large_image"
+      }
     }.freeze
 
     class << self
-      def sample_user(display_name: "hackclub_dev", projects_count: 5, stardust_earned: 350, hours_logged: 42)
-        MockUser.new(
-          display_name: display_name,
-          projects_count: projects_count,
-          stardust_earned: stardust_earned,
-          hours_logged: hours_logged
-        )
+      def sample_user(display_name: "hackclub_dev", bio: nil)
+        MockUser.new(display_name: display_name, bio: bio)
       end
     end
 
-    def initialize(user)
+    def initialize(user, stats: {})
       super()
       @user = user
+      @stats = stats
     end
 
     def render
       create_stardance_canvas
+      draw_diagonal_scrim(opacity: 0.3)
 
       draw_avatar
-      place_stardance_logo(x: 60, y: 45, width: 200, height: 56)
+      place_stardance_logo(x: 80, y: 60, width: 240, height: 68)
       draw_title
-      draw_subtitle
-      place_star_character(x: 30, y: 20, width: 120, height: 120, gravity: "SouthWest")
+      draw_stats
+      place_star_character(x: 30, y: 20, width: 140, height: 140, gravity: "SouthWest")
     end
 
     private
@@ -75,30 +94,45 @@ module OgImage
       lines_drawn = draw_glowing_multiline_text(
         "@#{@user.display_name}",
         x: 80,
-        y: 130,
-        size: 82,
+        y: 170,
+        size: 72,
         color: "#fffcf4",
         glow_color: "#ebb7ff",
-        max_chars: 14,
+        max_chars: 18,
         max_lines: 2,
-        glow_radius: 8,
-        glow_opacity: 0.35,
+        glow_radius: 6,
+        glow_opacity: 0.3,
         font: heading_font_name
       )
-      @title_end_y = 130 + (lines_drawn * 82 * 1.3).to_i
+      @title_end_y = 170 + (lines_drawn * 72 * 1.3).to_i
     end
 
-    def draw_subtitle
+    def draw_stats
       stats = build_stats
       return if stats.empty?
 
-      start_y = @title_end_y + 10
+      start_y = @title_end_y + 20
       stats.each_with_index do |stat, index|
+        icon_x = 80
+        icon_y = start_y + (index * 52)
+        text_x = icon_x + 50
+
+        if stat[:icon]
+          icon_path = Rails.root.join("app", "assets", "images", "icons", stat[:icon])
+          place_image(
+            icon_path.to_s,
+            x: icon_x,
+            y: icon_y,
+            width: 42,
+            height: 42
+          )
+        end
+
         draw_text(
-          stat,
-          x: 80,
-          y: start_y + (index * 44),
-          size: 34,
+          stat[:text],
+          x: text_x,
+          y: icon_y,
+          size: 42,
           color: "#c9c9c9"
         )
       end
@@ -118,45 +152,15 @@ module OgImage
     end
 
     def build_stats
+      p = @stats[:projects_count] || 0
+      s = @stats[:ships_count] || 0
+      d = @stats[:devlogs_count] || 0
+
       stats = []
-      stats << "#{projects_count} #{"project".pluralize projects_count}" if projects_count > 0
-      stats << "#{stardust_earned} Stardust earned" if stardust_earned > 0
-      stats << "#{hours_logged} #{"hour".pluralize hours_logged} worked" if hours_logged > 0
-      stats << "Joined #{joined_ago}"
+      stats << { text: "#{p} #{"project".pluralize(p)}", icon: "rocket.png" }
+      stats << { text: "#{s} #{"ship".pluralize(s)}", icon: "box.png" }
+      stats << { text: "#{d} #{"devlog".pluralize(d)}", icon: "paper.png" }
       stats
-    end
-
-    def joined_ago
-      return "recently" unless @user.respond_to?(:created_at) && @user.created_at
-
-      ActionController::Base.helpers.time_ago_in_words(@user.created_at) + " ago"
-    end
-
-    def projects_count
-      return @user.projects.count if @user.respond_to?(:projects)
-      return @user.projects_count.to_i if @user.respond_to?(:projects_count)
-
-      0
-    end
-
-    def stardust_earned
-      if @user.respond_to?(:balance)
-        @user.balance.to_i
-      elsif @user.respond_to?(:stardust_earned)
-        @user.stardust_earned.to_i
-      else
-        0
-      end
-    end
-
-    def hours_logged
-      if @user.respond_to?(:devlog_seconds_total)
-        (@user.devlog_seconds_total / 3600.0).round
-      elsif @user.respond_to?(:hours_logged)
-        @user.hours_logged.to_i
-      else
-        0
-      end
     end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
     <meta name="twitter:creator" content="@hackclub">
     <meta property="og:locale" content="en_US">
     <meta property="og:site_name" content="Stardance - Hack Club">
+    <meta name="theme-color" content="#FFE564">
 
     <% og_title = content_for?(:og_title) ? yield(:og_title) : (content_for?(:title) ? "#{yield(:title)} - Stardance" : "Stardance - Hack Club") %>
     <% og_description = content_for?(:og_description) ? yield(:og_description) : "The largest STEM event of the summer: make anything you want and earn free prizes." %>

--- a/app/views/og_image_previews/show.html.erb
+++ b/app/views/og_image_previews/show.html.erb
@@ -78,10 +78,11 @@
     .preview-container {
       flex: 1;
       display: flex;
+      flex-direction: column;
       align-items: center;
-      justify-content: center;
       padding: 2rem;
       overflow: auto;
+      gap: 2rem;
     }
     .preview-wrapper {
       background: #fff;
@@ -93,6 +94,82 @@
       display: block;
       max-width: 100%;
       height: auto;
+    }
+
+    .meta-section {
+      width: 100%;
+      max-width: 540px;
+    }
+    .meta-section h3 {
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: #999;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.75rem;
+    }
+
+    .social-card {
+      background: #2b2d31;
+      border-left: 4px solid #FFE564;
+      border-radius: 4px;
+      overflow: hidden;
+      margin-bottom: 2rem;
+    }
+    .social-card__body {
+      padding: 0.5rem 1rem 0.5rem;
+    }
+    .social-card__site {
+      font-size: 0.75rem;
+      color: #b5bac1;
+      margin-bottom: 0.25rem;
+    }
+    .social-card__title {
+      font-size: 1rem;
+      font-weight: 600;
+      color: #00a8fc;
+      margin-bottom: 0.25rem;
+    }
+    .social-card__desc {
+      font-size: 0.875rem;
+      color: #dbdee1;
+      line-height: 1.4;
+    }
+    .social-card__img {
+      padding: 0.25rem 1rem 0.75rem;
+    }
+    .social-card__img img {
+      display: block;
+      max-width: 100%;
+      border-radius: 4px;
+    }
+
+    .meta-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.85rem;
+      background: #fff;
+      border-radius: 8px;
+      overflow: hidden;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+    }
+    .meta-table td {
+      padding: 0.5rem 0.75rem;
+      border-bottom: 1px solid #eee;
+      vertical-align: top;
+    }
+    .meta-table td:first-child {
+      width: 140px;
+      font-weight: 600;
+      color: #555;
+      font-family: monospace;
+      font-size: 0.8rem;
+    }
+    .meta-table td:last-child {
+      color: #333;
+    }
+    .meta-table tr:last-child td {
+      border-bottom: none;
     }
   </style>
 </head>
@@ -116,16 +193,48 @@
     <main class="main">
       <header class="header">
         <h2><%= @preview_name.titleize %></h2>
-        <div class="header-actions">
-          <a href="<%= og_image_preview_path(@preview_name, format: :png) %>" target="_blank">Open in new tab</a>
-          <a href="<%= og_image_preview_path(@preview_name, format: :png) %>" download="<%= @preview_name.parameterize %>.png">Download</a>
-        </div>
+        <% if @has_og_image %>
+          <div class="header-actions">
+            <a href="<%= og_image_preview_path(@preview_name, format: :png) %>" target="_blank">Open in new tab</a>
+            <a href="<%= og_image_preview_path(@preview_name, format: :png) %>" download="<%= @preview_name.parameterize %>.png">Download</a>
+          </div>
+        <% end %>
       </header>
 
       <div class="preview-container">
-        <div class="preview-wrapper">
-          <img src="<%= og_image_preview_path(@preview_name, format: :png) %>" alt="<%= @preview_name %>">
-        </div>
+        <% if @has_og_image %>
+          <div class="preview-wrapper">
+            <img src="<%= og_image_preview_path(@preview_name, format: :png) %>" alt="<%= @preview_name %>">
+          </div>
+        <% end %>
+
+        <% if @preview_meta %>
+          <div class="meta-section">
+            <h3>Link Preview</h3>
+            <div class="social-card">
+              <div class="social-card__body">
+                <div class="social-card__site"><%= @preview_meta[:site_name] %></div>
+                <div class="social-card__title"><%= @preview_meta[:title] %></div>
+                <div class="social-card__desc"><%= @preview_meta[:description] %></div>
+              </div>
+              <% if @has_og_image %>
+                <div class="social-card__img">
+                  <img src="<%= og_image_preview_path(@preview_name, format: :png) %>" alt="">
+                </div>
+              <% end %>
+            </div>
+
+            <h3>Meta Tags</h3>
+            <table class="meta-table">
+              <tr><td>og:title</td><td><%= @preview_meta[:title] %></td></tr>
+              <tr><td>og:description</td><td><%= @preview_meta[:description] %></td></tr>
+              <tr><td>og:image</td><td><%= @has_og_image ? "(attached)" : "(none — uses default)" %></td></tr>
+              <tr><td>og:url</td><td><%= @preview_meta[:url] %></td></tr>
+              <tr><td>og:site_name</td><td><%= @preview_meta[:site_name] %></td></tr>
+              <tr><td>twitter:card</td><td><%= @preview_meta[:twitter_card] %></td></tr>
+            </table>
+          </div>
+        <% end %>
       </div>
     </main>
   </div>

--- a/app/views/projects/devlogs/show.html.erb
+++ b/app/views/projects/devlogs/show.html.erb
@@ -1,4 +1,13 @@
 <% content_for :title, "Devlog by @#{@post.user&.display_name}" %>
+<% content_for :og_title, "@#{@post.user&.display_name} on #{@project.title} | Stardance" %>
+<% content_for :og_description, truncate(@devlog.body.to_s, length: 200) %>
+<%
+  og_first_image = @devlog.attachments.find { |a| a.image? }
+  if og_first_image
+    content_for :og_image, url_for(og_first_image.variant(:large))
+    content_for :twitter_card, "summary_large_image"
+  end
+%>
 
 <div class="app-layout">
   <main class="app-layout__main devlog-detail" aria-label="Devlog">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,11 +1,10 @@
+<% owner = @project.memberships.find_by(role: :owner)&.user %>
 <% content_for :title, @project.title %>
-<% content_for :og_title, @project.title %>
-<% content_for :og_description, truncate(@project.display_description.to_s, length: 200) %>
+<% content_for :og_title, "#{@project.title} by @#{owner&.display_name} | Stardance" %>
+<% content_for :og_description, @project.display_description.present? ? truncate(@project.display_description.to_s, length: 200) : "#{@project.devlogs_count} devlogs · #{(@project.duration_seconds.to_i / 3600.0).round} hours worked" %>
 <% content_for :og_image, project_og_image_url(@project, format: :png) %>
 <% content_for :twitter_card, "summary_large_image" %>
-<% content_for :og_author, @project.memberships.find_by(role: :owner)&.user&.display_name %>
-
-<% owner = @project.memberships.find_by(role: :owner)&.user %>
+<% content_for :og_author, owner&.display_name %>
 <% if owner&.preference&.search_engine_indexing_off? %>
   <% content_for :head do %>
     <meta name="robots" content="noindex, nofollow">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,8 @@
 <% content_for :title, @user.display_name %>
-<% content_for :og_title, "#{@user.display_name} on Stardance" %>
-<% content_for :og_description, "#{@stats[:projects_count]} projects · #{@stats[:ships_count]} ships · #{@stats[:devlogs_count]} devlogs" %>
+<% content_for :og_title, "@#{@user.display_name} | Stardance" %>
+<% content_for :og_description, @user.bio.present? ? truncate(@user.bio, length: 200) : "#{@stats[:projects_count]} projects · #{@stats[:ships_count]} ships · #{@stats[:devlogs_count]} devlogs" %>
 <% content_for :og_image, user_og_image_url(@user, format: :png) %>
+<% content_for :twitter_card, "summary_large_image" %>
 
 <% if @user.preference&.search_engine_indexing_off? %>
   <% content_for :head do %>


### PR DESCRIPTION
makes it better esp for devlogs, like how twitter does it! yay...


devlog meta tags preview now show the content of the devlog + the image they uploaded 

project page and user profile page previews now have title 'project by @ user | Stardance' or '@ user | Stardance' with description included in meta tags

also removed useless tabs in the ogimg preview and made it show text as well

why can't i attach images on github :( 