### PR TITLE
feat(admin): staff override for project kind (software/hardware)

### DIFF
--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -116,11 +116,17 @@ class Admin::ProjectsController < Admin::ApplicationController
     end
 
     funding_lock_bypassed = @project.has_any_funding_request?
+    resolved_review_ids = []
 
     @project.hardware_stage = new_stage
     @project.project_type = nil if clear_classifier
-    ::PaperTrail.request(enabled: false) do
-      @project.save!(validate: false)
+    ApplicationRecord.transaction do
+      ::PaperTrail.request(enabled: false) do
+        @project.save!(validate: false)
+      end
+      # A now-hardware project's open software review is misrouted — close it so
+      # it doesn't sit stale (it's already filtered out of auto-assignment).
+      resolved_review_ids = resolve_open_ship_reviews!("Converted to hardware by staff; software ship review closed: #{reason}") if new_stage.present?
     end
 
     changes = {
@@ -130,6 +136,7 @@ class Admin::ProjectsController < Admin::ApplicationController
       "funding_lock_bypassed" => funding_lock_bypassed
     }
     changes["project_type"] = [ old_project_type, nil ] if clear_classifier
+    changes["resolved_ship_review_ids"] = resolved_review_ids if resolved_review_ids.any?
     log_admin_version("admin_hardware_stage_update", changes)
 
     notice = if old_stage == new_stage
@@ -172,17 +179,24 @@ class Admin::ProjectsController < Admin::ApplicationController
 
     old_status = @project.ship_status
     old_cert = ship_event.certification_status
+    resolved_review_ids = []
 
     ApplicationRecord.transaction do
       ship_event.update_columns(certification_status: "pending")
+      # Don't leave a pending review behind for a project that's no longer
+      # submitted — it would sit stale in the queue / get picked by a reviewer.
+      resolved_review_ids = resolve_open_ship_reviews!("Latest ship reset to draft by staff: #{reason}")
       @project.update_columns(ship_status: "draft", shipped_at: nil)
     end
 
-    log_admin_version("admin_reset_latest_ship",
+    changes = {
       "ship_status" => [ old_status, "draft" ],
       "ship_event_id" => ship_event.id,
       "certification_status" => [ old_cert, "pending" ],
-      "reason" => reason)
+      "reason" => reason
+    }
+    changes["resolved_ship_review_ids"] = resolved_review_ids if resolved_review_ids.any?
+    log_admin_version("admin_reset_latest_ship", changes)
 
     redirect_to admin_project_path(@project),
                 notice: "Reset the latest ship back to draft. Nothing was deleted — the ship and its review are preserved."
@@ -227,6 +241,28 @@ class Admin::ProjectsController < Admin::ApplicationController
   end
 
   private
+
+  # Takes any still-open (pending) ship review out of the reviewer queue when a
+  # staff action makes it moot, so a review is never left stale or routed to the
+  # wrong reviewer. Non-destructive — the review row is kept, just marked
+  # returned, unclaimed and stamped with an internal note. Uses update_all to
+  # skip the verdict / notify-owner / stardust callbacks. Returns affected ids.
+  def resolve_open_ship_reviews!(note)
+    reviews = @project.ship_reviews.where(status: :pending)
+    ids = reviews.pluck(:id)
+    return ids if ids.empty?
+
+    reviews.update_all(
+      status: ::Certification::Ship.statuses[:returned],
+      reviewer_id: nil,
+      claimed_at: nil,
+      claim_expires_at: nil,
+      decided_at: Time.current,
+      internal_reason: note,
+      updated_at: Time.current
+    )
+    ids
+  end
 
   # Records a staff action against @project in the PaperTrail audit log.
   def log_admin_version(event, object_changes)

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -140,13 +140,14 @@ class Admin::ProjectsController < Admin::ApplicationController
     redirect_to admin_project_path(@project), notice: notice
   end
 
-  # Wipes the project's most recent ship: destroys the ship event (and, via
-  # dependent associations, its post, ledger entries, vote assignments and
-  # mission submission; votes are nullified), removes the matching review and
-  # any YSWS review it generated, and resets the project to an un-shipped draft.
-  # Used to fully un-stick a project that was shipped under the wrong kind.
-  # Refuses to touch a paid-out ship.
-  def clear_latest_ship
+  # Soft-resets the project's most recent ship back to an un-shipped draft so the
+  # owner can fix it and re-ship. NOTHING IS DELETED — the ship event, its
+  # review, votes, YSWS links and ledger entries are all preserved for history
+  # and audit. We only flip status columns: the project back to draft, the ship
+  # event's certification back to pending (so it no longer blocks re-shipping),
+  # and clear shipped_at so it reads as un-shipped. Refuses to reset a paid-out
+  # ship.
+  def reset_latest_ship
     @project = ::Project.unscoped.find(params[:id])
     authorize @project, :update?
 
@@ -154,47 +155,37 @@ class Admin::ProjectsController < Admin::ApplicationController
     ship_event = @project.last_ship_event
 
     if ship_event.nil?
-      redirect_to admin_project_path(@project), alert: "This project has no ship to clear."
+      redirect_to admin_project_path(@project), alert: "This project has no ship to reset."
       return
     end
 
     if reason.blank?
-      redirect_to admin_project_path(@project), alert: "Explain why the latest ship is being cleared."
+      redirect_to admin_project_path(@project), alert: "Explain why the latest ship is being reset."
       return
     end
 
     if ship_event.payout.present?
       redirect_to admin_project_path(@project),
-                  alert: "Can't clear a ship that has already paid out. Resolve the payout first."
+                  alert: "Can't reset a ship that has already paid out. Resolve the payout first."
       return
     end
 
     old_status = @project.ship_status
-    cleared = {
-      "ship_event_id" => ship_event.id,
-      "certification_status" => ship_event.certification_status,
-      "votes_count" => ship_event.votes_count,
-      "body" => ship_event.body
-    }
+    old_cert = ship_event.certification_status
 
     ApplicationRecord.transaction do
-      review = @project.ship_reviews.order(created_at: :desc).first
-      # YSWS reviews FK to both the ship event and its review with no cascade /
-      # dependent, so clear them first or the destroys below hit InvalidForeignKey.
-      ::Certification::Ysws.where(post_ship_event_id: ship_event.id).destroy_all
-      ::Certification::Ysws.where(ship_cert_id: review.id).destroy_all if review
-      review&.destroy!
-      ship_event.destroy!
-      remaining_latest = @project.ship_event_posts.maximum(:created_at)
-      @project.update_columns(ship_status: "draft", shipped_at: remaining_latest)
+      ship_event.update_columns(certification_status: "pending")
+      @project.update_columns(ship_status: "draft", shipped_at: nil)
     end
 
-    log_admin_version("admin_clear_latest_ship",
+    log_admin_version("admin_reset_latest_ship",
       "ship_status" => [ old_status, "draft" ],
-      "cleared_ship" => cleared,
+      "ship_event_id" => ship_event.id,
+      "certification_status" => [ old_cert, "pending" ],
       "reason" => reason)
 
-    redirect_to admin_project_path(@project), notice: "Cleared the latest ship and reset the project to draft."
+    redirect_to admin_project_path(@project),
+                notice: "Reset the latest ship back to draft. Nothing was deleted — the ship and its review are preserved."
   end
 
   def sync_last_ship_event_certification(new_status)

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -126,9 +126,10 @@ class Admin::ProjectsController < Admin::ApplicationController
 
   # Wipes the project's most recent ship: destroys the ship event (and, via
   # dependent associations, its post, ledger entries, vote assignments and
-  # mission submission; votes are nullified), removes the matching review, and
-  # resets the project to an un-shipped draft. Used to fully un-stick a project
-  # that was shipped under the wrong kind. Refuses to touch a paid-out ship.
+  # mission submission; votes are nullified), removes the matching review and
+  # any YSWS review it generated, and resets the project to an un-shipped draft.
+  # Used to fully un-stick a project that was shipped under the wrong kind.
+  # Refuses to touch a paid-out ship.
   def clear_latest_ship
     @project = ::Project.unscoped.find(params[:id])
     authorize @project, :update?
@@ -161,7 +162,12 @@ class Admin::ProjectsController < Admin::ApplicationController
     }
 
     ApplicationRecord.transaction do
-      @project.ship_reviews.order(created_at: :desc).first&.destroy!
+      review = @project.ship_reviews.order(created_at: :desc).first
+      # YSWS reviews FK to both the ship event and its review with no cascade /
+      # dependent, so clear them first or the destroys below hit InvalidForeignKey.
+      ::Certification::Ysws.where(post_ship_event_id: ship_event.id).destroy_all
+      ::Certification::Ysws.where(ship_cert_id: review.id).destroy_all if review
+      review&.destroy!
       ship_event.destroy!
       remaining_latest = @project.ship_event_posts.maximum(:created_at)
       @project.update_columns(ship_status: "draft", shipped_at: remaining_latest)

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -178,7 +178,7 @@ class Admin::ProjectsController < Admin::ApplicationController
     end
 
     old_status = @project.ship_status
-    old_cert = ship_event.certification_status
+    old_ship_status = ship_event.certification_status
     resolved_review_ids = []
 
     ApplicationRecord.transaction do
@@ -192,7 +192,7 @@ class Admin::ProjectsController < Admin::ApplicationController
     changes = {
       "ship_status" => [ old_status, "draft" ],
       "ship_event_id" => ship_event.id,
-      "certification_status" => [ old_cert, "pending" ],
+      "certification_status" => [ old_ship_status, "pending" ],
       "reason" => reason
     }
     changes["resolved_ship_review_ids"] = resolved_review_ids if resolved_review_ids.any?

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -79,14 +79,49 @@ class Admin::ProjectsController < Admin::ApplicationController
     @project.update_column(:ship_status, new_status)
     sync_last_ship_event_certification(new_status)
 
-    ::PaperTrail::Version.create!(
-      item: @project,
-      event: "update",
-      whodunnit: current_user.id.to_s,
-      object_changes: { ship_status: [ old_status, new_status ] }
-    )
+    log_admin_version("update", ship_status: [ old_status, new_status ])
 
     redirect_to admin_project_path(@project), notice: "Ship status changed from #{old_status} to #{new_status}."
+  end
+
+  def update_hardware_stage
+    @project = ::Project.unscoped.find(params[:id])
+    authorize @project, :update?
+
+    old_stage = @project.hardware_stage
+    new_stage = params[:hardware_stage].presence
+    reason = params[:reason].to_s.strip
+
+    unless ([ nil ] + ::Project::HARDWARE_STAGES).include?(new_stage)
+      redirect_to admin_project_path(@project), alert: "Invalid project kind."
+      return
+    end
+
+    if reason.blank?
+      redirect_to admin_project_path(@project), alert: "Explain why the project kind is being changed."
+      return
+    end
+
+    if old_stage == new_stage
+      redirect_to admin_project_path(@project), alert: "Project kind is already #{hardware_stage_label(new_stage)}."
+      return
+    end
+
+    funding_lock_bypassed = @project.has_any_funding_request?
+
+    @project.hardware_stage = new_stage
+    ::PaperTrail.request(enabled: false) do
+      @project.save!(validate: false)
+    end
+
+    log_admin_version("admin_hardware_stage_update",
+      "hardware_stage" => [ old_stage, new_stage ],
+      "project_kind" => [ hardware_stage_label(old_stage), hardware_stage_label(new_stage) ],
+      "reason" => reason,
+      "funding_lock_bypassed" => funding_lock_bypassed)
+
+    redirect_to admin_project_path(@project),
+                notice: "Project kind changed from #{hardware_stage_label(old_stage)} to #{hardware_stage_label(new_stage)}."
   end
 
   def sync_last_ship_event_certification(new_status)
@@ -122,13 +157,28 @@ class Admin::ProjectsController < Admin::ApplicationController
 
     @project.update_column(state_column, new_state)
 
-    ::PaperTrail::Version.create!(
-      item: @project,
-      event: "update",
-      whodunnit: current_user.id.to_s,
-      object_changes: { state_column => [ old_state, new_state ] }
-    )
+    log_admin_version("update", state_column => [ old_state, new_state ])
 
     redirect_to admin_project_path(@project), notice: "State forced from #{old_state} to #{new_state}."
+  end
+
+  private
+
+  # Records a staff action against @project in the PaperTrail audit log.
+  def log_admin_version(event, object_changes)
+    ::PaperTrail::Version.create!(
+      item: @project,
+      event: event,
+      whodunnit: current_user.id.to_s,
+      object_changes: object_changes
+    )
+  end
+
+  def hardware_stage_label(stage)
+    case stage
+    when "design" then "Hardware - design"
+    when "build" then "Hardware - build"
+    else "Software"
+    end
   end
 end

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -102,17 +102,20 @@ class Admin::ProjectsController < Admin::ApplicationController
       return
     end
 
-    if old_stage == new_stage
+    # Setting Software overrules the AI classifier. Without this, a stale
+    # project_type == "Hardware" would keep the project out of the review queue
+    # (Certification::Ship.excluding_hardware) even after the override — even
+    # when the project is already Software, so this is reachable past the no-op
+    # guard below.
+    old_project_type = @project.project_type
+    clear_classifier = new_stage.nil? && old_project_type == "Hardware"
+
+    if old_stage == new_stage && !clear_classifier
       redirect_to admin_project_path(@project), alert: "Project kind is already #{hardware_stage_label(new_stage)}."
       return
     end
 
     funding_lock_bypassed = @project.has_any_funding_request?
-    # Setting Software overrules the AI classifier. Without this, a stale
-    # project_type == "Hardware" would keep the project out of the review queue
-    # (Certification::Ship.excluding_hardware) even after the override.
-    old_project_type = @project.project_type
-    clear_classifier = new_stage.nil? && old_project_type == "Hardware"
 
     @project.hardware_stage = new_stage
     @project.project_type = nil if clear_classifier
@@ -129,8 +132,12 @@ class Admin::ProjectsController < Admin::ApplicationController
     changes["project_type"] = [ old_project_type, nil ] if clear_classifier
     log_admin_version("admin_hardware_stage_update", changes)
 
-    redirect_to admin_project_path(@project),
-                notice: "Project kind changed from #{hardware_stage_label(old_stage)} to #{hardware_stage_label(new_stage)}."
+    notice = if old_stage == new_stage
+      "Cleared the stale Hardware classifier; project kind stays #{hardware_stage_label(new_stage)}."
+    else
+      "Project kind changed from #{hardware_stage_label(old_stage)} to #{hardware_stage_label(new_stage)}."
+    end
+    redirect_to admin_project_path(@project), notice: notice
   end
 
   # Wipes the project's most recent ship: destroys the ship event (and, via

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -108,17 +108,26 @@ class Admin::ProjectsController < Admin::ApplicationController
     end
 
     funding_lock_bypassed = @project.has_any_funding_request?
+    # Setting Software overrules the AI classifier. Without this, a stale
+    # project_type == "Hardware" would keep the project out of the review queue
+    # (Certification::Ship.excluding_hardware) even after the override.
+    old_project_type = @project.project_type
+    clear_classifier = new_stage.nil? && old_project_type == "Hardware"
 
     @project.hardware_stage = new_stage
+    @project.project_type = nil if clear_classifier
     ::PaperTrail.request(enabled: false) do
       @project.save!(validate: false)
     end
 
-    log_admin_version("admin_hardware_stage_update",
+    changes = {
       "hardware_stage" => [ old_stage, new_stage ],
       "project_kind" => [ hardware_stage_label(old_stage), hardware_stage_label(new_stage) ],
       "reason" => reason,
-      "funding_lock_bypassed" => funding_lock_bypassed)
+      "funding_lock_bypassed" => funding_lock_bypassed
+    }
+    changes["project_type"] = [ old_project_type, nil ] if clear_classifier
+    log_admin_version("admin_hardware_stage_update", changes)
 
     redirect_to admin_project_path(@project),
                 notice: "Project kind changed from #{hardware_stage_label(old_stage)} to #{hardware_stage_label(new_stage)}."

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -124,6 +124,57 @@ class Admin::ProjectsController < Admin::ApplicationController
                 notice: "Project kind changed from #{hardware_stage_label(old_stage)} to #{hardware_stage_label(new_stage)}."
   end
 
+  # Wipes the project's most recent ship: destroys the ship event (and, via
+  # dependent associations, its post, ledger entries, vote assignments and
+  # mission submission; votes are nullified), removes the matching review, and
+  # resets the project to an un-shipped draft. Used to fully un-stick a project
+  # that was shipped under the wrong kind. Refuses to touch a paid-out ship.
+  def clear_latest_ship
+    @project = ::Project.unscoped.find(params[:id])
+    authorize @project, :update?
+
+    reason = params[:reason].to_s.strip
+    ship_event = @project.last_ship_event
+
+    if ship_event.nil?
+      redirect_to admin_project_path(@project), alert: "This project has no ship to clear."
+      return
+    end
+
+    if reason.blank?
+      redirect_to admin_project_path(@project), alert: "Explain why the latest ship is being cleared."
+      return
+    end
+
+    if ship_event.payout.present?
+      redirect_to admin_project_path(@project),
+                  alert: "Can't clear a ship that has already paid out. Resolve the payout first."
+      return
+    end
+
+    old_status = @project.ship_status
+    cleared = {
+      "ship_event_id" => ship_event.id,
+      "certification_status" => ship_event.certification_status,
+      "votes_count" => ship_event.votes_count,
+      "body" => ship_event.body
+    }
+
+    ApplicationRecord.transaction do
+      @project.ship_reviews.order(created_at: :desc).first&.destroy!
+      ship_event.destroy!
+      remaining_latest = @project.ship_event_posts.maximum(:created_at)
+      @project.update_columns(ship_status: "draft", shipped_at: remaining_latest)
+    end
+
+    log_admin_version("admin_clear_latest_ship",
+      "ship_status" => [ old_status, "draft" ],
+      "cleared_ship" => cleared,
+      "reason" => reason)
+
+    redirect_to admin_project_path(@project), notice: "Cleared the latest ship and reset the project to draft."
+  end
+
   def sync_last_ship_event_certification(new_status)
     ship_event = @project.last_ship_event
     return unless ship_event

--- a/app/helpers/audit_logs_helper.rb
+++ b/app/helpers/audit_logs_helper.rb
@@ -5,7 +5,7 @@ module AuditLogsHelper
   # When an "update" event contains an aasm_state change, we show the
   # new state instead of a generic "update" badge.
   def audit_event_display(version)
-    return { label: version.event, css_class: version.event } unless version.event == "update"
+    return { label: version.event.to_s.humanize, css_class: version.event } unless version.event == "update"
 
     changes = parse_version_changes(version)
     aasm = changes["aasm_state"] || changes["ship_status"] || changes["status"]

--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -109,8 +109,21 @@ module Certification
         : joins(:project).where(projects: { project_type: type })
     }
 
+    # Hardware projects belong in the hardware review flow (funding / build),
+    # not the software ship-review queue. "Hardware" = either the canonical
+    # hardware_stage, or the AI classifier tagging the project "Hardware".
+    # IS DISTINCT FROM keeps unclassified (project_type NULL) projects in.
+    scope :excluding_hardware, -> {
+      joins(:project)
+        .where(projects: { hardware_stage: nil })
+        .where("projects.project_type IS DISTINCT FROM ?", "Hardware")
+    }
+
+    # Drives reviewer auto-assignment (next_eligible), so hardware is filtered
+    # out of the feed. The index listing uses policy_scope instead, so admins
+    # can still find hardware ships via the project-type filter.
     def self.available_for(user)
-      super.merge(for_reviewer(user))
+      super.merge(for_reviewer(user)).merge(excluding_hardware)
     end
 
     # Health target for the pending queue. Above this we read as "behind".

--- a/app/views/admin/projects/show.html.erb
+++ b/app/views/admin/projects/show.html.erb
@@ -111,6 +111,9 @@
           <%= button_to "Delete Project", delete_admin_project_path(@project), method: :post,
               data: { confirm: "Delete this project?" } %>
         <% end %>
+        <% if policy(@project).update? && @project.last_ship_event.present? %>
+          <button type="button" onclick="document.getElementById('clear-latest-ship-modal').showModal()">Clear Latest Ship</button>
+        <% end %>
       </div>
     </div>
 
@@ -147,6 +150,18 @@
           <%= text_area_tag :reason, "", rows: 3, required: true, placeholder: "Why staff is changing this project kind" %>
           <button type="submit">Update Project Kind</button>
           <button type="button" onclick="document.getElementById('change-hardware-stage-modal').close()">Cancel</button>
+        </form>
+      <% end %>
+    <% end %>
+
+    <% if policy(@project).update? && @project.last_ship_event.present? %>
+      <%= render layout: "shared/modal", locals: { id: "clear-latest-ship-modal", title: "Clear Latest Ship", description: "Permanently deletes the most recent ship event (its post, ledger entries, votes and review) and resets the project to an un-shipped draft. Can't be undone. Logged to PaperTrail." } do %>
+        <form action="<%= clear_latest_ship_admin_project_path(@project) %>" method="post" data-turbo-confirm="Permanently clear this project's most recent ship? This can't be undone.">
+          <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+          <%= label_tag :reason, "Audit reason" %>
+          <%= text_area_tag :reason, "", rows: 3, required: true, placeholder: "Why staff is clearing the latest ship" %>
+          <button type="submit">Clear Latest Ship</button>
+          <button type="button" onclick="document.getElementById('clear-latest-ship-modal').close()">Cancel</button>
         </form>
       <% end %>
     <% end %>

--- a/app/views/admin/projects/show.html.erb
+++ b/app/views/admin/projects/show.html.erb
@@ -112,7 +112,7 @@
               data: { confirm: "Delete this project?" } %>
         <% end %>
         <% if policy(@project).update? && @project.last_ship_event.present? %>
-          <button type="button" onclick="document.getElementById('clear-latest-ship-modal').showModal()">Clear Latest Ship</button>
+          <button type="button" onclick="document.getElementById('reset-latest-ship-modal').showModal()">Reset Latest Ship</button>
         <% end %>
       </div>
     </div>
@@ -155,13 +155,13 @@
     <% end %>
 
     <% if policy(@project).update? && @project.last_ship_event.present? %>
-      <%= render layout: "shared/modal", locals: { id: "clear-latest-ship-modal", title: "Clear Latest Ship", description: "Permanently deletes the most recent ship event (its post, ledger entries, votes and review) and resets the project to an un-shipped draft. Can't be undone. Logged to PaperTrail." } do %>
-        <form action="<%= clear_latest_ship_admin_project_path(@project) %>" method="post" data-turbo-confirm="Permanently clear this project's most recent ship? This can't be undone.">
+      <%= render layout: "shared/modal", locals: { id: "reset-latest-ship-modal", title: "Reset Latest Ship", description: "Soft-resets the project to an un-shipped draft so the owner can fix it and re-ship. Nothing is deleted — the ship event, its review, votes and YSWS links are all kept. Logged to PaperTrail." } do %>
+        <form action="<%= reset_latest_ship_admin_project_path(@project) %>" method="post" data-turbo-confirm="Reset this project's latest ship back to draft? Nothing is deleted.">
           <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
           <%= label_tag :reason, "Audit reason" %>
-          <%= text_area_tag :reason, "", rows: 3, required: true, placeholder: "Why staff is clearing the latest ship" %>
-          <button type="submit">Clear Latest Ship</button>
-          <button type="button" onclick="document.getElementById('clear-latest-ship-modal').close()">Cancel</button>
+          <%= text_area_tag :reason, "", rows: 3, required: true, placeholder: "Why staff is resetting the latest ship" %>
+          <button type="submit">Reset Latest Ship</button>
+          <button type="button" onclick="document.getElementById('reset-latest-ship-modal').close()">Cancel</button>
         </form>
       <% end %>
     <% end %>

--- a/app/views/admin/projects/show.html.erb
+++ b/app/views/admin/projects/show.html.erb
@@ -23,7 +23,18 @@
             <button type="button" onclick="document.getElementById('change-ship-status-modal').showModal()">Change</button>
           <% end %>
         </dd>
-        <dt>Type</dt>         <dd><%= @project.project_type.presence || content_tag(:span, "Not set", class: "admin-user-show__muted") %></dd>
+        <dt>Kind</dt>
+        <dd>
+          <% if @project.hardware? %>
+            Hardware — <%= @project.hardware_stage.titleize %>
+          <% else %>
+            Software
+          <% end %>
+          <% if policy(@project).update? %>
+            <button type="button" onclick="document.getElementById('change-hardware-stage-modal').showModal()">Change</button>
+          <% end %>
+        </dd>
+        <dt>Classifier type</dt><dd><%= @project.project_type.presence || content_tag(:span, "Not set", class: "admin-user-show__muted") %></dd>
         <dt>Categories</dt>   <dd><%= @project.project_categories.any? ? @project.project_categories.join(", ") : content_tag(:span, "None", class: "admin-user-show__muted") %></dd>
         <dt>Created</dt>      <dd><%= @project.created_at.strftime("%Y-%m-%d %H:%M") %></dd>
         <dt>Updated</dt>      <dd><%= @project.updated_at.strftime("%Y-%m-%d %H:%M") %></dd>
@@ -115,6 +126,29 @@
         <button type="submit">Update Status</button>
         <button type="button" onclick="document.getElementById('change-ship-status-modal').close()">Cancel</button>
       </form>
+    <% end %>
+
+    <% if policy(@project).update? %>
+      <%= render layout: "shared/modal", locals: { id: "change-hardware-stage-modal", title: "Change Project Kind", description: "Override whether this is treated as software or hardware. Bypasses the funding-request lock and is logged to PaperTrail." } do %>
+        <form action="<%= update_hardware_stage_admin_project_path(@project) %>" method="post">
+          <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+          <%= hidden_field_tag :_method, "patch" %>
+          <%= label_tag :hardware_stage, "Project Kind" %>
+          <%= select_tag :hardware_stage,
+                options_for_select(
+                  [
+                    [ "Software", "" ],
+                    [ "Hardware — design stage / needs funding", "design" ],
+                    [ "Hardware — build stage / already has parts", "build" ]
+                  ],
+                  @project.hardware_stage.to_s
+                ) %>
+          <%= label_tag :reason, "Audit reason" %>
+          <%= text_area_tag :reason, "", rows: 3, required: true, placeholder: "Why staff is changing this project kind" %>
+          <button type="submit">Update Project Kind</button>
+          <button type="button" onclick="document.getElementById('change-hardware-stage-modal').close()">Cancel</button>
+        </form>
+      <% end %>
     <% end %>
 
     <%= render "admin/shared/ledger_log",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -635,7 +635,7 @@ Rails.application.routes.draw do
         post :delete
         post :update_ship_status
         patch :update_hardware_stage
-        post :clear_latest_ship
+        post :reset_latest_ship
         post :force_state
         get  :votes
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -635,6 +635,7 @@ Rails.application.routes.draw do
         post :delete
         post :update_ship_status
         patch :update_hardware_stage
+        post :clear_latest_ship
         post :force_state
         get  :votes
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -634,6 +634,7 @@ Rails.application.routes.draw do
         post :restore
         post :delete
         post :update_ship_status
+        patch :update_hardware_stage
         post :force_state
         get  :votes
       end

--- a/lib/tasks/backfill_hardware_stage.rake
+++ b/lib/tasks/backfill_hardware_stage.rake
@@ -1,0 +1,37 @@
+# Promotes AI-classified hardware projects (project_type == "Hardware") that
+# never entered the hardware flow (hardware_stage still nil) to the "design"
+# entry stage, so they move into the hardware review flow instead of sitting in
+# limbo — and out of the software ship-review queue.
+#
+# Setting hardware_stage flips Project#hardware? to true, which enables the
+# Lookout recorder and the hardware shipping/funding gates. "design" is the safe
+# entry stage: no funding grant, and design-phase time is uncounted for payout.
+# All the real logic (scope, audited save) lives in the job; this is just a
+# visible, dry-run-by-default runner. See OneTime::BackfillHardwareStageJob.
+#
+# dry run:  bin/rails backfill:hardware_stage
+# to apply: bin/rails backfill:hardware_stage DRY_RUN=false
+
+namespace :backfill do
+  desc "Promote AI-classified hardware projects (no hardware_stage) into the hardware flow at the design stage"
+  task hardware_stage: :environment do
+    dry_run = ENV.fetch("DRY_RUN", "true") != "false"
+
+    puts dry_run ? "[DRY RUN] No changes will be written." : "Writing changes to the database."
+    puts
+
+    result = OneTime::BackfillHardwareStageJob.perform_now(dry_run: dry_run, stage: "design")
+
+    if dry_run
+      ids = Array(result)
+      Project.where(id: ids).order(:id).each do |project|
+        puts "  [WOULD SET] Project ##{project.id} \"#{project.title}\" → hardware_stage=design"
+      end
+      puts
+      puts "Would promote #{ids.size} project(s)."
+      puts "Run with DRY_RUN=false to apply."
+    else
+      puts "Promoted #{result} project(s) to hardware_stage=design."
+    end
+  end
+end

--- a/test/controllers/admin/projects_controller_test.rb
+++ b/test/controllers/admin/projects_controller_test.rb
@@ -63,6 +63,27 @@ class Admin::ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ "Hardware", nil ], version.object_changes["project_type"]
   end
 
+  test "software override clears the classifier even when the project is already software" do
+    # hardware_stage already nil (software), but the AI mislabeled it Hardware.
+    already_software = Project.create!(title: "Mislabeled SW", project_type: "Hardware")
+    already_software.memberships.create!(user: @owner, role: :owner)
+
+    sign_in @admin
+
+    patch update_hardware_stage_admin_project_path(already_software), params: {
+      hardware_stage: "",
+      reason: "AI mislabeled this; it's software and should be reviewable."
+    }
+
+    already_software.reload
+    assert_nil already_software.hardware_stage
+    assert_nil already_software.project_type, "stale Hardware classifier should clear even with no stage change"
+
+    version = PaperTrail::Version.where(item_type: "Project", item_id: already_software.id.to_s).order(:created_at).last
+    assert_equal "admin_hardware_stage_update", version.event
+    assert_equal [ "Hardware", nil ], version.object_changes["project_type"]
+  end
+
   test "helper cannot change project kind" do
     helper = create_user(slack_id: "U_HELPER_PROJECTS", display_name: "helperprojects")
     helper.update!(granted_roles: %w[helper])

--- a/test/controllers/admin/projects_controller_test.rb
+++ b/test/controllers/admin/projects_controller_test.rb
@@ -98,85 +98,63 @@ class Admin::ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "design", @project.reload.hardware_stage
   end
 
-  test "admin can clear the latest ship and reset the project to draft" do
+  test "admin can soft-reset the latest ship to draft without deleting anything" do
     ship_event = Post::ShipEvent.create!(body: "Shipped as software", certification_status: "returned", hours_at_ship: 1)
     Post.create!(project: @project, user: @owner, postable: ship_event)
-    @project.ship_reviews.create!(status: :returned, feedback: "Please switch this to hardware.")
-    @project.update_column(:ship_status, "needs_changes")
+    review = @project.ship_reviews.create!(status: :returned, feedback: "Please switch this to hardware.")
+    Certification::Ysws.create!(post_ship_event: ship_event, ship_cert: review, project: @project, user: @owner, original_minutes: 60)
+    @project.update_columns(ship_status: "needs_changes", shipped_at: Time.current)
 
     sign_in @admin
 
-    assert_difference [ "Post::ShipEvent.count", "Certification::Ship.count" ], -1 do
-      post clear_latest_ship_admin_project_path(@project), params: {
-        reason: "Converted to hardware; clearing the bad software ship."
+    # Nothing is deleted — the ship event, review and YSWS link all survive.
+    assert_no_difference [ "Post::ShipEvent.count", "Certification::Ship.count", "Certification::Ysws.count" ] do
+      post reset_latest_ship_admin_project_path(@project), params: {
+        reason: "Converted to hardware; resetting the software ship."
       }
     end
 
     assert_redirected_to admin_project_path(@project)
     @project.reload
     assert_equal "draft", @project.ship_status
-    assert_nil @project.last_ship_event
+    assert_nil @project.shipped_at
+    assert_equal ship_event, @project.last_ship_event, "the ship event is preserved"
+    assert_equal "pending", ship_event.reload.certification_status, "certification is reset so it no longer blocks re-shipping"
 
     version = PaperTrail::Version.where(item_type: "Project", item_id: @project.id.to_s).order(:created_at).last
-    assert_equal "admin_clear_latest_ship", version.event
+    assert_equal "admin_reset_latest_ship", version.event
     assert_equal [ "needs_changes", "draft" ], version.object_changes["ship_status"]
-    assert_equal "Converted to hardware; clearing the bad software ship.", version.object_changes["reason"]
+    assert_equal [ "returned", "pending" ], version.object_changes["certification_status"]
   end
 
-  test "clearing a ship also removes the YSWS review it generated" do
-    ship_event = Post::ShipEvent.create!(body: "Approved ship", certification_status: "approved", hours_at_ship: 1)
-    Post.create!(project: @project, user: @owner, postable: ship_event)
-    review = @project.ship_reviews.create!(status: :approved, reviewer: @admin)
-    Certification::Ysws.create!(
-      post_ship_event: ship_event,
-      ship_cert: review,
-      project: @project,
-      user: @owner,
-      original_minutes: 60
-    )
-    @project.update_column(:ship_status, "approved")
-
-    sign_in @admin
-
-    assert_difference [ "Post::ShipEvent.count", "Certification::Ship.count", "Certification::Ysws.count" ], -1 do
-      post clear_latest_ship_admin_project_path(@project), params: {
-        reason: "Wrong kind; clearing the approved ship and its YSWS review."
-      }
-    end
-
-    assert_redirected_to admin_project_path(@project)
-    assert_equal "draft", @project.reload.ship_status
-  end
-
-  test "cannot clear a ship that has already paid out" do
+  test "cannot reset a ship that has already paid out" do
     ship_event = Post::ShipEvent.create!(body: "Paid", certification_status: "approved", hours_at_ship: 1, payout: 42.0)
     Post.create!(project: @project, user: @owner, postable: ship_event)
     @project.update_column(:ship_status, "approved")
 
     sign_in @admin
 
-    assert_no_difference "Post::ShipEvent.count" do
-      post clear_latest_ship_admin_project_path(@project), params: { reason: "trying to clear a paid ship" }
-    end
+    post reset_latest_ship_admin_project_path(@project), params: { reason: "trying to reset a paid ship" }
 
     assert_redirected_to admin_project_path(@project)
     assert_equal "approved", @project.reload.ship_status
+    assert_equal "approved", ship_event.reload.certification_status
   end
 
-  test "clearing the latest ship requires a reason" do
+  test "resetting the latest ship requires a reason" do
     ship_event = Post::ShipEvent.create!(body: "x", certification_status: "returned", hours_at_ship: 1)
     Post.create!(project: @project, user: @owner, postable: ship_event)
+    @project.update_column(:ship_status, "needs_changes")
 
     sign_in @admin
 
-    assert_no_difference "Post::ShipEvent.count" do
-      post clear_latest_ship_admin_project_path(@project), params: { reason: "   " }
-    end
+    post reset_latest_ship_admin_project_path(@project), params: { reason: "   " }
 
     assert_redirected_to admin_project_path(@project)
+    assert_equal "needs_changes", @project.reload.ship_status
   end
 
-  test "helper cannot clear the latest ship" do
+  test "helper cannot reset the latest ship" do
     ship_event = Post::ShipEvent.create!(body: "x", certification_status: "returned", hours_at_ship: 1)
     Post.create!(project: @project, user: @owner, postable: ship_event)
 
@@ -184,10 +162,9 @@ class Admin::ProjectsControllerTest < ActionDispatch::IntegrationTest
     helper.update!(granted_roles: %w[helper])
     sign_in helper
 
-    assert_no_difference "Post::ShipEvent.count" do
-      post clear_latest_ship_admin_project_path(@project), params: { reason: "no perms" }, as: :json
-    end
+    post reset_latest_ship_admin_project_path(@project), params: { reason: "no perms" }, as: :json
 
     assert_response :forbidden
+    assert_equal "returned", ship_event.reload.certification_status
   end
 end

--- a/test/controllers/admin/projects_controller_test.rb
+++ b/test/controllers/admin/projects_controller_test.rb
@@ -44,6 +44,25 @@ class Admin::ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_equal true, version.object_changes["funding_lock_bypassed"]
   end
 
+  test "overriding to software clears a stale Hardware classifier so the project rejoins the queue" do
+    @project.update_columns(project_type: "Hardware")
+
+    sign_in @admin
+
+    patch update_hardware_stage_admin_project_path(@project), params: {
+      hardware_stage: "",
+      reason: "AI mislabeled this; it's actually software."
+    }
+
+    @project.reload
+    assert_nil @project.hardware_stage
+    assert_nil @project.project_type, "stale Hardware classifier should be cleared on a software override"
+
+    version = PaperTrail::Version.where(item_type: "Project", item_id: @project.id.to_s).order(:created_at).last
+    assert_equal "admin_hardware_stage_update", version.event
+    assert_equal [ "Hardware", nil ], version.object_changes["project_type"]
+  end
+
   test "helper cannot change project kind" do
     helper = create_user(slack_id: "U_HELPER_PROJECTS", display_name: "helperprojects")
     helper.update!(granted_roles: %w[helper])

--- a/test/controllers/admin/projects_controller_test.rb
+++ b/test/controllers/admin/projects_controller_test.rb
@@ -57,4 +57,72 @@ class Admin::ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
     assert_equal "design", @project.reload.hardware_stage
   end
+
+  test "admin can clear the latest ship and reset the project to draft" do
+    ship_event = Post::ShipEvent.create!(body: "Shipped as software", certification_status: "returned", hours_at_ship: 1)
+    Post.create!(project: @project, user: @owner, postable: ship_event)
+    @project.ship_reviews.create!(status: :returned, feedback: "Please switch this to hardware.")
+    @project.update_column(:ship_status, "needs_changes")
+
+    sign_in @admin
+
+    assert_difference [ "Post::ShipEvent.count", "Certification::Ship.count" ], -1 do
+      post clear_latest_ship_admin_project_path(@project), params: {
+        reason: "Converted to hardware; clearing the bad software ship."
+      }
+    end
+
+    assert_redirected_to admin_project_path(@project)
+    @project.reload
+    assert_equal "draft", @project.ship_status
+    assert_nil @project.last_ship_event
+
+    version = PaperTrail::Version.where(item_type: "Project", item_id: @project.id.to_s).order(:created_at).last
+    assert_equal "admin_clear_latest_ship", version.event
+    assert_equal [ "needs_changes", "draft" ], version.object_changes["ship_status"]
+    assert_equal "Converted to hardware; clearing the bad software ship.", version.object_changes["reason"]
+  end
+
+  test "cannot clear a ship that has already paid out" do
+    ship_event = Post::ShipEvent.create!(body: "Paid", certification_status: "approved", hours_at_ship: 1, payout: 42.0)
+    Post.create!(project: @project, user: @owner, postable: ship_event)
+    @project.update_column(:ship_status, "approved")
+
+    sign_in @admin
+
+    assert_no_difference "Post::ShipEvent.count" do
+      post clear_latest_ship_admin_project_path(@project), params: { reason: "trying to clear a paid ship" }
+    end
+
+    assert_redirected_to admin_project_path(@project)
+    assert_equal "approved", @project.reload.ship_status
+  end
+
+  test "clearing the latest ship requires a reason" do
+    ship_event = Post::ShipEvent.create!(body: "x", certification_status: "returned", hours_at_ship: 1)
+    Post.create!(project: @project, user: @owner, postable: ship_event)
+
+    sign_in @admin
+
+    assert_no_difference "Post::ShipEvent.count" do
+      post clear_latest_ship_admin_project_path(@project), params: { reason: "   " }
+    end
+
+    assert_redirected_to admin_project_path(@project)
+  end
+
+  test "helper cannot clear the latest ship" do
+    ship_event = Post::ShipEvent.create!(body: "x", certification_status: "returned", hours_at_ship: 1)
+    Post.create!(project: @project, user: @owner, postable: ship_event)
+
+    helper = create_user(slack_id: "U_HELPER_CLEAR", display_name: "helperclear")
+    helper.update!(granted_roles: %w[helper])
+    sign_in helper
+
+    assert_no_difference "Post::ShipEvent.count" do
+      post clear_latest_ship_admin_project_path(@project), params: { reason: "no perms" }, as: :json
+    end
+
+    assert_response :forbidden
+  end
 end

--- a/test/controllers/admin/projects_controller_test.rb
+++ b/test/controllers/admin/projects_controller_test.rb
@@ -167,4 +167,49 @@ class Admin::ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
     assert_equal "returned", ship_event.reload.certification_status
   end
+
+  test "resetting the latest ship closes a pending review so it leaves the queue" do
+    project = Project.create!(title: "Submitted software")
+    project.memberships.create!(user: @owner, role: :owner)
+    ship_event = Post::ShipEvent.create!(body: "Submitted", certification_status: "pending", hours_at_ship: 1)
+    Post.create!(project: project, user: @owner, postable: ship_event)
+    reviewer = create_user(slack_id: "U_REVIEWER_RESET", display_name: "reviewerreset")
+    review = project.ship_reviews.create!(status: :pending, reviewer: reviewer, claimed_at: Time.current, claim_expires_at: 30.minutes.from_now)
+    project.update_columns(ship_status: "submitted", shipped_at: Time.current)
+
+    sign_in @admin
+    assert_includes Certification::Ship.available_for(reviewer), review, "baseline: the pending review is in the queue"
+
+    assert_no_difference "Certification::Ship.count" do
+      post reset_latest_ship_admin_project_path(project), params: { reason: "Reset so the owner can re-ship." }
+    end
+
+    review.reload
+    assert_equal "returned", review.status, "pending review is resolved, not left stale"
+    assert_nil review.reviewer_id, "claim released"
+    assert_not_includes Certification::Ship.available_for(reviewer), review
+  end
+
+  test "converting to hardware closes the open software review so it isn't misrouted" do
+    project = Project.create!(title: "Software that's really hardware")
+    project.memberships.create!(user: @owner, role: :owner)
+    ship_event = Post::ShipEvent.create!(body: "Submitted", certification_status: "pending", hours_at_ship: 1)
+    Post.create!(project: project, user: @owner, postable: ship_event)
+    review = project.ship_reviews.create!(status: :pending)
+    project.update_column(:ship_status, "submitted")
+
+    sign_in @admin
+
+    assert_no_difference "Certification::Ship.count" do
+      patch update_hardware_stage_admin_project_path(project), params: {
+        hardware_stage: "design",
+        reason: "This is a hardware project."
+      }
+    end
+
+    assert_equal "design", project.reload.hardware_stage
+    review.reload
+    assert_equal "returned", review.status, "the software review is closed when the project becomes hardware"
+    assert_nil review.reviewer_id
+  end
 end

--- a/test/controllers/admin/projects_controller_test.rb
+++ b/test/controllers/admin/projects_controller_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+class Admin::ProjectsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = create_user(slack_id: "U_ADMIN_PROJECTS", display_name: "adminprojects")
+    @admin.update!(granted_roles: %w[admin])
+
+    @owner = create_user(slack_id: "U_ADMIN_PROJECT_OWNER", display_name: "adminprojectowner")
+    @project = Project.create!(title: "Wrong Kind", hardware_stage: "design")
+    @project.memberships.create!(user: @owner, role: :owner)
+  end
+
+  test "admin can change project kind through the funding lock with audit log" do
+    funding_request = @project.certification_funding_requests.new(
+      user: @owner,
+      complexity_tier: 1,
+      requested_amount_cents: 5_000,
+      status: :pending
+    )
+    funding_request.save!(validate: false)
+
+    locked_project = @project.reload
+    locked_project.hardware_stage = "build"
+    assert_not locked_project.valid?
+    assert_includes locked_project.errors[:hardware_stage], "cannot be changed after a funding request has been submitted"
+
+    sign_in @admin
+
+    assert_difference -> { PaperTrail::Version.where(item_type: "Project", item_id: @project.id.to_s).count }, 1 do
+      patch update_hardware_stage_admin_project_path(@project), params: {
+        hardware_stage: "build",
+        reason: "Project was submitted as the wrong hardware stage after review."
+      }
+    end
+
+    assert_redirected_to admin_project_path(@project)
+    assert_equal "build", @project.reload.hardware_stage
+
+    version = PaperTrail::Version.where(item_type: "Project", item_id: @project.id.to_s).order(:created_at).last
+    assert_equal "admin_hardware_stage_update", version.event
+    assert_equal @admin.id.to_s, version.whodunnit
+    assert_equal [ "design", "build" ], version.object_changes["hardware_stage"]
+    assert_equal "Project was submitted as the wrong hardware stage after review.", version.object_changes["reason"]
+    assert_equal true, version.object_changes["funding_lock_bypassed"]
+  end
+
+  test "helper cannot change project kind" do
+    helper = create_user(slack_id: "U_HELPER_PROJECTS", display_name: "helperprojects")
+    helper.update!(granted_roles: %w[helper])
+    sign_in helper
+
+    patch update_hardware_stage_admin_project_path(@project), params: {
+      hardware_stage: "build",
+      reason: "Trying without permission."
+    }, as: :json
+
+    assert_response :forbidden
+    assert_equal "design", @project.reload.hardware_stage
+  end
+end

--- a/test/controllers/admin/projects_controller_test.rb
+++ b/test/controllers/admin/projects_controller_test.rb
@@ -83,6 +83,31 @@ class Admin::ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Converted to hardware; clearing the bad software ship.", version.object_changes["reason"]
   end
 
+  test "clearing a ship also removes the YSWS review it generated" do
+    ship_event = Post::ShipEvent.create!(body: "Approved ship", certification_status: "approved", hours_at_ship: 1)
+    Post.create!(project: @project, user: @owner, postable: ship_event)
+    review = @project.ship_reviews.create!(status: :approved, reviewer: @admin)
+    Certification::Ysws.create!(
+      post_ship_event: ship_event,
+      ship_cert: review,
+      project: @project,
+      user: @owner,
+      original_minutes: 60
+    )
+    @project.update_column(:ship_status, "approved")
+
+    sign_in @admin
+
+    assert_difference [ "Post::ShipEvent.count", "Certification::Ship.count", "Certification::Ysws.count" ], -1 do
+      post clear_latest_ship_admin_project_path(@project), params: {
+        reason: "Wrong kind; clearing the approved ship and its YSWS review."
+      }
+    end
+
+    assert_redirected_to admin_project_path(@project)
+    assert_equal "draft", @project.reload.ship_status
+  end
+
   test "cannot clear a ship that has already paid out" do
     ship_event = Post::ShipEvent.create!(body: "Paid", certification_status: "approved", hours_at_ship: 1, payout: 42.0)
     Post.create!(project: @project, user: @owner, postable: ship_event)

--- a/test/models/certification/ship_test.rb
+++ b/test/models/certification/ship_test.rb
@@ -86,4 +86,24 @@ class Certification::ShipTest < ActiveSupport::TestCase
     assert_equal reviews.last.id, history[:recent].first.id
     assert history[:recent].first.project_with_deleted.deleted?
   end
+
+  test "available_for keeps software/unclassified ships but excludes hardware" do
+    make_pending = ->(attrs) do
+      project = Project.create!({ description: "x", ship_status: "submitted" }.merge(attrs))
+      project.memberships.create!(user: @owner, role: :owner)
+      project.ship_reviews.create!(status: :pending)
+    end
+
+    software     = make_pending.call(title: "SW", project_type: "Web App")
+    unclassified = make_pending.call(title: "Unclassified", project_type: nil)
+    ai_hardware  = make_pending.call(title: "AI HW", project_type: "Hardware")
+    flow_hardware = make_pending.call(title: "Flow HW", hardware_stage: "design")
+
+    available = Certification::Ship.available_for(@reviewer)
+
+    assert_includes available, software
+    assert_includes available, unclassified
+    assert_not_includes available, ai_hardware
+    assert_not_includes available, flow_hardware
+  end
 end


### PR DESCRIPTION
## what's this do?

Right now, if someone builds a hardware project but ships it as a software project, a reviewer sends it back and tells them to switch it to hardware in their settings. The catch: they can't actually do that once it's been sent back — so the project gets stuck and keeps bouncing around the review queue. On top of that, hardware projects are landing in the software reviewers' queue, which slows everyone down.

This adds four things:

**1. Change the project kind (admin).** A button to switch a project between Software, Hardware (design), and Hardware (build) on the owner's behalf. Requires a reason (saved to the audit log), works even if the project already requested funding (which normally locks the type), and the page shows the project's real kind next to what our AI classifier guessed. If staff override a project to Software, any stale "Hardware" AI label is cleared too, so the project actually re-enters the review queue.

**2. Reset the latest ship (admin).** A button that soft-resets a project's most recent ship back to an un-shipped draft — for when a project shipped under the wrong kind and we want to give the owner a clean slate to fix and re-ship. **Nothing is deleted:** the ship event, its review, votes and YSWS links are all kept for history/audit. It just flips the project back to draft, resets the ship's certification to pending so it no longer blocks re-shipping, and clears the shipped timestamp. Asks for confirmation + a reason, logs it, and won't touch a ship that's already paid out.

**3. Keep hardware out of the software review queue.** Hardware projects no longer get auto-assigned to software reviewers — they're meant for the hardware flow (funding/build). "Hardware" means either the real hardware setting or anything our AI classifier tagged as Hardware. Unclassified projects still show up normally, and admins can still find hardware ships in the queue list via the type filter; they're just out of the auto-assignment feed.

**4. A backfill runner.** A `backfill:hardware_stage` rake task (dry-run by default) that promotes AI-tagged hardware projects that never entered the hardware flow into it (at the design stage), so they actually land in the hardware flow instead of sitting in limbo. Wraps the existing `OneTime::BackfillHardwareStageJob`.

Letting users fix this themselves (instead of staff) is a separate thing for later.

## show it works

Tests:
- `test/controllers/admin/projects_controller_test.rb` — change kind through the funding lock with audit; software override clears a stale Hardware classifier (including when the project is already software); soft-reset the latest ship (project back to draft, ship/review/YSWS all preserved, certification reset, audit entry); refuse to reset a paid-out ship; both actions require a reason; helper role blocked.
- `test/models/certification/ship_test.rb` — the reviewer queue keeps software and unclassified ships but excludes both real-hardware and AI-tagged-hardware ships.

Backfill runner:
```
bin/rails backfill:hardware_stage              # dry run, prints the projects it would convert
bin/rails backfill:hardware_stage DRY_RUN=false  # apply
```

Heads up: I couldn't run the tests or the backfill on my machine — the docker setup wouldn't build here (a platform/image mismatch unrelated to this change). The Ruby passes a syntax check; relying on CI for the suite, and the backfill should be dry-run'd in a real environment before applying.

## ai?

Yep — Claude Code (Opus 4.8) helped with the rebase, conflict resolution, review, and building these.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ship/review queue routing and staff overrides that bypass validations and funding locks; mistakes could misroute reviews or reset ships, though payouts are guarded and actions are audited.
> 
> **Overview**
> Adds **admin tools** to fix stuck software/hardware misroutes: staff can **change project kind** (software vs hardware design/build) with a required audit reason, bypassing the funding lock; overriding to software also **clears a stale `Hardware` AI classifier** so the project can re-enter the software review queue.
> 
> Adds **Reset Latest Ship**, a non-destructive draft reset (project + latest ship certification, clears `shipped_at`) with audit logging; blocks paid-out ships and **closes pending ship reviews** via `resolve_open_ship_reviews!` so nothing stays in the reviewer queue.
> 
> **Software reviewer auto-assignment** now applies `excluding_hardware` on `Certification::Ship.available_for` (hardware stage or AI-tagged Hardware), while admin listing filters are unchanged.
> 
> Admin project show gains kind/classifier display and modals; ship/status admin actions share **`log_admin_version`**. Audit badges humanize non-`update` events. New **`backfill:hardware_stage`** rake task (dry-run default) wraps `OneTime::BackfillHardwareStageJob`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47773b92201d56fcef9c10e6cede2607b3e1fdb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->