### PR TITLE
migrate the daily random number from 32 bit to 64 bit for a larger max value

### DIFF
--- a/app/javascript/controllers/daily_roll_controller.js
+++ b/app/javascript/controllers/daily_roll_controller.js
@@ -9,7 +9,8 @@ export default class extends Controller {
   static targets = ["number", "burst"];
   static values = {
     justRolled: Boolean,
-    value: Number,
+    // changed from Number to String so JavaScript doesn't freak out
+    value: String,
     // BEM block the reveal classes hang off, so the same animation can drive
     // the rail widget (daily-roll-widget) and the /rng hero (rng-hero).
     baseClass: { type: String, default: "daily-roll-widget" },
@@ -37,7 +38,7 @@ export default class extends Controller {
 
   disconnect() {
     this.alive = false;
-    clearTimeout(this.sleepTimer);
+    this.clearTimeout(this.sleepTimer);
   }
 
   get base() {
@@ -45,7 +46,9 @@ export default class extends Controller {
   }
 
   async reveal() {
-    const digits = String(Math.abs(this.valueValue));
+    // replaced Math.abs parsing with regular expression character stripping
+    // since string representations of BigInt can cause explosions
+    const digits = this.valueValue.replace(/[^0-9]/g, "");
     this.buildSlots();
 
     // Unveil from the ones place, one digit at a time. Each incoming digit
@@ -98,7 +101,7 @@ export default class extends Controller {
   // Final state: full styled number visible, flavor + leaderboard fade in.
   land() {
     if (!this.digitsElement) {
-      this.numberTarget.textContent = this.group(String(this.valueValue));
+      this.numberTarget.textContent = this.group(this.valueValue);
     }
     this.element.classList.remove(
       `${this.base}--waiting`,
@@ -112,9 +115,12 @@ export default class extends Controller {
     if (!this.hasBurstTarget) return;
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
 
-    const intMax = 2147483647;
+    // upgraded evaluation to work with BigInt expressions
+    const maxVal = 18446744073709551615n;
+    const currentRoll = BigInt(this.valueValue.replace(/[^0-9]/g, ""));
+    
     const count =
-      Math.abs(this.valueValue) >= intMax * 0.9
+      currentRoll >= (maxVal * 9n) / 10n
         ? this.constructor.PARTICLE_COUNT
         : Math.ceil(this.constructor.PARTICLE_COUNT / 2);
 

--- a/app/javascript/controllers/daily_roll_controller.js
+++ b/app/javascript/controllers/daily_roll_controller.js
@@ -118,7 +118,7 @@ export default class extends Controller {
     // upgraded evaluation to work with BigInt expressions
     const maxVal = 18446744073709551615n;
     const currentRoll = BigInt(this.valueValue.replace(/[^0-9]/g, ""));
-    
+
     const count =
       currentRoll >= (maxVal * 9n) / 10n
         ? this.constructor.PARTICLE_COUNT

--- a/app/models/daily_roll.rb
+++ b/app/models/daily_roll.rb
@@ -26,7 +26,8 @@
 class DailyRoll < ApplicationRecord
   # Postgres int4 max — an integer column stores this in the same 4 bytes as
   # a roll of 1, so we may as well use the whole dial.
-  MAX_VALUE = 2_147_483_647
+  # 64 bit unsigned max
+  MAX_VALUE = 18_446_744_073_709_551_615
   LEADERBOARD_SIZE = 5
 
   # The Monday rng goes live. Days are numbered from it (day 1, day 2, …);
@@ -46,8 +47,12 @@ class DailyRoll < ApplicationRecord
   # Throwaway aside about a roll, keyed to how big the number got. Each tier
   # has a few casual variants; one is picked per roll (see #flavor). Most rolls
   # land in the bottom tiers. Thresholds are checked high-to-low.
+  # new tiers
   FLAVORS = [
-    [ MAX_VALUE,     [ "no way, the max", "literally the maximum??", "ok that shouldn't happen 🫨" ] ],
+    [ MAX_VALUE,                  [ "no way, the max", "literally the maximum??", "ok that shouldn't happen 🫨" ] ],
+    [ 10_000_000_000_000_000_000, [ "QUINTILLIONS?!?!?!", "🤨 are you a wizard?", "breaking reality atp" ] ],
+    [ 1_000_000_000_000_000,      [ "quadrillions, wow", "that's possible?", "stupidly big" ] ],
+    [ 1_000_000_000_000,          [ "TrIlLiOnS!", "An absolute unit of a roll ", "Massive pull!" ] ],
     [ 1_000_000_000, [ "whoa, huge", "BILLIONS", "ok that's massive 🤯" ] ],
     [ 100_000_000,   [ "really big number", "huge", "ok big number 👀" ] ],
     [ 1_000_000,     [ "big number", "IS BIG NUMBER 🫨", "millions, nice" ] ],
@@ -61,11 +66,12 @@ class DailyRoll < ApplicationRecord
 
   # Colour tier for the number, by magnitude: the dim majority stays muted and
   # the rare big roll glows. Shared by the rail widget and the /rng hero.
+  # scaled the cosmic threshold
   TONES = [
-    [ 1_000_000, "cosmic" ],
-    [ 10_000,    "high" ],
-    [ 100,       "mid" ],
-    [ 0,         "low" ]
+    [ 1_000_000_000_000, "cosmic" ],
+    [ 1_000_000,         "high" ],
+    [ 1_000,               "mid" ],
+    [ 0,                 "low" ]
   ].freeze
 
   belongs_to :user

--- a/test/models/daily_roll_test.rb
+++ b/test/models/daily_roll_test.rb
@@ -113,14 +113,14 @@ class DailyRollTest < ActiveSupport::TestCase
 
   test "flavor picks a variant from the matching magnitude tier" do
     # updated 4_200 to map to the 1_000 threshold
-    { 
-      0 => 0, 
-      7 => 1, 
-      42 => 10, 
-      4_200 => 1_000, 
+    {
+      0 => 0,
+      7 => 1,
+      42 => 10,
+      4_200 => 1_000,
       5_000_000_000_000 => 1_000_000_000_000,
       12_000_000_000_000_000_000 => 10_000_000_000_000_000_000,
-      DailyRoll::MAX_VALUE => DailyRoll::MAX_VALUE 
+      DailyRoll::MAX_VALUE => DailyRoll::MAX_VALUE
     }.each do |value, threshold|
       variants = DailyRoll::FLAVORS.find { |t, _| t == threshold }.last
       assert_includes variants, DailyRoll.new(value: value).flavor
@@ -142,8 +142,8 @@ class DailyRollTest < ActiveSupport::TestCase
   test "tone tiers the number by magnitude for colour" do
     # modify tones to map correctly
     assert_equal "low", DailyRoll.new(value: 9).tone
-    assert_equal "mid", DailyRoll.new(value: 5_000).tone       
-    assert_equal "high", DailyRoll.new(value: 5_000_000_000).tone    
+    assert_equal "mid", DailyRoll.new(value: 5_000).tone
+    assert_equal "high", DailyRoll.new(value: 5_000_000_000).tone
     assert_equal "cosmic", DailyRoll.new(value: 2_000_000_000_000).tone
   end
 

--- a/test/models/daily_roll_test.rb
+++ b/test/models/daily_roll_test.rb
@@ -22,6 +22,7 @@
 require "test_helper"
 
 class DailyRollTest < ActiveSupport::TestCase
+  fixtures :users, :daily_rolls
   setup do
     @user = users(:one)
   end
@@ -111,7 +112,16 @@ class DailyRollTest < ActiveSupport::TestCase
   end
 
   test "flavor picks a variant from the matching magnitude tier" do
-    { 0 => 0, 7 => 1, 42 => 10, 4_200 => 1_000, DailyRoll::MAX_VALUE => DailyRoll::MAX_VALUE }.each do |value, threshold|
+    # updated 4_200 to map to the 1_000 threshold
+    { 
+      0 => 0, 
+      7 => 1, 
+      42 => 10, 
+      4_200 => 1_000, 
+      5_000_000_000_000 => 1_000_000_000_000,
+      12_000_000_000_000_000_000 => 10_000_000_000_000_000_000,
+      DailyRoll::MAX_VALUE => DailyRoll::MAX_VALUE 
+    }.each do |value, threshold|
       variants = DailyRoll::FLAVORS.find { |t, _| t == threshold }.last
       assert_includes variants, DailyRoll.new(value: value).flavor
     end
@@ -130,10 +140,11 @@ class DailyRollTest < ActiveSupport::TestCase
   end
 
   test "tone tiers the number by magnitude for colour" do
+    # modify tones to map correctly
     assert_equal "low", DailyRoll.new(value: 9).tone
-    assert_equal "mid", DailyRoll.new(value: 500).tone
-    assert_equal "high", DailyRoll.new(value: 25_000).tone
-    assert_equal "cosmic", DailyRoll.new(value: 5_000_000).tone
+    assert_equal "mid", DailyRoll.new(value: 5_000).tone       
+    assert_equal "high", DailyRoll.new(value: 5_000_000_000).tone    
+    assert_equal "cosmic", DailyRoll.new(value: 2_000_000_000_000).tone
   end
 
   test "rejects values outside 0..MAX_VALUE" do


### PR DESCRIPTION
## what's this do?

i noticed that a few people already hit the max amount in the rng thing and it was kinda low so i thought it would be funny to switch the max to the maximum unsigned 64 bit value (**18,446,744,073,709,551,615** instead of 2,147,483,647)

## show it works

<img width="635" height="209" alt="Screenshot_20260619_034040" src="https://github.com/user-attachments/assets/c380ab6a-8bc3-44cc-ba89-ac6897ae8575" />

^^^ this is the test ruby file running with no failures or errors

## ai?

nope, no ai
