### PR TITLE
Fix(certification): unseekable verdict/devlog videos on YSWS review page

### DIFF
--- a/app/assets/stylesheets/pages/admin/_ysws_reviews.scss
+++ b/app/assets/stylesheets/pages/admin/_ysws_reviews.scss
@@ -945,9 +945,6 @@ body:has(.certification-ysws) {
 
   // Video Card
   .video-card {
-    position: relative;
-    z-index: 1;
-
     h3 {
       color: var(--color-brand-lilac);
       font-size: var(--font-size-l);
@@ -957,9 +954,6 @@ body:has(.certification-ysws) {
     }
 
     &__player {
-      position: relative;
-      z-index: 2;
-      pointer-events: auto;
       background: #000;
     }
 
@@ -2230,9 +2224,6 @@ body:has(.certification-ysws) {
       object-fit: contain;
       border-radius: var(--border-radius);
       box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
-      position: relative;
-      z-index: 1;
-      pointer-events: auto;
 
       &.hidden {
         display: none;

--- a/app/views/admin/certification/ysws/show.html.erb
+++ b/app/views/admin/certification/ysws/show.html.erb
@@ -80,7 +80,7 @@
       <section class="review-card video-card">
         <h3>Ship Cert Video</h3>
         <% if @review.ship_cert&.verdict_video&.attached? %>
-          <video class="video-card__player" src="<%= url_for(@review.ship_cert.verdict_video) %>"
+          <video class="video-card__player" src="<%= rails_storage_redirect_path(@review.ship_cert.verdict_video) %>"
                  controls playsinline preload="metadata" style="width:100%;border-radius:var(--profile-radius)"></video>
         <% else %>
           <div class="video-placeholder">
@@ -313,9 +313,9 @@
                   <div class="media-grid">
                     <% devlog_review.post_devlog.attachments.each do |attachment| %>
                       <% if attachment.video? %>
-                        <a href="<%= url_for(attachment) %>" class="media-item video-item" data-action="click->certification--ysws--media-viewer#open">
+                        <a href="<%= rails_storage_redirect_path(attachment) %>" class="media-item video-item" data-action="click->certification--ysws--media-viewer#open">
                           <video class="media-thumbnail" muted>
-                            <source src="<%= url_for(attachment) %>" type="<%= attachment.content_type %>">
+                            <source src="<%= rails_storage_redirect_path(attachment) %>" type="<%= attachment.content_type %>">
                           </video>
                           <div class="media-type-badge">Video</div>
                         </a>


### PR DESCRIPTION
##AI 
- Yes - Bugfix was led by Claude, with me assiting it along the way. I made references to schema, questioned weird changes, and ensured that it was using the mcp correctly.

## Problem

Videos on the YSWS review page (`/admin/certification/ysws/:id`) could not be scrubbed or seeked — clicking ahead/back on the progress bar did nothing, and only the very start was reachable.

## Root cause

The page served ActiveStorage videos through **proxy mode** via `url_for(...)`. The ActiveStorage proxy controller includes `ActionController::Live`, so its responses are chunked with no usable `Content-Length`, and behind Cloudflare the proxy path **answers every HTTP `Range:` request with `200` (full body) instead of `206 Partial Content`** — on both cache HIT and MISS. With no working range support, the browser's `video.seekable` collapses to `[0, 0]`, making scrubbing impossible. (Completed reviews only *seemed* to work because the file was already fully buffered/cached from the reviewer's watch.)

### Verified against production

| Path | `Range: bytes=0-1` result |
|---|---|
| Proxy URL (current), cache HIT | `200 OK`, full body, no `Content-Range`/`Accept-Ranges` |
| Proxy URL, cache MISS (origin) | `200 OK` — still no `206` |
| **Redirect route → R2** | `302` → R2 returns **`206 Partial Content`** + `Content-Range: bytes 0-1/200731163` + `Content-Length` + `Accept-Ranges` |

R2 (the underlying S3-compatible store) serves native Range correctly; the proxy layer is what strips it.

## Fix

- Serve the **verdict video**, the **devlog video link**, and its `<source>` via `rails_storage_redirect_path(...)` instead of `url_for(...)`. The browser is redirected straight to R2 and gets native Range support. The media-viewer modal reads the clicked link's `href`, so it inherits the fix automatically. **Images stay on the proxy** (no range needed, benefits from CDN caching).
- Remove the no-op `z-index`/`pointer-events` CSS added by the earlier failed fix attempt (commit `ec8fadc0`); hit-testing confirmed nothing ever overlapped the player.

## Testing

- Read the stock Rails 8.1.3 ActiveStorage proxy/streaming source and confirmed the chunked/no-`Content-Length` behavior and the 100 MB single-range cap.
- Ran live `curl` Range probes against a real production verdict video on both the proxy and redirect routes (table above) — proxy returns `200`, redirect→R2 returns `206`.

## Notes

- No migration. View + CSS only.
- This bug **cannot be reproduced in development** — dev uses redirect mode + the Disk service, which already handles ranges correctly. The proxy/Cloudflare interaction only exists in production.
- Presigned R2 URLs use the default 5-minute expiry (`X-Amz-Expires=300`). On very long watches a seek after 5 minutes could hit an expired URL; left at the default here to avoid a global config change. Can revisit if it surfaces in practice.