### PR TITLE
fix(missions): ensure that static prize ships are not voted on or payed out because of votes

### DIFF
--- a/app/models/post/ship_event.rb
+++ b/app/models/post/ship_event.rb
@@ -73,6 +73,7 @@ class Post::ShipEvent < ApplicationRecord
     where(certification_status: "approved", payout: nil)
       .where("post_ship_events.votes_count < ?", VOTES_TO_LEAVE_POOL)
       .where("post_ship_events.hours_at_ship > 0")
+      .where.not(id: Mission::Submission.where(deleted_at: nil, payout_path: "static_prize").select(:ship_event_id))
   }
   scope :paid_out, -> { where(certification_status: "approved").where.not(payout: nil) }
 


### PR DESCRIPTION
## what's this do?

I accidentally was allowing static prize projects to go into voting and so they would get paid out from that. This blocks both

## show it works

<img width="36" height="35" alt="image" src="https://github.com/user-attachments/assets/fb2059d2-cdad-4c16-92fc-04f2f1a88938" />
(me not having a payout)

## ai?

claude
