### PR TITLE
feat(admin/referral): add manual referral attribution

### DIFF
--- a/app/controllers/admin/raffles/participants_controller.rb
+++ b/app/controllers/admin/raffles/participants_controller.rb
@@ -2,7 +2,7 @@ module Admin
   module Raffles
     class ParticipantsController < Admin::ApplicationController
       before_action :set_participant, only: [
-        :show, :reject_referrals, :ban_participant, :ban_user, :ban_referred_users,
+        :show, :link_referral, :reject_referrals, :ban_participant, :ban_user, :ban_referred_users,
         :reject_selected, :ban_selected,
         :reject_referral, :ban_referred_user, :clear_fraud, :unclear_fraud
       ]
@@ -28,6 +28,53 @@ module Admin
         @referrals = @participant.referrals
                                  .includes(:referred_user, :credited_week)
                                  .order(created_at: :desc)
+      end
+
+      def link_referral
+        authorize :admin, :access_raffles?
+
+        user = ::User.find_by(id: params[:user_id])
+        unless user
+          return redirect_back fallback_location: admin_raffles_participant_path(@participant),
+                               allow_other_host: false,
+                               alert: "User not found."
+        end
+
+        existing = ::Raffle::Referral.find_by(referred_user_id: user.id)
+        if existing
+          return redirect_back fallback_location: admin_raffles_participant_path(@participant),
+                               allow_other_host: false,
+                               alert: "#{user.display_name} already has a referral (status: #{existing.status}, referrer: #{existing.participant.display_name})."
+        end
+
+        if @participant.user_id == user.id
+          return redirect_back fallback_location: admin_raffles_participant_path(@participant),
+                               allow_other_host: false,
+                               alert: "Can't link a participant as referred by themselves."
+        end
+
+        referral = nil
+        ::PaperTrail.request(whodunnit: current_user.id) do
+          referral = ::Raffle::Referral.create!(
+            participant: @participant,
+            referred_user: user,
+            channel: :web,
+            raw_ref: "admin-linked",
+            status: :pending
+          )
+
+          if user.hca_linked?
+            week = ::Raffle::Week.current
+            if week
+              referral.paper_trail_event = "admin_credit"
+              referral.update!(status: :verified, credited_week: week, verified_at: Time.current)
+              @participant.user&.sync_referral_achievements!
+            end
+          end
+        end
+
+        redirect_to admin_raffles_participant_path(@participant),
+                    notice: "#{user.display_name} linked as referred (status: #{referral.reload.status})."
       end
 
       # ── Bulk actions ──────────────────────────────────────────────────

--- a/app/views/admin/raffles/participants/show.html.erb
+++ b/app/views/admin/raffles/participants/show.html.erb
@@ -139,3 +139,14 @@
 <% else %>
   <p>No referrals yet.</p>
 <% end %>
+
+<h3>Link a user as referred by this participant</h3>
+<p style="color: #9ca3af; font-size: 0.875rem;">
+  Enter a user ID to create a referral record linking them to <strong><%= @participant.display_name %></strong>.
+  If the user has linked their Hack Club account, the referral is verified and credited immediately.
+</p>
+<%= form_with url: link_referral_admin_raffles_participant_path(@participant), method: :post, class: "admin-actions-wrap" do |f| %>
+  <%= f.number_field :user_id, required: true, placeholder: "User ID", style: "width: 120px;" %>
+  <%= f.submit "Link as referred", class: "btn-primary slim",
+      data: { turbo_confirm: "Link this user as referred by #{@participant.display_name}?" } %>
+<% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -24,6 +24,39 @@
       <div><b>Balance:</b> <%= @user.balance %> tickets</div>
       <div><b>Roles:</b> <%= @user.roles.map { |r| r.to_s.titleize }.join(", ") %></div>
       <div>
+        <b>Raffle:</b>
+        <% participant = Raffle::Participant.find_by(user_id: @user.id) %>
+        <% referral = Raffle::Referral.find_by(referred_user_id: @user.id) %>
+        <% if participant %>
+          <%= link_to "Participant (#{participant.code})", admin_raffles_participant_path(participant), style: "color: #3b82f6;" %>
+        <% end %>
+        <% if referral %>
+          <%= participant ? " · " : "" %>
+          Referred by <%= link_to referral.participant.display_name, admin_raffles_participant_path(referral.participant), style: "color: #3b82f6;" %>
+          (<span class="badge badge-<%= referral.status %>"><%= referral.status %></span>)
+        <% end %>
+        <% if @user.ref.present? && !referral %>
+          <% ref_match = @user.ref.strip.downcase.match(/\A[rd]-([a-z0-9]{5})\z/) %>
+          <% ref_participant = ref_match && Raffle::Participant.find_by(code: ref_match[1]) %>
+          Ref code: <code><%= @user.ref %></code> (not linked) ·
+          <% if ref_participant %>
+            would be referred by <%= link_to ref_participant.display_name, admin_raffles_participant_path(ref_participant), style: "color: #3b82f6;" %> ·
+            <%= button_to "Link referral",
+                link_referral_admin_raffles_participant_path(ref_participant),
+                params: { user_id: @user.id },
+                method: :post,
+                class: "btn-primary slim",
+                style: "display: inline; padding: 2px 8px; font-size: 0.8rem;",
+                data: { turbo_confirm: "Link #{@user.display_name} as referred by #{ref_participant.display_name}?" } %>
+          <% else %>
+            <span style="color: #9ca3af;">ref code doesn't match any participant</span>
+          <% end %>
+        <% end %>
+        <% if !participant && !referral && @user.ref.blank? %>
+          <span style="color: #9ca3af;">Not in raffle</span>
+        <% end %>
+      </div>
+      <div>
         <b>Projects (<%= @all_projects.size %>):</b>
         <ul>
           <% @all_projects.each do |project| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -642,6 +642,7 @@ Rails.application.routes.draw do
       end
       resources :participants, only: [ :index, :show ] do
         member do
+          post :link_referral
           post :reject_referrals
           post :ban_participant
           post :ban_user

--- a/test/controllers/admin/raffles/participants_link_referral_test.rb
+++ b/test/controllers/admin/raffles/participants_link_referral_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class Admin::Raffles::ParticipantsLinkReferralTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = users(:tongyu)
+    @referred = users(:referral_referred_one)
+    @referrer_participant = raffle_participants(:referrer)
+  end
+
+  test "admin can link a user as referred by a participant" do
+    sign_in @admin
+
+    assert_difference "Raffle::Referral.count", 1 do
+      post link_referral_admin_raffles_participant_path(@referrer_participant),
+           params: { user_id: @referred.id }
+    end
+
+    assert_redirected_to admin_raffles_participant_path(@referrer_participant)
+    referral = Raffle::Referral.find_by(referred_user_id: @referred.id)
+    assert referral
+    assert_equal @referrer_participant.id, referral.participant_id
+  end
+
+  test "non-admin cannot link a referral" do
+    sign_in users(:one)
+
+    post link_referral_admin_raffles_participant_path(@referrer_participant),
+         params: { user_id: @referred.id }
+    assert_response :not_found
+  end
+
+  test "rejects self-referral" do
+    sign_in @admin
+
+    post link_referral_admin_raffles_participant_path(@referrer_participant),
+         params: { user_id: @referrer_participant.user_id }
+
+    assert_redirected_to admin_raffles_participant_path(@referrer_participant)
+    assert_match(/themselves/i, flash[:alert])
+  end
+
+  test "rejects if referral already exists" do
+    sign_in @admin
+    Raffle::Referral.create!(
+      participant: @referrer_participant,
+      referred_user: @referred,
+      channel: :web,
+      raw_ref: "test",
+      status: :pending
+    )
+
+    post link_referral_admin_raffles_participant_path(@referrer_participant),
+         params: { user_id: @referred.id }
+
+    assert_redirected_to admin_raffles_participant_path(@referrer_participant)
+    assert_match(/already has a referral/i, flash[:alert])
+  end
+end

--- a/test/fixtures/raffle_participants.yml
+++ b/test/fixtures/raffle_participants.yml
@@ -1,0 +1,7 @@
+referrer:
+  user_id: <%= ActiveRecord::FixtureSet.identify(:referral_referrer) %>
+  code: abc12
+  eligible: true
+  age_group: teen
+  created_at: <%= 1.week.ago.to_fs(:db) %>
+  updated_at: <%= 1.week.ago.to_fs(:db) %>

--- a/test/fixtures/raffle_referrals.yml
+++ b/test/fixtures/raffle_referrals.yml
@@ -1,0 +1,1 @@
+# empty — referrals are created via the Register service

--- a/test/fixtures/raffle_weeks.yml
+++ b/test/fixtures/raffle_weeks.yml
@@ -1,0 +1,7 @@
+current_week:
+  number: 1
+  status: active
+  prize: "AMD RX 9060 XT"
+  opened_at: <%= 3.days.ago.to_fs(:db) %>
+  created_at: <%= 1.week.ago.to_fs(:db) %>
+  updated_at: <%= 1.week.ago.to_fs(:db) %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -84,3 +84,31 @@ three:
   display_name: MyString
   slack_id: U_FIXTURE_THREE
   votes_count: 0
+
+tongyu:
+  email: bucketfishy@gmail.com
+  display_name: tongyu
+  slack_id: U_FIXTURE_TONGYU
+  votes_count: 0
+  granted_roles: "{admin}"
+
+referral_referrer:
+  email: referrer@example.test
+  display_name: raffle_referrer
+  slack_id: U_FIXTURE_REFERRER
+  votes_count: 0
+  onboarded_at: <%= 1.week.ago.to_fs(:db) %>
+
+referral_referred_one:
+  email: referred1@example.test
+  display_name: referred_one
+  slack_id: U_FIXTURE_REFERRED1
+  votes_count: 0
+  ref: r-abc12
+
+referral_referred_two:
+  email: referred2@example.test
+  display_name: referred_two
+  slack_id: U_FIXTURE_REFERRED2
+  votes_count: 0
+  ref: r-abc12


### PR DESCRIPTION
sometimes people's referrals are broken. this adds admin tooling to manually attribute referrals so that we can fix this. yay!

1: firstly sometimes the referral code doesn't link the referral even though the code is there. this doesn't make sense. but if it happens again u can link them manually
<img width="675" height="213" alt="image" src="https://github.com/user-attachments/assets/53a0be7e-36ee-4a36-b59e-1f223a80f9b0" />


2: you can also just add people
<img width="494" height="164" alt="image" src="https://github.com/user-attachments/assets/5b88daa6-6988-4af8-9e00-bc9a8d9164ab" />
