### PR TITLE
Reword reviewer notification copy ('ship event' → 'project')

### DIFF
--- a/app/views/notification_mailer/submission_pending_for_reviewer.html.erb
+++ b/app/views/notification_mailer/submission_pending_for_reviewer.html.erb
@@ -10,7 +10,7 @@
   <% if builder && project_title.present? %>
     <strong>@<%= builder.display_name %></strong> just submitted <strong><%= project_title %></strong><% if mission_name %> for <strong><%= mission_name %></strong><% end %> and needs a reviewer.
   <% elsif builder %>
-    <strong>@<%= builder.display_name %></strong> just submitted a ship event<% if mission_name %> for <strong><%= mission_name %></strong><% end %> and needs a reviewer.
+    <strong>@<%= builder.display_name %></strong> just submitted a project<% if mission_name %> for <strong><%= mission_name %></strong><% end %> and needs a reviewer.
   <% else %>
     A new submission<% if mission_name %> for <strong><%= mission_name %></strong><% end %> is waiting for a reviewer.
   <% end %>

--- a/app/views/notification_mailer/submission_pending_for_reviewer.text.erb
+++ b/app/views/notification_mailer/submission_pending_for_reviewer.text.erb
@@ -4,7 +4,7 @@
 
 Ready for your review!
 
-<% if builder && project_title.present? %>@<%= builder.display_name %> just submitted "<%= project_title %>"<% if mission_name %> for <%= mission_name %><% end %> and needs a reviewer.<% elsif builder %>@<%= builder.display_name %> just submitted a ship event<% if mission_name %> for <%= mission_name %><% end %> and needs a reviewer.<% else %>A new submission<% if mission_name %> for <%= mission_name %><% end %> is waiting for a reviewer.<% end %>
+<% if builder && project_title.present? %>@<%= builder.display_name %> just submitted "<%= project_title %>"<% if mission_name %> for <%= mission_name %><% end %> and needs a reviewer.<% elsif builder %>@<%= builder.display_name %> just submitted a project<% if mission_name %> for <%= mission_name %><% end %> and needs a reviewer.<% else %>A new submission<% if mission_name %> for <%= mission_name %><% end %> is waiting for a reviewer.<% end %>
 
 Approve, request revisions, or reject — payout's on hold until you do.
 

--- a/app/views/notifications/inbox/_submission_pending_for_reviewer.html.erb
+++ b/app/views/notifications/inbox/_submission_pending_for_reviewer.html.erb
@@ -1,6 +1,7 @@
 <%= render "notifications/inbox/actor", notification: notification, fallback: "A builder" %>
-<span class="notifications-item__verb"> submitted a project for your review</span>
+<span class="notifications-item__verb"> submitted a project</span>
 <% if notification.record && notification.record.mission %>
-  <span class="notifications-item__verb">—</span>
+  <span class="notifications-item__verb">to</span>
   <%= link_to notification.record.mission.name, mission_path(notification.record.mission), class: "notifications-item__actor" %>
 <% end %>
+<span class="notifications-item__verb">for your review</span>

--- a/app/views/notifications/inbox/_submission_pending_for_reviewer.html.erb
+++ b/app/views/notifications/inbox/_submission_pending_for_reviewer.html.erb
@@ -1,6 +1,6 @@
 <%= render "notifications/inbox/actor", notification: notification, fallback: "A builder" %>
-<span class="notifications-item__verb"> submitted a ship event for your review</span>
+<span class="notifications-item__verb"> submitted a project for your review</span>
 <% if notification.record && notification.record.mission %>
-  <span class="notifications-item__verb">on</span>
+  <span class="notifications-item__verb">—</span>
   <%= link_to notification.record.mission.name, mission_path(notification.record.mission), class: "notifications-item__actor" %>
 <% end %>


### PR DESCRIPTION
## What

Reword the "submission pending for reviewer" notification copy to drop the internal **"ship event"** jargon, which was confusing reviewers.

Reviewers now see:

> @AK_47 submitted **a project** for your review — Hackpad

(previously: "submitted **a ship event** for your review **on** Hackpad")

## Why

A reviewer flagged the inbox notification copy as confusing — "ship event" is internal terminology, and "on Hackpad" read oddly since Hackpad is a *mission*. This is a pure copy change.

## Changes

Applied consistently across all channels that used the jargon:

- **Inbox** (`notifications/inbox/_submission_pending_for_reviewer.html.erb`): "ship event" → "project", and connector "on" → "—" to match sibling submission notifications (e.g. "Your mission submission was approved — Hackpad").
- **Email HTML** (`notification_mailer/submission_pending_for_reviewer.html.erb`): "ship event" → "project" in the no-project-title fallback branch.
- **Email text** (`notification_mailer/submission_pending_for_reviewer.text.erb`): same.
- **Slack**: no change needed — already read cleanly ("New mission submission to review").

No logic, models, or migrations touched — view copy only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> View-only copy changes in notification templates with no logic or data handling impact.
> 
> **Overview**
> Updates **submission pending for reviewer** copy so reviewers see user-facing **“project”** language instead of internal **“ship event”** jargon.
> 
> **Email** (HTML and plain text): when there’s no project title, the fallback line now says the builder “submitted a project” rather than “submitted a ship event.”
> 
> **Inbox**: rephrases the item to “submitted a project” **to** `[mission]` **for your review**, replacing the old “submitted a ship event for your review on [mission]” wording so it reads more like sibling submission notifications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 275d34342cdc1a9bcce1ade19940838e48d1cde9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->