### PR TITLE
[codex] Make hearting optimistic and animated in every context

### DIFF
--- a/app/assets/stylesheets/components/_like_button.scss
+++ b/app/assets/stylesheets/components/_like_button.scss
@@ -46,8 +46,23 @@
     transition: opacity 0.15s ease;
   }
 
+  // The button renders both the outline and filled heart so the liked state can
+  // be toggled instantly client-side (no icon swap round-trip). CSS decides
+  // which one is visible.
+  &__icon--fill {
+    display: none;
+  }
+
   &__btn--liked &__icon {
     opacity: 1;
+  }
+
+  &__btn--liked &__icon--outline {
+    display: none;
+  }
+
+  &__btn--liked &__icon--fill {
+    display: inline-block;
   }
 
   &__btn--animate &__icon {

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -9,6 +9,7 @@ class LikesController < ApplicationController
       @likeable.reload
 
       respond_to do |format|
+        format.json { render json: like_state }
         format.turbo_stream
         format.html { redirect_back fallback_location: @likeable }
       end
@@ -16,6 +17,7 @@ class LikesController < ApplicationController
       @likeable.reload
 
       respond_to do |format|
+        format.json { render json: like_state }
         format.turbo_stream { render :create, status: :unprocessable_entity }
         format.html { redirect_back fallback_location: @likeable, alert: @like.errors.full_messages.to_sentence }
       end
@@ -30,12 +32,22 @@ class LikesController < ApplicationController
     @likeable.reload
 
     respond_to do |format|
+      format.json { render json: like_state }
       format.turbo_stream
       format.html { redirect_back fallback_location: @likeable }
     end
   end
 
   private
+
+  # Authoritative current state for the optimistic like controller to reconcile
+  # against.
+  def like_state
+    {
+      liked: current_user.present? && @likeable.likes.exists?(user: current_user),
+      count: @likeable.likes_count
+    }
+  end
 
   def set_likeable
     if params[:devlog_id].present?

--- a/app/helpers/likes_helper.rb
+++ b/app/helpers/likes_helper.rb
@@ -1,0 +1,13 @@
+module LikesHelper
+  # Renders the filled "liked" heart with its gradient id namespaced to the
+  # record. Many hearts render on one page, and a shared `url(#id)` fill
+  # reference resolves to the first matching gradient in the document — which
+  # sits inside a display:none icon until that card is liked — leaving every
+  # other liked heart painted with an empty fill. Namespacing the id per
+  # likeable avoids the collision.
+  def like_fill_icon(likeable, css_class:)
+    inline_svg_tag("icons/like-fill.svg", class: css_class)
+      .gsub("stardance-like-fill", "stardance-like-fill-#{dom_id(likeable)}")
+      .html_safe
+  end
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -184,6 +184,9 @@ application.register("horizontal-scroll", HorizontalScrollController);
 import JsonHighlightController from "./json_highlight_controller";
 application.register("json-highlight", JsonHighlightController);
 
+import LikeController from "./like_controller";
+application.register("like", LikeController);
+
 import LookoutCaptureController from "./lookout_capture_controller";
 application.register("lookout-capture", LookoutCaptureController);
 

--- a/app/javascript/controllers/like_controller.js
+++ b/app/javascript/controllers/like_controller.js
@@ -1,0 +1,118 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Optimistic, animated like button.
+//
+// The like button renders in many contexts — the home feed, profile feeds,
+// project pages, the devlog page — and several of those live inside Turbo
+// Frames with `target="_top"` (or `turbo: false` regions) where a plain form
+// submission triggers a full page navigation instead of an in-place update.
+//
+// This controller intercepts the form submit, updates the UI instantly (so the
+// heart animation always plays), and persists the change with a background
+// fetch. Liking therefore never navigates or reloads the page, regardless of
+// the surrounding Turbo context.
+//
+// The wrapping <form> (button_to) stays as a no-JS fallback: without this
+// controller it submits normally and the Turbo Stream response updates the
+// button.
+export default class extends Controller {
+  static values = {
+    liked: Boolean,
+    count: Number,
+    url: String,
+  };
+
+  static targets = ["button", "count"];
+
+  connect() {
+    // Last state the server is known to agree with — used to reconcile the
+    // optimistic UI and to roll it back if a request fails.
+    this.syncedLiked = this.likedValue;
+    this.syncedCount = this.countValue;
+  }
+
+  toggle(event) {
+    event.preventDefault();
+
+    this.likedValue = !this.likedValue;
+    this.countValue = Math.max(0, this.countValue + (this.likedValue ? 1 : -1));
+    if (this.likedValue) this.#animate();
+
+    this.#scheduleSync();
+  }
+
+  likedValueChanged() {
+    if (!this.hasButtonTarget) return;
+    this.buttonTarget.classList.toggle(
+      "like-button__btn--liked",
+      this.likedValue,
+    );
+    this.buttonTarget.setAttribute("aria-pressed", String(this.likedValue));
+  }
+
+  countValueChanged() {
+    if (this.hasCountTarget) this.countTarget.textContent = this.countValue;
+  }
+
+  #animate() {
+    if (!this.hasButtonTarget) return;
+    const btn = this.buttonTarget;
+    btn.classList.remove("like-button__btn--animate");
+    // Force a reflow so the animation restarts on rapid re-likes.
+    void btn.offsetWidth;
+    btn.classList.add("like-button__btn--animate");
+  }
+
+  #scheduleSync() {
+    clearTimeout(this.syncTimer);
+    // Collapse rapid toggles into a single request for the settled state.
+    this.syncTimer = setTimeout(() => this.#sync(), 250);
+  }
+
+  async #sync() {
+    if (this.inFlight) {
+      this.#scheduleSync();
+      return;
+    }
+
+    const desired = this.likedValue;
+    if (desired === this.syncedLiked) return;
+
+    this.inFlight = true;
+    try {
+      const response = await fetch(this.urlValue, {
+        method: desired ? "POST" : "DELETE",
+        headers: {
+          Accept: "application/json",
+          "X-CSRF-Token": this.#csrfToken,
+          "X-Requested-With": "XMLHttpRequest",
+        },
+        credentials: "same-origin",
+      });
+      if (!response.ok) {
+        throw new Error(`Like request failed: ${response.status}`);
+      }
+
+      const data = await response.json();
+      this.syncedLiked = data.liked;
+      this.syncedCount = data.count;
+
+      // Adopt the authoritative count only if the user has settled on the
+      // same state the server now reflects, so we don't clobber a re-toggle.
+      if (this.likedValue === data.liked) this.countValue = data.count;
+    } catch {
+      // Request failed (offline, 4xx, etc.) — roll back to the last
+      // server-confirmed state.
+      this.likedValue = this.syncedLiked;
+      this.countValue = this.syncedCount;
+    } finally {
+      this.inFlight = false;
+      // The user toggled again while the request was in flight — keep syncing.
+      if (this.likedValue !== this.syncedLiked) this.#scheduleSync();
+    }
+  }
+
+  get #csrfToken() {
+    return document.querySelector('meta[name="csrf-token"]')?.content || "";
+  }
+}

--- a/app/views/likes/_button.html.erb
+++ b/app/views/likes/_button.html.erb
@@ -5,7 +5,6 @@
     current_user && likeable.likes.exists?(user: current_user)
   end
 
-  icon = liked ? "icons/like-fill.svg" : "icons/like.svg"
   button_classes = [
     "like-button__btn",
     ("like-button__btn--liked" if liked),
@@ -13,18 +12,26 @@
   ].compact
 %>
 
-<div id="<%= dom_id(likeable, :like_button) %>" class="like-button">
+<div id="<%= dom_id(likeable, :like_button) %>"
+     class="like-button"
+     data-controller="like"
+     data-like-liked-value="<%= liked %>"
+     data-like-count-value="<%= likeable.likes_count %>"
+     data-like-url-value="<%= devlog_like_path(likeable) %>">
   <% if current_user %>
     <%= button_to devlog_like_path(likeable),
           method: liked ? :delete : :post,
           class: button_classes,
-          form_class: "like-button__form" do %>
-      <%= inline_svg_tag(icon, class: "like-button__icon") %>
-      <span class="like-button__count"><%= likeable.likes_count %></span>
+          form: { class: "like-button__form", data: { action: "submit->like#toggle" } },
+          data: { "like-target": "button" },
+          aria: { pressed: liked } do %>
+      <%= inline_svg_tag("icons/like.svg", class: "like-button__icon like-button__icon--outline") %>
+      <%= like_fill_icon(likeable, css_class: "like-button__icon like-button__icon--fill") %>
+      <span class="like-button__count" data-like-target="count"><%= likeable.likes_count %></span>
     <% end %>
   <% else %>
     <div class="like-button__btn like-button__btn--disabled">
-      <%= inline_svg_tag("icons/like.svg", class: "like-button__icon") %>
+      <%= inline_svg_tag("icons/like.svg", class: "like-button__icon like-button__icon--outline") %>
       <span class="like-button__count"><%= likeable.likes_count %></span>
     </div>
   <% end %>

--- a/test/controllers/likes_controller_test.rb
+++ b/test/controllers/likes_controller_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+class LikesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @author = User.create!(slack_id: "U_LIKE_AUTHOR", display_name: "likeauthor", email: "likeauthor@example.test")
+    @author.identities.create!(provider: "hack_club", uid: "hca_like_author", access_token: "fake-token-like-author")
+    @liker = User.create!(slack_id: "U_LIKE_LIKER", display_name: "likeliker", email: "likeliker@example.test")
+    @liker.identities.create!(provider: "hack_club", uid: "hca_like_liker", access_token: "fake-token-like-liker")
+
+    @project = Project.create!(title: "Likeable Project", description: "A project with a likeable devlog")
+    @project.memberships.create!(user: @author, role: :owner)
+
+    @devlog = Post::Devlog.new(body: "work log", duration_seconds: 1.hour)
+    @devlog.uploading_attachments = true
+    @devlog.save!
+    Post.create!(project: @project, user: @author, postable: @devlog)
+  end
+
+  test "create responds with authoritative json state and persists the like" do
+    sign_in @liker
+
+    assert_difference -> { @devlog.likes.count }, 1 do
+      post devlog_like_path(@devlog), as: :json
+    end
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal true, body["liked"]
+    assert_equal 1, body["count"]
+  end
+
+  test "destroy responds with json state and removes the like" do
+    sign_in @liker
+    @devlog.likes.create!(user: @liker)
+
+    assert_difference -> { @devlog.likes.count }, -1 do
+      delete devlog_like_path(@devlog), as: :json
+    end
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal false, body["liked"]
+    assert_equal 0, body["count"]
+  end
+
+  test "create still serves a turbo_stream that replaces the like button" do
+    sign_in @liker
+
+    post devlog_like_path(@devlog), headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_match "turbo-stream", response.media_type
+    assert_match "like-button__btn", response.body
+  end
+
+  test "guests cannot create a like" do
+    assert_no_difference -> { Like.count } do
+      post devlog_like_path(@devlog), as: :json
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a Stimulus `like` controller so devlog hearts update optimistically, animate immediately, and persist with JSON requests instead of navigating/reloading inside feed/profile/project/devlog contexts.
- Keeps the no-JS/Turbo Stream fallback intact while rendering both outline and filled hearts for instant state changes.
- Namespaces the filled-heart SVG gradient per likeable record so multiple liked hearts on one page render correctly.
- Adds controller coverage for JSON create/destroy responses and the existing Turbo Stream response.

## Scope guard

This branch is rebuilt from current `origin/main` and intentionally excludes the unrelated `improved-agent-experience` commits. Checked absent from `codex/heart-animation-messaging`: `bca38f86`, `0799caf6`, `18f39f9b`.

Changed files are limited to the like implementation/tests; the flow GIFs below are hosted on cdn.hackclub.com.

## AGENTS.md / repo conventions

- No DB migrations, schema changes, generators, admin surfaces, PaperTrail audit flows, encrypted fields, or Lockbox/blind-index changes are involved.
- Authorization remains through the existing `LikePolicy`; the JSON response path is added inside the already-authorized create/destroy actions.
- Tests use Minitest under `test/controllers`; no RSpec was added.
- Frontend code stays in `app/javascript/controllers` and is registered through the Stimulus manifest used by the esbuild pipeline.
- SCSS stays on the existing BEM-style `.like-button` block, uses classes instead of inline styles, and references Stardance CSS variables / brand tokens rather than new hardcoded theme colors.
- The existing like partial and Turbo Stream fallback are reused instead of replacing the whole like system; no Flavortown styling or dead code is carried forward.
- GIF evidence is hosted on Hack Club CDN; no CDN key or generated binary artifact is stored in the repo.

## Validation

- `git diff --check origin/main...HEAD`
- `RAILS_ENV=test DATABASE_URL=postgresql://postgres:pass@localhost:5432/stardance_test mise exec ruby@ruby-3.4.3 -- bin/rails test test/controllers/likes_controller_test.rb`
- `mise exec ruby@ruby-3.4.3 -- bundle exec rubocop app/controllers/likes_controller.rb app/helpers/likes_helper.rb test/controllers/likes_controller_test.rb`
- `mise exec ruby@ruby-3.4.3 -- bundle exec erb_lint app/views/likes/_button.html.erb`
- `./node_modules/.bin/prettier --check app/javascript/controllers/like_controller.js app/javascript/controllers/index.js app/assets/stylesheets/components/_like_button.scss`
- `npm exec -- esbuild app/javascript/application.js --bundle --sourcemap --format=esm --outdir=/tmp/stardance-heart-build --public-path=/assets`
- Playwright/Chrome runtime verification against local Rails test server: home feed, project page, profile feed, and devlog detail each POSTed `/devlogs/:id/like`, stayed on the same URL, set `aria-pressed="true"`, applied the liked class, and showed count `1`.
- Each CDN GIF URL below was verified as `200 image/gif`.

Note: Rails boot emitted the existing local `MJML 5` binary warning during test/server commands.

## Flow GIFs

### Home feed

![Home feed heart flow](https://cdn.hackclub.com/019ef213-bbf1-7de9-a8ae-5e830021f436/home-feed.gif)

### Project page

![Project page heart flow](https://cdn.hackclub.com/019ef213-c13b-7ab7-b52f-64a50e5e39c2/project-page.gif)

### Profile feed

![Profile feed heart flow](https://cdn.hackclub.com/019ef213-be12-7e6e-9935-484af476dbfe/profile-feed.gif)

### Devlog detail

![Devlog detail heart flow](https://cdn.hackclub.com/019ef213-b9ab-7ec8-a862-a0d9979508cb/devlog-detail.gif)
