### PR TITLE
Open devlog comments in a new tab on modified/right click

### DIFF
--- a/app/components/posts/card_component.html.erb
+++ b/app/components/posts/card_component.html.erb
@@ -82,13 +82,21 @@
   <footer class="feed-post-card__actions">
     <% if show_comments && interaction_post&.postable_type == "Post::Devlog" %>
       <div class="feed-post-card__comment-action" data-controller="comment-modal">
-        <button type="button"
-                class="feed-post-card__action"
-                aria-label="<%= interaction_postable.comments_count %> comments"
-                data-action="comment-modal#open">
+        <% comment_action_inner = capture do %>
           <%= inline_svg_tag "icons/comment.svg", class: "feed-post-card__action-icon" %>
           <span id="<%= comments_count_id %>"><%= interaction_postable.comments_count %></span>
-        </button>
+        <% end %>
+        <% if comments_url.present? %>
+          <%= link_to comments_url,
+                class: "feed-post-card__action",
+                aria: { label: "#{interaction_postable.comments_count} comments" },
+                data: { action: "comment-modal#open" } do %><%= comment_action_inner %><% end %>
+        <% else %>
+          <button type="button"
+                  class="feed-post-card__action"
+                  aria-label="<%= interaction_postable.comments_count %> comments"
+                  data-action="comment-modal#open"><%= comment_action_inner %></button>
+        <% end %>
 
         <dialog class="comment-modal"
                 data-comment-modal-target="dialog"

--- a/app/components/posts/card_component.rb
+++ b/app/components/posts/card_component.rb
@@ -149,6 +149,11 @@ module Posts
       display_post&.views_count.to_i
     end
 
+    def comments_url
+      base = card_link_url
+      "#{base}#comments" if base.present?
+    end
+
     def comments_count_id
       if interaction_postable.present?
         "comments_count_#{interaction_postable.class.name.underscore.tr('/', '_')}_#{interaction_postable.id}"

--- a/app/javascript/controllers/comment_modal_controller.js
+++ b/app/javascript/controllers/comment_modal_controller.js
@@ -15,7 +15,14 @@ export default class extends Controller {
     this.dialogTarget.removeEventListener("close", this._onClose);
   }
 
-  open() {
+  open(event) {
+    // The trigger is a real link to the devlog's comments; let modified clicks
+    // (open in new tab/window) fall through to the browser's default.
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)
+      return;
+
+    event.preventDefault();
+
     this._scrollY = window.scrollY;
     this._previousOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";


### PR DESCRIPTION
## what's this do?

Currently when users Cmd+Click or Ctrl+Click the comment button to open the comment page on a devlog in a new tab, it opens the comment modal. This PR changes it so it opens the intended page in a new tab. See the below video for the before /a fter.

## show it works

https://github.com/user-attachments/assets/66657605-168f-47f0-864c-97672eacf404

## ai?

Claude Code