### PR TITLE
Fix reply textarea rendering at half width

### DIFF
--- a/app/assets/stylesheets/components/_feed.scss
+++ b/app/assets/stylesheets/components/_feed.scss
@@ -1719,13 +1719,15 @@
   &__textarea {
     background: transparent;
     border: none;
+    box-sizing: border-box;
     color: var(--color-space-text);
-    flex: 1;
+    display: block;
     font-family: inherit;
     font-size: 1.2rem;
     min-height: 120px;
     padding: 4px 0;
     resize: none;
+    width: 100%;
 
     &::placeholder {
       color: var(--color-space-text-muted);


### PR DESCRIPTION
Have a full-width reply area. Edits with Claude Code but I tested it. Here is a before and after video:

Before:

https://github.com/user-attachments/assets/ef144766-0a9f-4529-936d-ae84bf798ecc


After:

https://github.com/user-attachments/assets/87b894f4-dba9-4a01-a21a-e6ff32dc921f

