### PR TITLE
feat(homepage): add following, popular, newest feeds to homepage

### DIFF
--- a/app/assets/stylesheets/components/_feed.scss
+++ b/app/assets/stylesheets/components/_feed.scss
@@ -1,3 +1,49 @@
+.feed-tabs {
+  display: flex;
+  gap: var(--space-xs);
+  overflow-x: auto;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  &__tab {
+    display: inline-flex;
+    align-items: center;
+    flex: 0 0 auto;
+    min-height: 34px;
+    padding: 0 14px;
+    border: 2px solid var(--color-space-border);
+    border-radius: 999px;
+    color: var(--color-space-text-muted);
+    background: transparent;
+    font: inherit;
+    font-size: calc(var(--font-size-s) * 1.15);
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+    cursor: pointer;
+    transition:
+      color 150ms ease,
+      background 150ms ease,
+      border-color 150ms ease;
+
+    &:hover,
+    &:focus-visible {
+      color: var(--color-space-text);
+      background: var(--color-space-surface-faint);
+      outline: none;
+    }
+
+    &--active {
+      color: var(--color-space-text);
+      background: var(--color-space-surface-soft);
+      border-color: var(--color-space-text-muted);
+    }
+  }
+}
+
 .feed-home {
   display: flex;
   flex-direction: column;

--- a/app/controllers/home/feeds_controller.rb
+++ b/app/controllers/home/feeds_controller.rb
@@ -3,6 +3,7 @@ class Home::FeedsController < ApplicationController
 
   FEED_LIMIT = 20
   RECOMMENDATION_POOL = 100 # after this, we fallback to SQL
+  TABS = %w[for_you following popular newest].freeze
   FeedPage = Struct.new(:page, :limit, :offset, :next, keyword_init: true)
 
   skip_before_action :remember_page
@@ -11,14 +12,28 @@ class Home::FeedsController < ApplicationController
   def show
     authorize :home, :feed?
     @feed_request_id = SecureRandom.uuid
+    @current_tab = TABS.include?(params[:tab]) ? params[:tab] : "for_you"
     load_feed
-    load_recommended_projects if first_page?
+    load_recommended_projects if first_page? && @current_tab == "for_you"
     render layout: false
   end
 
   private
 
   def load_feed
+    case @current_tab
+    when "following"  then load_following_feed
+    when "popular"    then paginate_and_filter(popular_scope, "popular")
+    when "newest"     then paginate_and_filter(newest_scope, "newest")
+    else                   load_for_you_feed
+    end
+
+    @liked_devlog_ids = liked_devlog_ids_for(@feed_posts)
+    @reposted_post_ids = reposted_post_ids_for(@feed_posts)
+    @show_post_views = Flipper.enabled?(:week_2_release, current_user)
+  end
+
+  def load_for_you_feed
     recommended = recommended_posts
     backfill = feed_scope.where.not(id: recommended.map(&:id))
 
@@ -27,9 +42,62 @@ class Home::FeedsController < ApplicationController
     @pagy.next = @pagy.page + 1 if has_next
 
     preload_feed_associations(@feed_posts)
-    @liked_devlog_ids = liked_devlog_ids_for(@feed_posts)
-    @reposted_post_ids = reposted_post_ids_for(@feed_posts)
-    @show_post_views = Flipper.enabled?(:week_2_release, current_user)
+  end
+
+  def load_following_feed
+    if current_user.blank?
+      @pagy = feed_pagy
+      @feed_posts = []
+      @feed_post_sources = {}
+      return
+    end
+
+    scope = feed_scope
+      .where(
+        "posts.user_id IN (:user_ids) OR posts.project_id IN (:project_ids)",
+        user_ids: current_user.following.select(:id),
+        project_ids: current_user.followed_projects.select(:id)
+      )
+      .where.not(user_id: current_user.id)
+      .reorder(created_at: :desc)
+
+    paginate_and_filter(scope, "following")
+  end
+
+  def paginate_and_filter(scope, source_label)
+    @pagy = feed_pagy
+    page_candidates = scope.offset(@pagy.offset).limit(@pagy.limit + 1).to_a
+    preload_feed_associations(page_candidates)
+    page_candidates.select! { |p| visible_post?(p) }
+
+    @feed_posts = page_candidates.first(@pagy.limit)
+    @feed_post_sources = @feed_posts.index_with { source_label }
+    @pagy.next = @pagy.page + 1 if page_candidates.size > @pagy.limit
+  end
+
+  def popular_scope
+    feed_scope
+      .where("posts.created_at >= ?", 7.days.ago)
+      .joins("LEFT JOIN post_devlogs ON post_devlogs.id = posts.postable_id AND posts.postable_type = 'Post::Devlog'")
+      .reorder(Arel.sql(<<~SQL.squish))
+        (
+          COALESCE(post_devlogs.likes_count, 0) * 5
+          + COALESCE(posts.reposts_count, 0) * 3
+          + COALESCE(posts.views_count, 0)
+        ) DESC,
+        posts.created_at DESC
+      SQL
+  end
+
+  def newest_scope
+    feed_scope.reorder(created_at: :desc)
+  end
+
+  def visible_post?(post)
+    return false unless post.postable.present?
+    return true unless post.repost?
+
+    post.visible_repost_original_for?(current_user)
   end
 
   def recommended_posts

--- a/app/controllers/home/feeds_controller.rb
+++ b/app/controllers/home/feeds_controller.rb
@@ -12,7 +12,7 @@ class Home::FeedsController < ApplicationController
   def show
     authorize :home, :feed?
     @feed_request_id = SecureRandom.uuid
-    @current_tab = TABS.include?(params[:tab]) ? params[:tab] : "for_you"
+    @current_tab = TABS.include?(params[:tab]) && Flipper.enabled?(:week_3_release, current_user) ? params[:tab] : "for_you"
     load_feed
     load_recommended_projects if first_page? && @current_tab == "for_you"
     render layout: false

--- a/app/javascript/controllers/feed_tabs_controller.js
+++ b/app/javascript/controllers/feed_tabs_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["tab"];
+  static values = { feedUrl: String };
+
+  switch(event) {
+    event.preventDefault();
+    const tab = event.currentTarget.dataset.tab;
+
+    this.tabTargets.forEach((el) => {
+      el.classList.toggle("feed-tabs__tab--active", el.dataset.tab === tab);
+    });
+
+    const url = new URL(this.feedUrlValue, window.location.origin);
+    if (tab !== "for_you") {
+      url.searchParams.set("tab", tab);
+    }
+
+    const frame = document.querySelector("turbo-frame#home_feed");
+    if (!frame) return;
+
+    frame.innerHTML =
+      '<div class="feed-loading" role="status" aria-live="polite">' +
+      '<span class="feed-loading__spinner" aria-hidden="true"></span>' +
+      '<span class="feed-loading__label">Loading the feed&hellip;</span>' +
+      "</div>";
+
+    frame.src = url.toString();
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -139,6 +139,9 @@ application.register("feed-engagement", FeedEngagementController);
 import FeedKeyboardController from "./feed_keyboard_controller";
 application.register("feed-keyboard", FeedKeyboardController);
 
+import FeedTabsController from "./feed_tabs_controller";
+application.register("feed-tabs", FeedTabsController);
+
 import FileUploadController from "./file_upload_controller";
 application.register("file-upload", FileUploadController);
 

--- a/app/views/home/feed_pages/_feed_page.html.erb
+++ b/app/views/home/feed_pages/_feed_page.html.erb
@@ -60,7 +60,9 @@
   <% end %>
 
   <p class="feed-home__empty">
-    <% if current_user.present? %>
+    <% if @current_tab == "following" %>
+      Nothing here yet. Follow some people or projects to see their posts here!
+    <% elsif current_user.present? %>
       Nothing here yet. Post a devlog or ship your project to start the feed.
     <% else %>
       Nothing here yet. Sign up to start building and see the feed come alive!
@@ -69,8 +71,9 @@
 <% end %>
 
 <% if @pagy.next %>
+  <% pagination_params = (local_assigns[:feed_params] || {}).merge(page: @pagy.next) %>
   <%= turbo_frame_tag "home_feed_page_#{@pagy.next}",
-                      src: home_feed_path(page: @pagy.next),
+                      src: home_feed_path(pagination_params),
                       loading: :lazy,
                       target: "_top",
                       class: "feed-home__frame" do %>

--- a/app/views/home/feeds/show.html.erb
+++ b/app/views/home/feeds/show.html.erb
@@ -1,9 +1,10 @@
+<% feed_params = @current_tab.present? && @current_tab != "for_you" ? { tab: @current_tab } : {} %>
 <% if @pagy.page > 1 %>
   <%= turbo_frame_tag "home_feed_page_#{@pagy.page}", target: "_top", class: "feed-home__frame" do %>
-    <%= render "home/feed_pages/feed_page" %>
+    <%= render "home/feed_pages/feed_page", feed_params: feed_params %>
   <% end %>
 <% else %>
   <%= turbo_frame_tag "home_feed", target: "_top", class: "feed-home__frame" do %>
-    <%= render "home/feed_pages/feed_page" %>
+    <%= render "home/feed_pages/feed_page", feed_params: feed_params %>
   <% end %>
 <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <div class="app-layout">
-  <main class="app-layout__main feed-home" aria-label="Home feed" data-controller="feed-keyboard">
+  <main class="app-layout__main feed-home" aria-label="Home feed" data-controller="feed-keyboard feed-tabs" data-feed-tabs-feed-url-value="<%= home_feed_path %>">
     <%= render "shared/raffle_referral_banner" %>
     <% if current_user.present? %>
       <%= render Posts::ComposerComponent.new(
@@ -16,6 +16,15 @@
             show_record: true
           ) %>
     <% end %>
+
+    <nav class="feed-tabs" aria-label="Feed filters">
+      <button class="feed-tabs__tab feed-tabs__tab--active" data-feed-tabs-target="tab" data-tab="for_you" data-action="feed-tabs#switch">For you</button>
+      <% if current_user.present? %>
+        <button class="feed-tabs__tab" data-feed-tabs-target="tab" data-tab="following" data-action="feed-tabs#switch">Following</button>
+      <% end %>
+      <button class="feed-tabs__tab" data-feed-tabs-target="tab" data-tab="popular" data-action="feed-tabs#switch">Popular</button>
+      <button class="feed-tabs__tab" data-feed-tabs-target="tab" data-tab="newest" data-action="feed-tabs#switch">Newest</button>
+    </nav>
 
     <%= turbo_frame_tag "home_feed", src: home_feed_path, target: "_top", class: "feed-home__frame" do %>
       <div class="feed-loading" role="status" aria-live="polite">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -17,14 +17,16 @@
           ) %>
     <% end %>
 
-    <nav class="feed-tabs" aria-label="Feed filters">
-      <button class="feed-tabs__tab feed-tabs__tab--active" data-feed-tabs-target="tab" data-tab="for_you" data-action="feed-tabs#switch">For you</button>
-      <% if current_user.present? %>
-        <button class="feed-tabs__tab" data-feed-tabs-target="tab" data-tab="following" data-action="feed-tabs#switch">Following</button>
-      <% end %>
-      <button class="feed-tabs__tab" data-feed-tabs-target="tab" data-tab="popular" data-action="feed-tabs#switch">Popular</button>
-      <button class="feed-tabs__tab" data-feed-tabs-target="tab" data-tab="newest" data-action="feed-tabs#switch">Newest</button>
-    </nav>
+    <% if Flipper.enabled?(:week_3_release, current_user) %>
+      <nav class="feed-tabs" aria-label="Feed filters">
+        <button class="feed-tabs__tab feed-tabs__tab--active" data-feed-tabs-target="tab" data-tab="for_you" data-action="feed-tabs#switch">For you</button>
+        <% if current_user.present? %>
+          <button class="feed-tabs__tab" data-feed-tabs-target="tab" data-tab="following" data-action="feed-tabs#switch">Following</button>
+        <% end %>
+        <button class="feed-tabs__tab" data-feed-tabs-target="tab" data-tab="popular" data-action="feed-tabs#switch">Popular</button>
+        <button class="feed-tabs__tab" data-feed-tabs-target="tab" data-tab="newest" data-action="feed-tabs#switch">Newest</button>
+      </nav>
+    <% end %>
 
     <%= turbo_frame_tag "home_feed", src: home_feed_path, target: "_top", class: "feed-home__frame" do %>
       <div class="feed-loading" role="status" aria-live="polite">


### PR DESCRIPTION
WOW!! homepage just got better...

<img width="734" height="266" alt="image" src="https://github.com/user-attachments/assets/85237c1e-2716-4882-868a-658e83691b52" />

for you: old gorse recommendation, no change there
following: latest-first feed of all devlogs, ships, and reposts from users and projects that you follow
popular: top posts from the past 7 days, weighted by 5 x likes, 3 x reposts, 1 x views, then recency tiebreaker
newest: latest-first feed of all devlogs, ships, reposts from all users

all tabs share the same base feed_scope (CTE with devlogs + ship events + deduplicated reposts, filtered by visibility/verification/bans)