### PR TITLE
feat: hackatime indicator on sidebar

### DIFF
--- a/app/assets/stylesheets/components/_sidebar.scss
+++ b/app/assets/stylesheets/components/_sidebar.scss
@@ -397,6 +397,42 @@ button.sidebar__nav-link {
   padding: var(--space-xs) var(--space-s);
 }
 
+.sidebar__hackatime {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-xxs) var(--space-s);
+  margin-bottom: var(--space-xs);
+  border-radius: var(--profile-radius);
+  background: var(--color-brand-mint-soft);
+  font-family: var(--font-family-text);
+  font-size: var(--font-size-s);
+  color: var(--color-brand-mint);
+}
+
+.sidebar__hackatime-dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+  animation: hackatime-pulse 2s ease-in-out infinite;
+}
+
+.sidebar__hackatime-time {
+  font-weight: 600;
+}
+
+.sidebar__hackatime-label {
+  font-size: var(--font-size-xs);
+  opacity: 0.7;
+}
+
+@keyframes hackatime-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
 .sidebar__guest-cta-btn {
   display: block;
   width: 100%;
@@ -455,6 +491,10 @@ button.sidebar__nav-link {
 }
 
 @media (max-width: 960px) {
+  .sidebar__hackatime {
+    display: none;
+  }
+
   .sidebar {
     position: fixed;
     z-index: 100;

--- a/app/assets/stylesheets/components/_sidebar.scss
+++ b/app/assets/stylesheets/components/_sidebar.scss
@@ -429,8 +429,13 @@ button.sidebar__nav-link {
 }
 
 @keyframes hackatime-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.35; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
 }
 
 .sidebar__guest-cta-btn {

--- a/app/components/sidebar_component.html.erb
+++ b/app/components/sidebar_component.html.erb
@@ -61,7 +61,7 @@
   </nav>
 
   <div class="sidebar__user" aria-live="polite">
-    <% if signed_in? && user.hackatime_identity.present? %>
+    <% if signed_in? && user.hackatime_identity.present? && !controller.session[:hackatime_indicator_hidden] %>
       <div class="sidebar__hackatime"
            data-controller="hackatime-indicator"
            data-hackatime-indicator-url-value="<%= helpers.my_hackatime_stats_path %>">
@@ -161,6 +161,16 @@
         <% end %>
         <small class="settings-form__hint">Links your coding time from Hackatime to your projects</small>
       </div>
+
+      <% if user.hackatime_identity.present? %>
+      <div class="settings-form__field">
+        <label class="settings-form__checkbox">
+          <%= check_box_tag :hackatime_indicator_hidden, "1", controller.session[:hackatime_indicator_hidden], id: "hackatime_indicator_hidden" %>
+          <span>Hide coding time indicator</span>
+        </label>
+        <small class="settings-form__hint">Hides the live minutes counted pill in the sidebar</small>
+      </div>
+      <% end %>
 
       <div class="modal__actions">
         <button type="button" class="modal__actions-close" onclick="document.getElementById('settings-form').reset(); document.getElementById('settings-modal').close()">Cancel</button>

--- a/app/components/sidebar_component.html.erb
+++ b/app/components/sidebar_component.html.erb
@@ -61,6 +61,15 @@
   </nav>
 
   <div class="sidebar__user" aria-live="polite">
+    <% if signed_in? && user.hackatime_identity.present? %>
+      <div class="sidebar__hackatime"
+           data-controller="hackatime-indicator"
+           data-hackatime-indicator-url-value="<%= helpers.my_hackatime_stats_path %>">
+        <span class="sidebar__hackatime-dot" aria-hidden="true"></span>
+        <span class="sidebar__hackatime-time" data-hackatime-indicator-target="time">…</span>
+        <span class="sidebar__hackatime-label">coded</span>
+      </div>
+    <% end %>
     <% if signed_in? %>
       <div class="sidebar__user-card">
         <div class="sidebar__user-meta">

--- a/app/controllers/my/hackatime_stats_controller.rb
+++ b/app/controllers/my/hackatime_stats_controller.rb
@@ -1,0 +1,11 @@
+class My::HackatimeStatsController < ApplicationController
+  def show
+    authorize :my, :show_hackatime_stats?
+
+    seconds = Rails.cache.fetch("hackatime_stats_display:#{current_user.id}", expires_in: 5.minutes) do
+      current_user.all_time_coding_seconds
+    end
+
+    render json: { seconds: seconds, formatted: helpers.format_seconds(seconds) }
+  end
+end

--- a/app/controllers/my/settings_controller.rb
+++ b/app/controllers/my/settings_controller.rb
@@ -9,6 +9,7 @@ class My::SettingsController < ApplicationController
       search_engine_indexing_off: params[:search_engine_indexing_off] == "1"
     )
     session[:streamer_mode] = params[:streamer_mode] == "1"
+    session[:hackatime_indicator_hidden] = params[:hackatime_indicator_hidden] == "1"
     redirect_back fallback_location: root_path, notice: "Settings saved"
   end
 

--- a/app/javascript/controllers/hackatime_indicator_controller.js
+++ b/app/javascript/controllers/hackatime_indicator_controller.js
@@ -19,7 +19,10 @@ export default class extends Controller {
   async #fetch() {
     try {
       const response = await fetch(this.urlValue, {
-        headers: { Accept: "application/json", "X-Requested-With": "XMLHttpRequest" },
+        headers: {
+          Accept: "application/json",
+          "X-Requested-With": "XMLHttpRequest",
+        },
       });
       if (!response.ok) return;
       const { formatted } = await response.json();

--- a/app/javascript/controllers/hackatime_indicator_controller.js
+++ b/app/javascript/controllers/hackatime_indicator_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["time"];
+  static values = {
+    url: String,
+    interval: { type: Number, default: 60000 },
+  };
+
+  connect() {
+    this.#fetch();
+    this.timer = setInterval(() => this.#fetch(), this.intervalValue);
+  }
+
+  disconnect() {
+    clearInterval(this.timer);
+  }
+
+  async #fetch() {
+    try {
+      const response = await fetch(this.urlValue, {
+        headers: { Accept: "application/json", "X-Requested-With": "XMLHttpRequest" },
+      });
+      if (!response.ok) return;
+      const { formatted } = await response.json();
+      if (formatted) this.timeTarget.textContent = formatted;
+    } catch {
+      // network error — leave the displayed value as-is
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -169,6 +169,9 @@ application.register("form-submit-once", FormSubmitOnceController);
 import GuidePreviewController from "./guide_preview_controller";
 application.register("guide-preview", GuidePreviewController);
 
+import HackatimeIndicatorController from "./hackatime_indicator_controller";
+application.register("hackatime-indicator", HackatimeIndicatorController);
+
 import HackatimeLinkController from "./hackatime_link_controller";
 application.register("hackatime-link", HackatimeLinkController);
 

--- a/app/policies/my_policy.rb
+++ b/app/policies/my_policy.rb
@@ -26,4 +26,8 @@ class MyPolicy < ApplicationPolicy
   def update_notification_settings?
     signed_in_any?
   end
+
+  def show_hackatime_stats?
+    signed_in_any?
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -554,6 +554,7 @@ Rails.application.routes.draw do
       end
     end
     resource :notification_settings, only: [ :show, :update ], controller: "notification_settings"
+    resource :hackatime_stats, only: [ :show ]
   end
   get "my/achievements", to: "achievements#index", as: :my_achievements
 


### PR DESCRIPTION
## what's this do?

adds a hackatime indicator on sidebar.
- GET /my/hackatime_stats, returns total coded seconds, cached 5 min in Rails
- stimulus controller that fetches on page load & re-polls every 60s
- sidebar: only for hackatime connected, hidden in mobile

pulls seconds since event start

## show it works

<img width="313" height="289" alt="image" src="https://github.com/user-attachments/assets/f90e2383-57db-45c7-a33a-63525c39bff6" />

## ai? Yes

claude, reviewed & tested


context: [Slack](https://hackclub.slack.com/archives/C0AR0M43H61/p1782180206617959)