### PR TITLE
Quote repost preview

### DIFF
--- a/app/assets/stylesheets/components/_feed.scss
+++ b/app/assets/stylesheets/components/_feed.scss
@@ -358,6 +358,13 @@
     display: none;
   }
 
+  // The post being quoted, shown below the text box while composing a quote
+  // repost (reuses .feed-post-card__repost-preview for the timeline look).
+  // Non-interactivity comes from the `inert` attribute on the element.
+  &__quote-preview {
+    margin-top: 14px;
+  }
+
   &__info-wrap {
     display: flex;
     align-items: center;

--- a/app/components/posts/card_component.html.erb
+++ b/app/components/posts/card_component.html.erb
@@ -70,18 +70,11 @@
 
   <% if quote_repost? && original_post.present? %>
     <div class="feed-post-card__repost-preview">
-      <%= render Posts::CardComponent.new(
+      <%= render "shared/repost_preview_card",
             post: original_post,
             current_user: current_user,
-            theme: :"repost-preview",
-            compact: true,
-            show_likes: false,
-            show_comments: false,
-            show_reposts: false,
-            show_actions: false,
             track_engagement: track_engagement,
-            show_views: show_views
-          ) %>
+            show_views: show_views %>
     </div>
   <% end %>
 
@@ -219,7 +212,8 @@
                     simple_mode: true,
                     show_project_chips: false,
                     show_attachments: false,
-                    show_time_preview: false
+                    show_time_preview: false,
+                    quote_preview_post: repost_target
                   ) %>
             </dialog>
           <% else %>

--- a/app/components/posts/composer_component.html.erb
+++ b/app/components/posts/composer_component.html.erb
@@ -66,6 +66,22 @@
 
         <div class="md-preview markdown-content" data-markdown-preview-target="output" hidden></div>
 
+        <% if quote_preview? %>
+          <%# The post being quoted, shown below the text box and rendered exactly
+              as it appears nested inside a quote repost on the timeline — so the
+              composer reads like the final card (your thought up top, the quoted
+              post beneath) without echoing your text a second time. `inert` keeps
+              it a non-interactive preview: no clicks (so links can't navigate you
+              away mid-compose), no tab focus. %>
+          <div class="feed-composer__quote-preview feed-post-card__repost-preview" inert>
+            <%= render "shared/repost_preview_card",
+                  post: quote_preview_post,
+                  current_user: current_user,
+                  track_engagement: false,
+                  show_views: false %>
+          </div>
+        <% end %>
+
         <% if show_attachments? %>
           <div class="feed-composer__attach-wrap" data-composer-target="attachWrap">
             <label class="feed-composer__attach">

--- a/app/components/posts/composer_component.rb
+++ b/app/components/posts/composer_component.rb
@@ -7,13 +7,13 @@ module Posts
     attr_reader :post, :current_user, :projects, :selected_project, :test_time_granted,
                 :url, :scope, :aria_label, :body_label, :placeholder, :submit_text,
                 :disable_with, :simple_mode, :show_project_chips, :show_attachments,
-                :show_time_preview, :show_record
+                :show_time_preview, :show_record, :quote_preview_post
 
     def initialize(post:, current_user:, projects:, selected_project:, test_time_granted: false,
       url: nil, scope: nil, aria_label: "Create a devlog", body_label: "What are you working on?",
       placeholder: "What are you working on?", submit_text: "Post", disable_with: "Posting...",
       simple_mode: false, show_project_chips: true, show_attachments: true, show_time_preview: true,
-      show_record: false)
+      show_record: false, quote_preview_post: nil)
       @post = post
       @current_user = current_user
       @projects = projects
@@ -31,6 +31,15 @@ module Posts
       @show_attachments = show_attachments
       @show_time_preview = show_time_preview
       @show_record = show_record
+      @quote_preview_post = quote_preview_post
+    end
+
+    # When a post to quote is supplied, the composer shows it below the text box
+    # (rendered as it appears nested in a quote repost on the timeline) so the
+    # composer reads like the final card — your thought up top, the quoted post
+    # beneath — without echoing your text a second time.
+    def quote_preview?
+      quote_preview_post.present?
     end
 
     def enabled?

--- a/app/views/shared/_repost_preview_card.html.erb
+++ b/app/views/shared/_repost_preview_card.html.erb
@@ -1,0 +1,16 @@
+<%# A devlog rendered as it appears nested inside a quote repost: the
+    "repost-preview" theme with no action footer. Shared by the timeline
+    quote-repost card and the quote-repost composer's preview so the embedded
+    post stays visually identical in both. %>
+<%= render Posts::CardComponent.new(
+      post: post,
+      current_user: current_user,
+      theme: :"repost-preview",
+      compact: true,
+      show_likes: false,
+      show_comments: false,
+      show_reposts: false,
+      show_actions: false,
+      track_engagement: track_engagement,
+      show_views: show_views
+    ) %>


### PR DESCRIPTION
## what's this do?

When you quote repost someone's devlog, show their devlog inline in the editing area.

## show it works

Before:

https://github.com/user-attachments/assets/cc67bdac-238f-4fef-88f9-3ee055f53fe4

After:

https://github.com/user-attachments/assets/b37297b9-6eb8-4d13-a68f-d0561e74ca8f


## ai?

Claude Code