### PR TITLE
Route legacy hardware to the funding queue, hide it from ship review

### DIFF
--- a/app/jobs/one_time/backfill_hardware_funding_requests_job.rb
+++ b/app/jobs/one_time/backfill_hardware_funding_requests_job.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# Pulls legacy hardware projects into the funding review queue.
+#
+# The queue is a list of Certification::FundingRequest rows, so a project only
+# shows up once it has a pending request. Projects from before the queue existed
+# never got to submit one. This job creates a pending request for each eligible
+# legacy hardware project so reviewers can act on them.
+#
+# RUN OneTime::BackfillHardwareStageJob FIRST. That job (audited, dry-run by
+# default) promotes AI-typed hardware projects from hardware_stage = nil to the
+# "design" entry stage. This job deliberately does NOT touch hardware_stage — it
+# only acts on projects already sitting in "design", which is exactly the set the
+# stage job produces. Keeping the stage flip in one place preserves its audit
+# trail and the devlog-phase warnings documented there.
+#
+# DRY RUN BY DEFAULT: logs the candidate ids and writes nothing. Pass
+# dry_run: false to persist. Always dry-run first and eyeball the list.
+#
+# The owner never picked a tier or dollar amount, so each request is seeded with
+# a placeholder — tier B and $0 requested — and internal_reason records that it
+# was backfilled. The seeded request just means "this needs a funding decision";
+# the reviewer sets the real tier and amount on approval.
+#
+# Writes go through save(validate: false) to bypass the create guards (design
+# stage / has-devlogs / no-pending) — this backfill intentionally forces these
+# projects into the queue. PaperTrail (audit) still fires and is attributed to
+# this job via PaperTrail.request.
+#
+# Idempotent: the scope excludes any project that already has a funding request,
+# so re-running won't create duplicates.
+class OneTime::BackfillHardwareFundingRequestsJob < ApplicationJob
+  queue_as :literally_whenever
+
+  WHODUNNIT = "OneTime::BackfillHardwareFundingRequestsJob"
+
+  # Tier B — the smallest tier; reviewers bump it when they set the real amount.
+  BACKFILL_TIER = 1
+
+  # AI-typed hardware projects already promoted into the design stage (by
+  # BackfillHardwareStageJob) that have never had a funding request.
+  def scope
+    Project.where(project_type: "Hardware", hardware_stage: "design", deleted_at: nil)
+           .where.not(id: Certification::FundingRequest.select(:project_id))
+  end
+
+  def perform(dry_run: true)
+    candidates = scope.to_a
+    ownerless, eligible = candidates.partition { |p| p.memberships.owner.first&.user.nil? }
+
+    if dry_run
+      Rails.logger.info "[BackfillHardwareFundingRequests] DRY RUN — would create #{eligible.size} " \
+                        "funding request(s): #{eligible.map(&:id).inspect}"
+      Rails.logger.warn "[BackfillHardwareFundingRequests] DRY RUN — skipping #{ownerless.size} " \
+                        "ownerless project(s): #{ownerless.map(&:id).inspect}" if ownerless.any?
+      return eligible.map(&:id)
+    end
+
+    created = 0
+    skipped = ownerless.size
+    PaperTrail.request(whodunnit: WHODUNNIT) do
+      eligible.each do |project|
+        owner = project.memberships.owner.first.user
+        request = project.certification_funding_requests.new(
+          user: owner,
+          complexity_tier: BACKFILL_TIER,
+          requested_amount_cents: 0,
+          status: :pending,
+          internal_reason: "Backfilled: legacy hardware project from before the funding queue. " \
+                           "Owner never submitted a tier or amount — set the real tier and amount on approval."
+        )
+        request.save!(validate: false)
+        created += 1
+      rescue ActiveRecord::RecordNotUnique
+        # A pending request already exists (raced or partial prior run); leave it.
+        skipped += 1
+      end
+    end
+
+    Rails.logger.info "[BackfillHardwareFundingRequests] Created #{created} funding request(s), skipped #{skipped}"
+    created
+  end
+end

--- a/app/jobs/one_time/reroute_misfiled_hardware_job.rb
+++ b/app/jobs/one_time/reroute_misfiled_hardware_job.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Reroutes hardware projects that got mis-filed into the software ship review
+# queue. The AI type classifier (Project::TypeCheckJob, which runs at ship time)
+# marks these project_type == "Hardware"; some also sit at hardware_stage
+# "design". Hardware is judged in the funding queue, not peer ship review, so
+# rather than have a reviewer reject them — which dings the rejection rate and
+# pays a review bounty for no real work — this job:
+#
+#   1. deletes the stuck pending Certification::Ship review. No verdict, so no
+#      rejection and no bounty, and it frees the one-pending-review-per-project
+#      slot (a unique index) so the owner can reship later through the hardware
+#      flow; and
+#   2. DMs the owner to switch the project to Hardware in settings and submit
+#      their design for funding.
+#
+# It does NOT flip hardware_stage — the AI can be wrong, so the owner confirms by
+# switching it themselves in project settings.
+#
+# DRY RUN BY DEFAULT: logs the affected review ids and writes nothing. Pass
+# dry_run: false to act. Idempotent: once a review is deleted its project falls
+# out of scope, so re-running won't re-notify.
+#
+# Deletes go through PaperTrail.request so the audit version is attributed here.
+class OneTime::RerouteMisfiledHardwareJob < ApplicationJob
+  queue_as :literally_whenever
+
+  WHODUNNIT = "OneTime::RerouteMisfiledHardwareJob"
+
+  # Pending ship reviews whose project is hardware (design-stage or AI-typed) —
+  # exactly the set Certification::Ship.software_only hides from reviewers.
+  def scope
+    Certification::Ship
+      .where(status: :pending)
+      .joins(:project)
+      .where(projects: { deleted_at: nil })
+      .where("projects.hardware_stage = 'design' OR projects.project_type = 'Hardware'")
+  end
+
+  def perform(dry_run: true)
+    reviews = scope.includes(project: { memberships: :user }).to_a
+
+    if dry_run
+      Rails.logger.info "[RerouteMisfiledHardware] DRY RUN — would reroute #{reviews.size} " \
+                        "ship review(s): #{reviews.map(&:id).inspect}"
+      return reviews.map(&:id)
+    end
+
+    rerouted = 0
+    PaperTrail.request(whodunnit: WHODUNNIT) do
+      reviews.each do |review|
+        project = review.project
+        review.destroy!
+        notify_owner(project)
+        rerouted += 1
+      end
+    end
+
+    Rails.logger.info "[RerouteMisfiledHardware] Rerouted #{rerouted} ship review(s) out of the software queue"
+    rerouted
+  end
+
+  private
+
+  def notify_owner(project)
+    owner = project.memberships.owner.first&.user
+    return unless owner&.slack_id.present?
+
+    owner.dm_user(
+      "Heads up! '#{project.title}' looks like a hardware project, and hardware goes through a " \
+      "different path than software. We've taken it out of the ship review queue — to keep going, open " \
+      "your project settings, switch it to Hardware, and submit your design to request funding."
+    )
+  end
+end

--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -101,6 +101,16 @@ module Certification
       joins(:project)
         .where(projects: { deleted_at: nil })
         .where.not(project_id: user.memberships.select(:project_id))
+        .software_only
+    }
+
+    # Hardware is reviewed through the funding queue, not the ship review queue,
+    # so design-stage projects and anything the AI typed as "Hardware" are hidden
+    # here. Assumes the caller has already joined :project. IS DISTINCT FROM keeps
+    # plain software projects (NULL hardware_stage / project_type) in the queue.
+    scope :software_only, -> {
+      where("projects.hardware_stage IS DISTINCT FROM 'design'")
+        .where("projects.project_type IS DISTINCT FROM 'Hardware'")
     }
 
     scope :by_project_type, ->(type) {
@@ -125,26 +135,29 @@ module Certification
     def self.dashboard_stats(now: Time.current)
       today = now.beginning_of_day
       week = now.beginning_of_week
-      approved_count = where(status: :approved).count
-      returned_count = where(status: :returned).count
+      # Hardware is reviewed in the funding queue, so the ship queue's health
+      # numbers only count software reviews (see :software_only).
+      base = joins(:project).software_only
+      approved_count = base.where(status: :approved).count
+      returned_count = base.where(status: :returned).count
       decided_count = approved_count + returned_count
 
-      decided = where.not(status: :pending)
+      decided = base.where.not(status: :pending)
 
       {
-        pending: where(status: :pending).count,
+        pending: base.where(status: :pending).count,
         approved: approved_count,
         returned: returned_count,
         decided: decided_count,
         approval_rate: decided_count.zero? ? nil : (approved_count * 100.0 / decided_count).round,
         decisions_today: decided.where(decided_at: today..).count,
-        new_today: where(created_at: today..).count,
+        new_today: base.where(created_at: today..).count,
         decisions_this_week: decided.where(decided_at: week..).count,
-        new_this_week: where(created_at: week..).count,
-        oldest_pending: where(status: :pending).order(created_at: :asc).first,
+        new_this_week: base.where(created_at: week..).count,
+        oldest_pending: base.where(status: :pending).order(created_at: :asc).first,
         queue_target: QUEUE_TARGET,
         sla_days: SLA_DAYS,
-        overdue_pending: where(status: :pending).where("created_at < ?", now - SLA_DAYS.days).count
+        overdue_pending: base.where(status: :pending).where("created_at < ?", now - SLA_DAYS.days).count
       }
     end
 

--- a/app/policies/admin/certification/ship_policy.rb
+++ b/app/policies/admin/certification/ship_policy.rb
@@ -17,7 +17,8 @@ class Admin::Certification::ShipPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
       return scope.none unless user&.can_review?
-      scope.joins(:project).where(projects: { deleted_at: nil })
+      # Hardware is reviewed in the funding queue, so it never appears here.
+      scope.joins(:project).where(projects: { deleted_at: nil }).software_only
     end
   end
 

--- a/test/models/certification/ship_test.rb
+++ b/test/models/certification/ship_test.rb
@@ -86,4 +86,35 @@ class Certification::ShipTest < ActiveSupport::TestCase
     assert_equal reviews.last.id, history[:recent].first.id
     assert history[:recent].first.project_with_deleted.deleted?
   end
+
+  test "for_reviewer hides design-stage and AI-typed hardware, keeps software" do
+    software_review = @project.ship_reviews.create!(status: :pending)
+
+    design = Project.create!(title: "Design HW", description: "hardware in design",
+                             ship_status: "submitted", hardware_stage: "design")
+    design.memberships.create!(user: @owner, role: :owner)
+    design_review = design.ship_reviews.create!(status: :pending)
+
+    ai_hardware = Project.create!(title: "AI HW", description: "AI-typed hardware",
+                                  ship_status: "submitted", project_type: "Hardware")
+    ai_hardware.memberships.create!(user: @owner, role: :owner)
+    ai_review = ai_hardware.ship_reviews.create!(status: :pending)
+
+    visible = Certification::Ship.for_reviewer(@reviewer).pluck(:id)
+
+    assert_includes visible, software_review.id
+    refute_includes visible, design_review.id
+    refute_includes visible, ai_review.id
+  end
+
+  test "dashboard_stats pending count ignores hardware reviews" do
+    before = Certification::Ship.dashboard_stats[:pending]
+
+    design = Project.create!(title: "Design HW", description: "hardware in design",
+                             ship_status: "submitted", hardware_stage: "design")
+    design.memberships.create!(user: @owner, role: :owner)
+    design.ship_reviews.create!(status: :pending)
+
+    assert_equal before, Certification::Ship.dashboard_stats[:pending]
+  end
 end


### PR DESCRIPTION
## What & why

Handles hardware projects in three connected ways. Hardware is judged in the **funding queue**, not peer software ship review — so this PR routes hardware *into* the funding queue, *out of* ship review, and notifies builders who mis-filed.

### 1. Backfill legacy hardware into the funding review queue
`OneTime::BackfillHardwareFundingRequestsJob` creates a pending `Certification::FundingRequest` for each AI-typed hardware project already in the design stage with no request yet — so the old projects show up in the funding review queue.

- **Dry-run by default**; pass `dry_run: false` to persist.
- Owner never picked a tier/amount, so seeded with a placeholder (tier B, `$0`) + `internal_reason` marker; reviewer sets the real values on approval.
- `save(validate: false)` to bypass create guards, wrapped in `PaperTrail.request`. Idempotent.
- Does **not** touch `hardware_stage` — the existing audited `BackfillHardwareStageJob` owns that. Run order:
  ```ruby
  OneTime::BackfillHardwareStageJob.perform_now(dry_run: false)            # promote nil -> design
  OneTime::BackfillHardwareFundingRequestsJob.perform_now(dry_run: false)  # create requests
  ```

### 2. Hide hardware from the ship review queue
New `Certification::Ship.software_only` scope excludes `hardware_stage == "design"` **or** `project_type == "Hardware"` (NULL-safe via `IS DISTINCT FROM`). Applied to the reviewer listing (`ShipPolicy::Scope#resolve`), claim-next (`for_reviewer`), and `dashboard_stats` counts.

### 3. Reroute mis-filed hardware out of software review (don't reject)
`OneTime::RerouteMisfiledHardwareJob` handles hardware that got shipped as software and is stuck in the ship queue. Instead of a reviewer rejecting it (which inflates the rejection rate and pays a review bounty for nothing), it:

- **deletes the stuck pending ship review** — no verdict, no rejection, no bounty, and it frees the one-pending-review-per-project slot so the owner can reship later through the hardware flow; and
- **DMs the owner** to switch the project to Hardware in settings and submit for funding.

It does **not** auto-flip `hardware_stage` (the AI can be wrong — the owner confirms in settings). Dry-run by default, deletes audited via `PaperTrail`, idempotent (processed projects fall out of scope).

**How do we know it's hardware?** The AI type classifier (`Project::TypeCheckJob`) runs at ship time and sets `project_type`; `project_type == "Hardware"` is the signal — same one the backfill uses.

## Tests
Added cases to `test/models/certification/ship_test.rb` for the `software_only` exclusion. **Not yet run** — local Docker daemon was down.

## Notes
- All three are non-destructive to projects: ship-review rows are filtered/cleared, projects aren't deleted or force-converted.
- Build-stage hardware that isn't AI-typed `"Hardware"` still appears in ship review (faithful to the "design OR AI-typed Hardware" rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)