### PR TITLE
feat(shop): allow creating Outpost Ticket from the admin item UI

### DIFF
--- a/app/models/shop_item.rb
+++ b/app/models/shop_item.rb
@@ -218,7 +218,8 @@ class ShopItem < ApplicationRecord
     "ShopItem::SpecialFulfillmentItem",
     "ShopItem::HackClubberItem",
     "ShopItem::FreeStickers",
-    "ShopItem::SillyItemType"
+    "ShopItem::SillyItemType",
+    "ShopItem::OutpostTicket"
   ].freeze
 
   scope :shown_in_carousel, -> { where(show_in_carousel: true) }


### PR DESCRIPTION
## What

Adds `ShopItem::OutpostTicket` to `ShopItem::SELECTABLE_TYPES` so it shows up in the admin **New item** type picker.

## show work

bruh

## ai?

claude code opus 4.8