### PR TITLE
feat(outpost): make Presentable Hardware approval a manual toggle

### DIFF
--- a/app/controllers/admin/users/presentable_hardware_flags_controller.rb
+++ b/app/controllers/admin/users/presentable_hardware_flags_controller.rb
@@ -2,12 +2,11 @@ class Admin::Users::PresentableHardwareFlagsController < Admin::ApplicationContr
   before_action -> { head :not_found unless Flipper.enabled?(:hardware_flow, current_user) }
   before_action :set_user
 
-  # Granted after a showcase project (forms.hackclub.com/submit-showcase-project)
-  # has been reviewed. Unlocks the Outpost Ticket via the achievement gate.
+  # Manual toggle: an admin grants this once a hardware project is presentable.
+  # Awards the achievement that unlocks the Outpost Ticket via the shop gate.
   def create
     authorize @user, :manage_feature_flags?
 
-    @user.update!(manual_outpost_ticket_approval: params[:approval_url])
     @user.award_achievement!(:manual_outpost_ticket_approval, notified: true)
     log_change(true)
 
@@ -18,8 +17,7 @@ class Admin::Users::PresentableHardwareFlagsController < Admin::ApplicationContr
   def destroy
     authorize @user, :manage_feature_flags?
 
-    @user.update!(manual_outpost_ticket_approval: nil)
-    @user.achievements.where(achievement_slug: "manual_outpost_ticket_approval").destroy_all
+    @user.revoke_achievement!(:manual_outpost_ticket_approval)
     log_change(false)
 
     redirect_to admin_user_path(@user),
@@ -38,7 +36,7 @@ class Admin::Users::PresentableHardwareFlagsController < Admin::ApplicationContr
       item_id: @user.id,
       event: enabled ? "presentable_hardware_enable" : "presentable_hardware_disable",
       whodunnit: current_user.id,
-      object_changes: { manual_outpost_ticket_approval: [ !enabled, enabled ] }.to_json
+      object_changes: { outpost_ticket_approved: [ !enabled, enabled ] }.to_json
     )
   end
 end

--- a/app/models/achievement.rb
+++ b/app/models/achievement.rb
@@ -40,7 +40,9 @@ Achievement = Data.define(:slug, :name, :description, :icon, :earned_check, :pro
       name: "Presentable Hardware Project",
       description: "Got a hardware project polished enough to show off. Unlocks the Outpost Ticket.",
       icon: "rocket",
-      earned_check: ->(user) { user.manual_outpost_ticket_approval.present? },
+      # Manual-only: an admin grants/revokes this via the Outpost Ticket toggle
+      # on the user admin page. The achievement row is the source of truth.
+      earned_check: ->(user) { user.earned_achievement?(:manual_outpost_ticket_approval) },
       visibility: :visible
     )
   ].freeze

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,6 +69,10 @@ class User < ApplicationRecord
   include SemanticSearchIndexable
   include Gorse::SyncableUser
 
+  # Dropped in favour of the manual_outpost_ticket_approval achievement row.
+  # Kept ignored so a cached schema can't reference it mid-deploy.
+  self.ignored_columns += [ "manual_outpost_ticket_approval" ]
+
   has_paper_trail ignore: [ :votes_count, :updated_at, :shop_region, :ip_address, :user_agent ], on: [ :update, :destroy ]
   semantic_search_indexable type: "user"
 
@@ -217,7 +221,6 @@ class User < ApplicationRecord
   validates :display_name, format: { with: USERNAME_FORMAT, message: "can only contain letters, numbers, hyphens, and underscores" }, if: :display_name_changed?
   validates :hcb_email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
   validates :user_ref, length: { maximum: 100 }, allow_blank: true
-  validates :manual_outpost_ticket_approval, format: { with: /\Ahttps?:\/\/.+\z/i, message: "must be an HTTP(S) URL" }, allow_blank: true
 
   include User::Notifications
   include User::Roles

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,56 +2,55 @@
 #
 # Table name: users
 #
-#  id                             :bigint           not null, primary key
-#  age_attestation                :string
-#  approx_balance                 :integer          default(0), not null
-#  approx_total_earned            :integer          default(0), not null
-#  banned                         :boolean          default(FALSE), not null
-#  banned_at                      :datetime
-#  banned_reason                  :text
-#  bio                            :text
-#  display_name                   :string
-#  email                          :string
-#  enriched_ref                   :string
-#  experience_level               :string
-#  first_name                     :string
-#  geocoded_country               :string
-#  geocoded_lat                   :float
-#  geocoded_lon                   :float
-#  geocoded_subdivision           :string
-#  granted_roles                  :string           default([]), not null, is an Array
-#  guest_email                    :string
-#  has_gotten_free_stickers       :boolean          default(FALSE)
-#  has_pending_achievements       :boolean          default(FALSE), not null
-#  hcb_email                      :string
-#  interests                      :string           default([]), is an Array
-#  internal_notes                 :text
-#  ip_address                     :string
-#  last_name                      :string
-#  manual_outpost_ticket_approval :string
-#  manual_ysws_override           :boolean
-#  mission_review_notifications   :boolean          default(TRUE), not null
-#  onboarded_at                   :datetime
-#  outpost_discount_stardust      :integer          default(0), not null
-#  outpost_email_sent_at          :datetime
-#  ref                            :string
-#  regions                        :string           default([]), is an Array
-#  session_token                  :string
-#  shop_region                    :enum
-#  shop_tutorial_completed_at     :datetime
-#  shop_tutorial_started_at       :datetime
-#  synced_at                      :datetime
-#  things_dismissed               :string           default([]), not null, is an Array
-#  user_agent                     :string
-#  user_ref                       :string
-#  verification_checked_at        :datetime
-#  verification_status            :string           default("needs_submission"), not null
-#  vote_balance                   :integer          default(0), not null
-#  votes_count                    :integer
-#  ysws_eligible                  :boolean          default(FALSE), not null
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  slack_id                       :string
+#  id                           :bigint           not null, primary key
+#  age_attestation              :string
+#  approx_balance               :integer          default(0), not null
+#  approx_total_earned          :integer          default(0), not null
+#  banned                       :boolean          default(FALSE), not null
+#  banned_at                    :datetime
+#  banned_reason                :text
+#  bio                          :text
+#  display_name                 :string
+#  email                        :string
+#  enriched_ref                 :string
+#  experience_level             :string
+#  first_name                   :string
+#  geocoded_country             :string
+#  geocoded_lat                 :float
+#  geocoded_lon                 :float
+#  geocoded_subdivision         :string
+#  granted_roles                :string           default([]), not null, is an Array
+#  guest_email                  :string
+#  has_gotten_free_stickers     :boolean          default(FALSE)
+#  has_pending_achievements     :boolean          default(FALSE), not null
+#  hcb_email                    :string
+#  interests                    :string           default([]), is an Array
+#  internal_notes               :text
+#  ip_address                   :string
+#  last_name                    :string
+#  manual_ysws_override         :boolean
+#  mission_review_notifications :boolean          default(TRUE), not null
+#  onboarded_at                 :datetime
+#  outpost_discount_stardust    :integer          default(0), not null
+#  outpost_email_sent_at        :datetime
+#  ref                          :string
+#  regions                      :string           default([]), is an Array
+#  session_token                :string
+#  shop_region                  :enum
+#  shop_tutorial_completed_at   :datetime
+#  shop_tutorial_started_at     :datetime
+#  synced_at                    :datetime
+#  things_dismissed             :string           default([]), not null, is an Array
+#  user_agent                   :string
+#  user_ref                     :string
+#  verification_checked_at      :datetime
+#  verification_status          :string           default("needs_submission"), not null
+#  vote_balance                 :integer          default(0), not null
+#  votes_count                  :integer
+#  ysws_eligible                :boolean          default(FALSE), not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  slack_id                     :string
 #
 # Indexes
 #

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -138,23 +138,17 @@
   <div>
     <h2>Hardware</h2>
     <div>
-      <% if @user.manual_outpost_ticket_approval.present? %>
-        <p>
-          Manual Outpost Ticket approval:
-          <%= link_to "View in Airtable", @user.manual_outpost_ticket_approval, target: "_blank", rel: "noopener" %>
-        </p>
-        <%= button_to admin_user_presentable_hardware_flag_path(@user),
+      <% if @user.earned_achievement?(:manual_outpost_ticket_approval) %>
+        <p>Outpost Ticket: <strong>approved</strong></p>
+        <%= button_to "Remove approval ✗", admin_user_presentable_hardware_flag_path(@user),
                       method: :delete,
                       disabled: !current_user&.admin?,
-                      title: "Remove the manual Outpost Ticket approval" do %>
-          Remove approval ✗
-        <% end %>
+                      title: "Remove the Outpost Ticket approval" %>
       <% else %>
-        <%= form_with url: admin_user_presentable_hardware_flag_path(@user), method: :post do |f| %>
-          <%= f.label :approval_url, "Airtable record URL" %>
-          <%= f.url_field :approval_url, placeholder: "https://airtable.com/...", required: true %>
-          <%= f.submit "Approve Outpost Ticket", disabled: !current_user&.admin? %>
-        <% end %>
+        <%= button_to "Approve Outpost Ticket ✓", admin_user_presentable_hardware_flag_path(@user),
+                      method: :post,
+                      disabled: !current_user&.admin?,
+                      title: "Manually approve the Outpost Ticket" %>
       <% end %>
     </div>
   </div>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,56 +4,55 @@
 #
 # Table name: users
 #
-#  id                             :bigint           not null, primary key
-#  age_attestation                :string
-#  approx_balance                 :integer          default(0), not null
-#  approx_total_earned            :integer          default(0), not null
-#  banned                         :boolean          default(FALSE), not null
-#  banned_at                      :datetime
-#  banned_reason                  :text
-#  bio                            :text
-#  display_name                   :string
-#  email                          :string
-#  enriched_ref                   :string
-#  experience_level               :string
-#  first_name                     :string
-#  geocoded_country               :string
-#  geocoded_lat                   :float
-#  geocoded_lon                   :float
-#  geocoded_subdivision           :string
-#  granted_roles                  :string           default([]), not null, is an Array
-#  guest_email                    :string
-#  has_gotten_free_stickers       :boolean          default(FALSE)
-#  has_pending_achievements       :boolean          default(FALSE), not null
-#  hcb_email                      :string
-#  interests                      :string           default([]), is an Array
-#  internal_notes                 :text
-#  ip_address                     :string
-#  last_name                      :string
-#  manual_outpost_ticket_approval :string
-#  manual_ysws_override           :boolean
-#  mission_review_notifications   :boolean          default(TRUE), not null
-#  onboarded_at                   :datetime
-#  outpost_discount_stardust      :integer          default(0), not null
-#  outpost_email_sent_at          :datetime
-#  ref                            :string
-#  regions                        :string           default([]), is an Array
-#  session_token                  :string
-#  shop_region                    :enum
-#  shop_tutorial_completed_at     :datetime
-#  shop_tutorial_started_at       :datetime
-#  synced_at                      :datetime
-#  things_dismissed               :string           default([]), not null, is an Array
-#  user_agent                     :string
-#  user_ref                       :string
-#  verification_checked_at        :datetime
-#  verification_status            :string           default("needs_submission"), not null
-#  vote_balance                   :integer          default(0), not null
-#  votes_count                    :integer
-#  ysws_eligible                  :boolean          default(FALSE), not null
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  slack_id                       :string
+#  id                           :bigint           not null, primary key
+#  age_attestation              :string
+#  approx_balance               :integer          default(0), not null
+#  approx_total_earned          :integer          default(0), not null
+#  banned                       :boolean          default(FALSE), not null
+#  banned_at                    :datetime
+#  banned_reason                :text
+#  bio                          :text
+#  display_name                 :string
+#  email                        :string
+#  enriched_ref                 :string
+#  experience_level             :string
+#  first_name                   :string
+#  geocoded_country             :string
+#  geocoded_lat                 :float
+#  geocoded_lon                 :float
+#  geocoded_subdivision         :string
+#  granted_roles                :string           default([]), not null, is an Array
+#  guest_email                  :string
+#  has_gotten_free_stickers     :boolean          default(FALSE)
+#  has_pending_achievements     :boolean          default(FALSE), not null
+#  hcb_email                    :string
+#  interests                    :string           default([]), is an Array
+#  internal_notes               :text
+#  ip_address                   :string
+#  last_name                    :string
+#  manual_ysws_override         :boolean
+#  mission_review_notifications :boolean          default(TRUE), not null
+#  onboarded_at                 :datetime
+#  outpost_discount_stardust    :integer          default(0), not null
+#  outpost_email_sent_at        :datetime
+#  ref                          :string
+#  regions                      :string           default([]), is an Array
+#  session_token                :string
+#  shop_region                  :enum
+#  shop_tutorial_completed_at   :datetime
+#  shop_tutorial_started_at     :datetime
+#  synced_at                    :datetime
+#  things_dismissed             :string           default([]), not null, is an Array
+#  user_agent                   :string
+#  user_ref                     :string
+#  verification_checked_at      :datetime
+#  verification_status          :string           default("needs_submission"), not null
+#  vote_balance                 :integer          default(0), not null
+#  votes_count                  :integer
+#  ysws_eligible                :boolean          default(FALSE), not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  slack_id                     :string
 #
 # Indexes
 #

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,56 +2,55 @@
 #
 # Table name: users
 #
-#  id                             :bigint           not null, primary key
-#  age_attestation                :string
-#  approx_balance                 :integer          default(0), not null
-#  approx_total_earned            :integer          default(0), not null
-#  banned                         :boolean          default(FALSE), not null
-#  banned_at                      :datetime
-#  banned_reason                  :text
-#  bio                            :text
-#  display_name                   :string
-#  email                          :string
-#  enriched_ref                   :string
-#  experience_level               :string
-#  first_name                     :string
-#  geocoded_country               :string
-#  geocoded_lat                   :float
-#  geocoded_lon                   :float
-#  geocoded_subdivision           :string
-#  granted_roles                  :string           default([]), not null, is an Array
-#  guest_email                    :string
-#  has_gotten_free_stickers       :boolean          default(FALSE)
-#  has_pending_achievements       :boolean          default(FALSE), not null
-#  hcb_email                      :string
-#  interests                      :string           default([]), is an Array
-#  internal_notes                 :text
-#  ip_address                     :string
-#  last_name                      :string
-#  manual_outpost_ticket_approval :string
-#  manual_ysws_override           :boolean
-#  mission_review_notifications   :boolean          default(TRUE), not null
-#  onboarded_at                   :datetime
-#  outpost_discount_stardust      :integer          default(0), not null
-#  outpost_email_sent_at          :datetime
-#  ref                            :string
-#  regions                        :string           default([]), is an Array
-#  session_token                  :string
-#  shop_region                    :enum
-#  shop_tutorial_completed_at     :datetime
-#  shop_tutorial_started_at       :datetime
-#  synced_at                      :datetime
-#  things_dismissed               :string           default([]), not null, is an Array
-#  user_agent                     :string
-#  user_ref                       :string
-#  verification_checked_at        :datetime
-#  verification_status            :string           default("needs_submission"), not null
-#  vote_balance                   :integer          default(0), not null
-#  votes_count                    :integer
-#  ysws_eligible                  :boolean          default(FALSE), not null
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  slack_id                       :string
+#  id                           :bigint           not null, primary key
+#  age_attestation              :string
+#  approx_balance               :integer          default(0), not null
+#  approx_total_earned          :integer          default(0), not null
+#  banned                       :boolean          default(FALSE), not null
+#  banned_at                    :datetime
+#  banned_reason                :text
+#  bio                          :text
+#  display_name                 :string
+#  email                        :string
+#  enriched_ref                 :string
+#  experience_level             :string
+#  first_name                   :string
+#  geocoded_country             :string
+#  geocoded_lat                 :float
+#  geocoded_lon                 :float
+#  geocoded_subdivision         :string
+#  granted_roles                :string           default([]), not null, is an Array
+#  guest_email                  :string
+#  has_gotten_free_stickers     :boolean          default(FALSE)
+#  has_pending_achievements     :boolean          default(FALSE), not null
+#  hcb_email                    :string
+#  interests                    :string           default([]), is an Array
+#  internal_notes               :text
+#  ip_address                   :string
+#  last_name                    :string
+#  manual_ysws_override         :boolean
+#  mission_review_notifications :boolean          default(TRUE), not null
+#  onboarded_at                 :datetime
+#  outpost_discount_stardust    :integer          default(0), not null
+#  outpost_email_sent_at        :datetime
+#  ref                          :string
+#  regions                      :string           default([]), is an Array
+#  session_token                :string
+#  shop_region                  :enum
+#  shop_tutorial_completed_at   :datetime
+#  shop_tutorial_started_at     :datetime
+#  synced_at                    :datetime
+#  things_dismissed             :string           default([]), not null, is an Array
+#  user_agent                   :string
+#  user_ref                     :string
+#  verification_checked_at      :datetime
+#  verification_status          :string           default("needs_submission"), not null
+#  vote_balance                 :integer          default(0), not null
+#  votes_count                  :integer
+#  ysws_eligible                :boolean          default(FALSE), not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  slack_id                     :string
 #
 # Indexes
 #


### PR DESCRIPTION
## what do 
make the hardware super builder status a toggle without any airtable validations. doesn't wipe the old column, but there shouldn't be data there anyways

## show work
<img width="234" height="111" alt="image" src="https://github.com/user-attachments/assets/3fc4fe61-2db6-4d85-8767-17af670632f1" />

<img width="1279" height="613" alt="image" src="https://github.com/user-attachments/assets/edf4ea1b-6199-4718-a136-327a49844028" />

## ai?

claude code opus 4.8