### PR TITLE
fix(streak widget): make join hackatime button work

### DIFF
--- a/app/components/discover_rail/streak_widget.html.erb
+++ b/app/components/discover_rail/streak_widget.html.erb
@@ -28,6 +28,7 @@
       <p class="streak-widget__setup-text">Connect Hackatime to start tracking your coding streaks.</p>
       <%= button_to "/auth/hackatime",
             method: :post,
+            data: { turbo: false },
             class: "action-btn action-btn--primary action-btn--small streak-widget__setup-btn" do %>
         Connect Hackatime
       <% end %>

--- a/app/components/discover_rail/streak_widget.rb
+++ b/app/components/discover_rail/streak_widget.rb
@@ -7,7 +7,7 @@ module DiscoverRail
     GOAL = StreakActivity::DAILY_GOAL_SECONDS
 
     def render?
-      user.present?
+      user.present? && user.onboarded?
     end
 
     def setup_needed?


### PR DESCRIPTION
this button was not working but now it is working!

<img width="265" height="177" alt="image" src="https://github.com/user-attachments/assets/612acb4a-07df-45f3-9f15-55674b87ac6e" />
