### PR TITLE
feat(certification): Shows prior ysws reviews devlogs in a reship review - albeit frozen

### DIFF
--- a/app/assets/stylesheets/pages/admin/_ysws_reviews.scss
+++ b/app/assets/stylesheets/pages/admin/_ysws_reviews.scss
@@ -1110,6 +1110,41 @@ body:has(.certification-ysws) {
       gap: var(--space-xl);
     }
 
+    // Each review's devlogs are grouped; earlier reviews render frozen and are
+    // separated from the current (editable) review by a dashed divider.
+    .devlog-review-group {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-xl);
+
+      &:not(:last-child) {
+        margin-bottom: var(--space-xl);
+        padding-bottom: var(--space-xl);
+        border-bottom: 1px dashed var(--color-space-border);
+      }
+    }
+
+    .devlog-review-group__header {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: var(--space-s);
+      font-family: var(--font-family-sans);
+    }
+
+    .devlog-review-group__meta {
+      color: var(--color-space-text-muted);
+      font-size: var(--font-size-xs);
+    }
+
+    .devlog-review-group__current-label {
+      color: var(--color-brand-mint);
+      font-size: var(--font-size-s);
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
     .devlog-item {
       display: flex;
       gap: var(--space-l);
@@ -1120,6 +1155,21 @@ body:has(.certification-ysws) {
         border-bottom: none;
         padding-bottom: 0;
       }
+    }
+
+    // Devlogs from earlier reviews: dimmed and non-interactive.
+    .devlog-item--frozen {
+      opacity: 0.7;
+
+      .devlog-review-panel {
+        pointer-events: none;
+      }
+    }
+
+    .devlog-status.status-frozen {
+      background: rgba(255, 255, 255, 0.08);
+      color: var(--color-space-text-muted);
+      border: 1px solid var(--color-space-border);
     }
 
     .devlog-main {

--- a/app/controllers/admin/certification/ysws_controller.rb
+++ b/app/controllers/admin/certification/ysws_controller.rb
@@ -22,7 +22,20 @@ class Admin::Certification::YswsController < Admin::Certification::ApplicationCo
     # Check if review is already in unified DB
     @review.check_and_update_unified_db_status!
 
-    devlog_minutes = @review.devlog_reviews.map(&:original_minutes).compact
+    # Earlier reviews of the same project. Their devlogs are shown frozen
+    # (read-only) for context, oldest first, with only the current review's
+    # devlogs editable.
+    @prior_reviews = ::Certification::Ysws
+      .where(project_id: @review.project_id)
+      .where("id < ?", @review.id)
+      .includes(devlog_reviews: { post_devlog: :attachments_attachments })
+      .order(:id)
+
+    # Prior (frozen) + current devlogs, in display order, counted together in
+    # the header, time stats, and chart.
+    @all_devlog_reviews = @prior_reviews.flat_map(&:devlog_reviews) + @review.devlog_reviews.to_a
+
+    devlog_minutes = @all_devlog_reviews.map(&:original_minutes).compact
 
     @stats = {
       total_minutes: devlog_minutes.sum,

--- a/app/jobs/certification/ysws_airtable_sync_job.rb
+++ b/app/jobs/certification/ysws_airtable_sync_job.rb
@@ -314,7 +314,13 @@ module Certification
 
       ysws_justification = review.summary_justification.presence
       goi_note = ai_summary.present? ? "\n#{ai_summary}" : ""
-      project_update_note = review.project.update_description.present? ? "\nProject update: #{review.project.update_description}" : ""
+      # Only a reship (a review preceded by an earlier review of the same
+      # project) carries a meaningful project update, so only surface it then.
+      project_update_note = if prior_review?(review) && review.project.update_description.present?
+        "\nProject update: #{review.project.update_description}"
+      else
+        ""
+      end
 
       justification = <<~JUSTIFICATION
         The user logged #{original_formatted} on hackatime. #{total_original_minutes == total_approved_minutes ? "" : "(This was adjusted to #{approved_formatted} after review.)"}.
@@ -491,6 +497,15 @@ module Certification
     rescue StandardError => e
       Rails.logger.error "[YswsAirtableSyncJob] double-dip check error: #{e.class}: #{e.message}"
       false
+    end
+
+    # True when an earlier review exists for the same project (i.e. this is a
+    # reship). Mirrors the prior-review lookup on the YSWS review page.
+    def prior_review?(review)
+      Certification::Ysws
+        .where(project_id: review.project_id)
+        .where("id < ?", review.id)
+        .exists?
     end
 
     def prior_ship_event(review)

--- a/app/jobs/certification/ysws_airtable_sync_job.rb
+++ b/app/jobs/certification/ysws_airtable_sync_job.rb
@@ -314,10 +314,13 @@ module Certification
 
       ysws_justification = review.summary_justification.presence
       goi_note = ai_summary.present? ? "\n#{ai_summary}" : ""
-      # Only a reship (a review preceded by an earlier review of the same
-      # project) carries a meaningful project update, so only surface it then.
-      project_update_note = if prior_review?(review) && review.project.update_description.present?
+      # Surface the submitter's update description whenever there is one. Failing
+      # that, a reship (a review preceded by an earlier review of the same
+      # project) still notes the project update with a generic fallback.
+      project_update_note = if review.project.update_description.present?
         "\nProject update: #{review.project.update_description}"
+      elsif prior_review?(review)
+        "\nProject update: previously shipped to Stardance"
       else
         ""
       end

--- a/app/views/admin/certification/ysws/_devlog_review.html.erb
+++ b/app/views/admin/certification/ysws/_devlog_review.html.erb
@@ -1,0 +1,178 @@
+<%#
+  Renders a single devlog within a YSWS review.
+
+  Locals:
+    devlog_review   - Certification::Devlog to render
+    frozen          - when true, the review decision panel is read-only: no
+                      Stimulus controller is attached and every control is
+                      disabled. Used for devlogs belonging to earlier reviews.
+    sidebar_trigger - when true, this item triggers the details sidebar in
+                      popup mode (only the first item on the page should).
+
+  Relies on the page-level @repo_info and @devlog_commits for the git graph.
+%>
+<% frozen ||= false %>
+<% sidebar_trigger ||= false %>
+<div class="devlog-item<%= " devlog-item--frozen" if frozen %>"
+     <% unless frozen %>
+       data-controller="certification--ysws--devlog-review"
+       data-certification--ysws--devlog-review-id-value="<%= devlog_review.id %>"
+       data-certification--ysws--devlog-review-original-minutes-value="<%= devlog_review.original_minutes || 0 %>"
+       data-certification--ysws--devlog-review-status-value="<%= devlog_review.status %>"
+     <% end %>
+     <%= 'data-certification--ysws--review-sidebar-target="trigger"'.html_safe if sidebar_trigger %>>
+  <div class="devlog-main">
+    <div class="devlog-header-row">
+      <span class="devlog-id">Devlog #<%= devlog_review.post_devlog.id %></span>
+      <% if devlog_review.approved? %>
+        <span class="devlog-status status-approved">Approved</span>
+      <% elsif devlog_review.rejected? %>
+        <span class="devlog-status status-rejected">Rejected</span>
+      <% end %>
+      <% if frozen %>
+        <span class="devlog-status status-frozen" title="Reviewed in an earlier review">Locked</span>
+      <% end %>
+    </div>
+
+    <% if devlog_review.post_devlog.body.present? %>
+      <p class="devlog-desc"><%= devlog_review.post_devlog.body %></p>
+    <% else %>
+      <p class="devlog-desc empty-body-warning">body was empty, contact @AVD, this shouldn't happen</p>
+    <% end %>
+
+    <div class="devlog-media-section">
+      <div class="media-label">Devlog Media (<%= devlog_review.post_devlog.attachments.size %>)</div>
+      <% if devlog_review.post_devlog.attachments.any? %>
+        <div class="media-grid">
+          <% devlog_review.post_devlog.attachments.each do |attachment| %>
+            <% if attachment.video? %>
+              <a href="<%= url_for(attachment) %>" class="media-item video-item" data-action="click->certification--ysws--media-viewer#open">
+                <video class="media-thumbnail" muted>
+                  <source src="<%= url_for(attachment) %>" type="<%= attachment.content_type %>">
+                </video>
+                <div class="media-type-badge">Video</div>
+              </a>
+            <% else %>
+              <a href="<%= url_for(attachment) %>" class="media-item image-item" data-action="click->certification--ysws--media-viewer#open">
+                <%= image_tag attachment.variant(:thumb), class: "media-thumbnail", alt: "Devlog attachment" %>
+              </a>
+            <% end %>
+          <% end %>
+        </div>
+      <% else %>
+        <div class="media-placeholder">
+          <div class="placeholder-text">No media attached</div>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="devlog-time">
+      Original Time:
+      <span class="time-value"><%= ((devlog_review.original_minutes || 0) / 60.0).round(1) %> hrs</span>
+      <em>(<%= devlog_review.original_minutes || 0 %> minutes)</em>
+    </div>
+
+    <div class="devlog-git-section">
+      <%
+        dl_commits = @devlog_commits[devlog_review.post_devlog_id] || []
+        first_commit, last_commit = dl_commits.minmax_by { |c| c[:authored_at] || Time.at(0) }
+        compare_url = if first_commit && last_commit && first_commit != last_commit
+          first_sha = first_commit[:sha]
+          last_sha  = last_commit[:sha]
+          repo_base = @review.project.repo_url.to_s.chomp("/")
+          if @repo_info&.dig(:platform) == "github"
+            "#{repo_base}/compare/#{first_sha}...#{last_sha}"
+          elsif @repo_info&.dig(:platform)&.include?("gitlab")
+            "#{repo_base}/-/compare/#{first_sha}...#{last_sha}"
+          end
+        end
+      %>
+      <div class="git-label">
+        <% if compare_url %>
+          <%= link_to "Git Activity", compare_url, target: "_blank", rel: "noopener noreferrer" %>
+        <% else %>
+          Git Activity
+        <% end %>
+      </div>
+      <%= Certification::CommitGraphBuilder.new(dl_commits).svg %>
+    </div>
+  </div>
+
+  <!-- Review Decision Panel -->
+  <div class="devlog-review-panel<%= " #{devlog_review.status}" if frozen && devlog_review.reviewed? %>"
+       <%= 'data-certification--ysws--devlog-review-target="panel"'.html_safe unless frozen %>>
+    <div class="panel-title">Review Decision</div>
+
+    <div class="panel-section">
+      <div class="panel-label">Status:</div>
+      <div class="status-buttons">
+        <button class="status-btn btn-approve<%= " active" if frozen && devlog_review.approved? %>"
+                <% unless frozen %>
+                  data-certification--ysws--devlog-review-target="approveButton"
+                  data-action="click->certification--ysws--devlog-review#approve"
+                <% end %>
+                <%= "disabled" if frozen %>>
+          ✓ Approve
+        </button>
+        <button class="status-btn btn-reject<%= " active" if frozen && devlog_review.rejected? %>"
+                <% unless frozen %>
+                  data-certification--ysws--devlog-review-target="rejectButton"
+                  data-action="click->certification--ysws--devlog-review#reject"
+                <% end %>
+                <%= "disabled" if frozen %>>
+          ✗ Reject
+        </button>
+      </div>
+    </div>
+
+    <div class="panel-section">
+      <div class="panel-label">Approved Minutes:</div>
+      <div class="minutes-input-group">
+        <input type="number"
+               value="<%= devlog_review.approved_minutes || devlog_review.original_minutes || 0 %>"
+               class="minutes-input"
+               <% unless frozen %>
+                 data-certification--ysws--devlog-review-target="minutesInput"
+                 data-action="input->certification--ysws--devlog-review#updateMinutes"
+               <% end %>
+               min="0"
+               autocomplete="off"
+               <%= "disabled" if frozen %>>
+        <span class="minutes-label">minutes</span>
+        <span class="hours-display" <%= 'data-certification--ysws--devlog-review-target="hoursDisplay"'.html_safe unless frozen %>>
+          (<%= ((devlog_review.approved_minutes || devlog_review.original_minutes || 0) / 60.0).round(1) %>h)
+        </span>
+      </div>
+      <% unless frozen %>
+        <div class="quick-adjust-buttons">
+          <button class="adjust-btn"
+                  data-action="click->certification--ysws--devlog-review#quickAdjust"
+                  data-adjust-action="50%">50%</button>
+          <button class="adjust-btn"
+                  data-action="click->certification--ysws--devlog-review#quickAdjust"
+                  data-adjust-action="25%">25%</button>
+          <button class="adjust-btn"
+                  data-action="click->certification--ysws--devlog-review#quickAdjust"
+                  data-adjust-action="-30">-30min</button>
+          <button class="adjust-btn"
+                  data-action="click->certification--ysws--devlog-review#quickAdjust"
+                  data-adjust-action="-60">-1hr</button>
+          <button class="adjust-btn"
+                  data-action="click->certification--ysws--devlog-review#quickAdjust"
+                  data-adjust-action="reset">Reset</button>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="panel-section">
+      <div class="panel-label">Internal Notes:</div>
+      <textarea class="notes-textarea"
+                placeholder="notes..."
+                <% unless frozen %>
+                  data-certification--ysws--devlog-review-target="notesTextarea"
+                  data-action="input->certification--ysws--devlog-review#updateNotes"
+                <% end %>
+                <%= "disabled" if frozen %>><%= devlog_review.justification %></textarea>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/certification/ysws/show.html.erb
+++ b/app/views/admin/certification/ysws/show.html.erb
@@ -130,9 +130,9 @@
         </div>
         <div class="time-chart">
           <div class="chart-title">Time Distribution Across Devlogs</div>
-          <% if @review.devlog_reviews.any? %>
+          <% if @all_devlog_reviews.any? %>
             <%
-              chart_data = @review.devlog_reviews.each_with_index.map do |devlog_review, index|
+              chart_data = @all_devlog_reviews.each_with_index.map do |devlog_review, index|
                 {
                   label: "Devlog #{index + 1}",
                   minutes: devlog_review.original_minutes || 0
@@ -279,157 +279,35 @@
   <!-- Devlogs Section (Full Width) -->
   <section class="review-card devlogs-card">
     <div class="devlogs-header">
-      <h3>Devlogs (<%= @review.devlog_reviews.count %>)</h3>
+      <h3>Devlogs (<%= @all_devlog_reviews.size %>)</h3>
     </div>
 
-    <% if @review.devlog_reviews.any? %>
+    <% if @all_devlog_reviews.any? %>
       <div class="devlogs-list">
-        <% @review.devlog_reviews.each_with_index do |devlog_review, index| %>
-          <div class="devlog-item"
-               data-controller="certification--ysws--devlog-review"
-               data-certification--ysws--devlog-review-id-value="<%= devlog_review.id %>"
-               data-certification--ysws--devlog-review-original-minutes-value="<%= devlog_review.original_minutes || 0 %>"
-               data-certification--ysws--devlog-review-status-value="<%= devlog_review.status %>"
-               <%= 'data-certification--ysws--review-sidebar-target="trigger"'.html_safe if index == 0 %>>
-            <div class="devlog-main">
-              <div class="devlog-header-row">
-                <span class="devlog-id">Devlog #<%= devlog_review.post_devlog.id %></span>
-                <% if devlog_review.approved? %>
-                  <span class="devlog-status status-approved">Approved</span>
-                <% elsif devlog_review.rejected? %>
-                  <span class="devlog-status status-rejected">Rejected</span>
-                <% end %>
-              </div>
-
-              <% if devlog_review.post_devlog.body.present? %>
-                <p class="devlog-desc"><%= devlog_review.post_devlog.body %></p>
-              <% else %>
-                <p class="devlog-desc empty-body-warning">body was empty, contact @AVD, this shouldn't happen</p>
-              <% end %>
-
-              <div class="devlog-media-section">
-                <div class="media-label">Devlog Media (<%= devlog_review.post_devlog.attachments.size %>)</div>
-                <% if devlog_review.post_devlog.attachments.any? %>
-                  <div class="media-grid">
-                    <% devlog_review.post_devlog.attachments.each do |attachment| %>
-                      <% if attachment.video? %>
-                        <a href="<%= url_for(attachment) %>" class="media-item video-item" data-action="click->certification--ysws--media-viewer#open">
-                          <video class="media-thumbnail" muted>
-                            <source src="<%= url_for(attachment) %>" type="<%= attachment.content_type %>">
-                          </video>
-                          <div class="media-type-badge">Video</div>
-                        </a>
-                      <% else %>
-                        <a href="<%= url_for(attachment) %>" class="media-item image-item" data-action="click->certification--ysws--media-viewer#open">
-                          <%= image_tag attachment.variant(:thumb), class: "media-thumbnail", alt: "Devlog attachment" %>
-                        </a>
-                      <% end %>
-                    <% end %>
-                  </div>
-                <% else %>
-                  <div class="media-placeholder">
-                    <div class="placeholder-text">No media attached</div>
-                  </div>
-                <% end %>
-              </div>
-
-              <div class="devlog-time">
-                Original Time:
-                <span class="time-value"><%= ((devlog_review.original_minutes || 0) / 60.0).round(1) %> hrs</span>
-                <em>(<%= devlog_review.original_minutes || 0 %> minutes)</em>
-              </div>
-
-              <div class="devlog-git-section">
-                <%
-                  dl_commits = @devlog_commits[devlog_review.post_devlog_id] || []
-                  first_commit, last_commit = dl_commits.minmax_by { |c| c[:authored_at] || Time.at(0) }
-                  compare_url = if first_commit && last_commit && first_commit != last_commit
-                    first_sha = first_commit[:sha]
-                    last_sha  = last_commit[:sha]
-                    repo_base = @review.project.repo_url.to_s.chomp("/")
-                    if @repo_info&.dig(:platform) == "github"
-                      "#{repo_base}/compare/#{first_sha}...#{last_sha}"
-                    elsif @repo_info&.dig(:platform)&.include?("gitlab")
-                      "#{repo_base}/-/compare/#{first_sha}...#{last_sha}"
-                    end
-                  end
-                %>
-                <div class="git-label">
-                  <% if compare_url %>
-                    <%= link_to "Git Activity", compare_url, target: "_blank", rel: "noopener noreferrer" %>
-                  <% else %>
-                    Git Activity
-                  <% end %>
-                </div>
-                <%= Certification::CommitGraphBuilder.new(dl_commits).svg %>
-              </div>
+        <% @prior_reviews.each do |prior_review| %>
+          <% next if prior_review.devlog_reviews.empty? %>
+          <div class="devlog-review-group devlog-review-group--frozen">
+            <div class="devlog-review-group__header">
+              <%= link_to "Review ##{prior_review.id}", admin_certification_ysws_review_path(prior_review), class: "link-primary" %>
+              <%= review_status_badge(prior_review) %>
+              <span class="devlog-review-group__meta">shipped <%= prior_review.created_at.to_date %> · read-only</span>
             </div>
-
-            <!-- Review Decision Panel -->
-            <div class="devlog-review-panel"
-                 data-certification--ysws--devlog-review-target="panel">
-              <div class="panel-title">Review Decision</div>
-
-              <div class="panel-section">
-                <div class="panel-label">Status:</div>
-                <div class="status-buttons">
-                  <button class="status-btn btn-approve"
-                          data-certification--ysws--devlog-review-target="approveButton"
-                          data-action="click->certification--ysws--devlog-review#approve">
-                    ✓ Approve
-                  </button>
-                  <button class="status-btn btn-reject"
-                          data-certification--ysws--devlog-review-target="rejectButton"
-                          data-action="click->certification--ysws--devlog-review#reject">
-                    ✗ Reject
-                  </button>
-                </div>
-              </div>
-
-              <div class="panel-section">
-                <div class="panel-label">Approved Minutes:</div>
-                <div class="minutes-input-group">
-                  <input type="number"
-                         value="<%= devlog_review.approved_minutes || devlog_review.original_minutes || 0 %>"
-                         class="minutes-input"
-                         data-certification--ysws--devlog-review-target="minutesInput"
-                         data-action="input->certification--ysws--devlog-review#updateMinutes"
-                         min="0"
-                         autocomplete="off">
-                  <span class="minutes-label">minutes</span>
-                  <span class="hours-display" data-certification--ysws--devlog-review-target="hoursDisplay">
-                    (<%= ((devlog_review.approved_minutes || devlog_review.original_minutes || 0) / 60.0).round(1) %>h)
-                  </span>
-                </div>
-                <div class="quick-adjust-buttons">
-                  <button class="adjust-btn"
-                          data-action="click->certification--ysws--devlog-review#quickAdjust"
-                          data-adjust-action="50%">50%</button>
-                  <button class="adjust-btn"
-                          data-action="click->certification--ysws--devlog-review#quickAdjust"
-                          data-adjust-action="25%">25%</button>
-                  <button class="adjust-btn"
-                          data-action="click->certification--ysws--devlog-review#quickAdjust"
-                          data-adjust-action="-30">-30min</button>
-                  <button class="adjust-btn"
-                          data-action="click->certification--ysws--devlog-review#quickAdjust"
-                          data-adjust-action="-60">-1hr</button>
-                  <button class="adjust-btn"
-                          data-action="click->certification--ysws--devlog-review#quickAdjust"
-                          data-adjust-action="reset">Reset</button>
-                </div>
-              </div>
-
-              <div class="panel-section">
-                <div class="panel-label">Internal Notes:</div>
-                <textarea class="notes-textarea"
-                          placeholder="notes..."
-                          data-certification--ysws--devlog-review-target="notesTextarea"
-                          data-action="input->certification--ysws--devlog-review#updateNotes"><%= devlog_review.justification %></textarea>
-              </div>
-            </div>
+            <% prior_review.devlog_reviews.each do |devlog_review| %>
+              <%= render "devlog_review", devlog_review: devlog_review, frozen: true %>
+            <% end %>
           </div>
         <% end %>
+
+        <div class="devlog-review-group">
+          <% if @prior_reviews.any? { |r| r.devlog_reviews.any? } %>
+            <div class="devlog-review-group__header">
+              <span class="devlog-review-group__current-label">This review</span>
+            </div>
+          <% end %>
+          <% @review.devlog_reviews.each_with_index do |devlog_review, index| %>
+            <%= render "devlog_review", devlog_review: devlog_review, frozen: false, sidebar_trigger: index == 0 %>
+          <% end %>
+        </div>
       </div>
     <% else %>
       <div class="empty-devlogs">


### PR DESCRIPTION
A project's YSWS review page now also renders the devlogs of any earlier reviews for the same project (lower review id), oldest first, in a read-only/frozen state — only the current review's devlogs stay editable.

- Controller loads @prior_reviews and @all_devlog_reviews; the header count, time stats, and chart now span prior + current devlogs.
- Extract the devlog item into a shared _devlog_review partial with a frozen variant: no Stimulus controller/actions and disabled controls.
- Group devlogs per source review with a header and a 'This review' label.
- Add devlog-review-group / devlog-item--frozen BEM styles.


https://github.com/user-attachments/assets/c8a37bc0-962b-48c1-aa4c-bd3f6b243888



