### PR TITLE
fix: mjml error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN apt-get update -qq && \
     git \
     libopenblas0 \
     liblapack3 \
-    ffmpeg && \
+    ffmpeg \
+    nodejs && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 # Set production environment

--- a/config/initializers/mjml.rb
+++ b/config/initializers/mjml.rb
@@ -1,4 +1,9 @@
-Mjml.setup do |config|
-  mjml_path = Rails.root.join("node_modules/.bin/mjml")
-  config.mjml_binary = mjml_path.to_s if mjml_path.exist?
+mjml_path = Rails.root.join("node_modules/.bin/mjml")
+
+if mjml_path.exist?
+  Mjml.setup do |config|
+    config.mjml_binary = mjml_path.to_s
+  end
+else
+  Rails.logger.warn "[MJML] Binary not found at #{mjml_path} — email template rendering will be unavailable. Run `npm install` to fix this."
 end


### PR DESCRIPTION
Also made it so if it doesnt exist the whole app doesnt crash!

## what's this do?

Docker wasnt including nodejs which means it was trying to find something that didnt exist for mjml binaries!!

## ai?
Claude


If its reverted this pr will be closed