### PR TITLE
feat(admin/ships): add manual project-type override on ship review page

### DIFF
--- a/app/assets/stylesheets/pages/certification/ships/_show.scss
+++ b/app/assets/stylesheets/pages/certification/ships/_show.scss
@@ -326,6 +326,12 @@
     gap: var(--space-xs);
     margin-top: var(--space-s);
   }
+
+  &__claim-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+  }
 }
 
 @keyframes ship-review-pop {

--- a/app/controllers/admin/certification/ships_controller.rb
+++ b/app/controllers/admin/certification/ships_controller.rb
@@ -1,6 +1,6 @@
 class Admin::Certification::ShipsController < Admin::Certification::ApplicationController
   before_action :release_other_claims, only: [ :next ]
-  before_action :set_ship, only: [ :show, :update ]
+  before_action :set_ship, only: [ :show, :update, :set_project_type ]
   before_action :set_submitter_context, only: [ :show, :update ]
   before_action :set_body_class, only: [ :index, :show, :update, :logs ]
 
@@ -66,6 +66,13 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
   def show
     authorize @ship
     @reviewed_today = ::Certification::Ship.reviewed_today(current_user)
+  end
+
+  def set_project_type
+    authorize @ship
+    type = params[:project_type].presence_in(Project::USER_SELECTABLE_TYPES)
+    @ship.project.update!(project_type: type) if type
+    redirect_to admin_certification_ship_path(@ship), notice: type && "Project type updated."
   end
 
   def update

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -63,6 +63,7 @@ class Project < ApplicationRecord
     "Desktop App (Windows)", "Desktop App (Linux)", "Desktop App (macOS)",
     "Minecraft Mods", "Hardware", "Android App", "iOS App", "Other"
   ].freeze
+  USER_SELECTABLE_TYPES = (AVAILABLE_CATEGORIES - [ "Hardware" ]).freeze
 
   # Hardware projects carry a build/design stage; software projects leave
   # hardware_stage nil. Drives the Lookout screen-recording flow on the project
@@ -257,6 +258,7 @@ class Project < ApplicationRecord
   # allows nil, but not "").
   normalizes :hardware_stage, with: ->(value) { value.presence }
   validates :hardware_stage, inclusion: { in: HARDWARE_STAGES }, allow_nil: true
+  validates :project_type, inclusion: { in: AVAILABLE_CATEGORIES }, allow_nil: true
   validate :hardware_stage_locked_after_funding_request
 
   def hardware_stage_locked_after_funding_request

--- a/app/policies/admin/certification/ship_policy.rb
+++ b/app/policies/admin/certification/ship_policy.rb
@@ -14,6 +14,8 @@ class Admin::Certification::ShipPolicy < ApplicationPolicy
 
   def next? = user&.can_review?
 
+  def set_project_type? = show?
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       return scope.none unless user&.can_review?

--- a/app/views/admin/certification/ships/show.html.erb
+++ b/app/views/admin/certification/ships/show.html.erb
@@ -153,8 +153,19 @@
           <% else %>
             <div class="ship-review__claim">
               <p>You don't currently hold the claim on this review.</p>
-              <%= button_to "Claim this review", admin_certification_ship_claim_path(@ship), method: :post,
-                    class: "action-btn action-btn--large action-btn--primary" %>
+              <div class="ship-review__claim-actions">
+                <%= button_to "Claim this review", admin_certification_ship_claim_path(@ship), method: :post,
+                      class: "action-btn action-btn--large action-btn--primary" %>
+                <%= form_with url: set_project_type_admin_certification_ship_path(@ship), method: :patch do %>
+                  <%= select_tag :project_type,
+                        options_for_select(
+                          [["Unknown", "", { disabled: true }], *Project::USER_SELECTABLE_TYPES.map { |t| [t, t] }],
+                          @ship.project.project_type
+                        ),
+                        onchange: "this.form.requestSubmit()",
+                        class: "ship-queue__select" %>
+                <% end %>
+              </div>
               <%= link_to "Back to queue", admin_certification_ships_path,
                     class: "action-btn action-btn--small action-btn--secondary" %>
             </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -757,7 +757,7 @@ Rails.application.routes.draw do
           get :monitor, to: "ships/monitor#show"
         end
         patch :set_project_type, on: :member
-scope module: :ships do
+        scope module: :ships do
           resource :claim, only: [ :create, :destroy ]
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -756,7 +756,8 @@ Rails.application.routes.draw do
           get :logs
           get :monitor, to: "ships/monitor#show"
         end
-        scope module: :ships do
+        patch :set_project_type, on: :member
+scope module: :ships do
           resource :claim, only: [ :create, :destroy ]
         end
       end


### PR DESCRIPTION
## what's this do?

Adds the ability to manually change the project type of projects in review dash 

## show it works

<img width="587" height="795" alt="image" src="https://github.com/user-attachments/assets/676b99c8-471c-425a-849c-d944561ce0de" />

## ai?

claude 🥀 
