### PR TITLE
add a tab for new builders

### DIFF
--- a/app/controllers/home/feeds_controller.rb
+++ b/app/controllers/home/feeds_controller.rb
@@ -96,17 +96,19 @@ class Home::FeedsController < ApplicationController
 
   def new_builders_scope
     first_devlog_ids = Post.where(postable_type: "Post::Devlog")
+      .joins("INNER JOIN post_devlogs ON post_devlogs.id = posts.postable_id")
+      .where(post_devlogs: { deleted_at: nil })
       .group(:user_id)
       .select("MIN(posts.id)")
 
-    Post.of_devlogs(join: true)
+    feed_scope
+      .where(postable_type: "Post::Devlog")
+      .joins("INNER JOIN post_devlogs ON post_devlogs.id = posts.postable_id")
       .where(id: first_devlog_ids)
       .where(post_devlogs: { deleted_at: nil })
       .where("post_devlogs.duration_seconds > 0")
       .where("posts.created_at >= ?", 7.days.ago)
-      .joins("LEFT JOIN users feed_authors ON feed_authors.id = posts.user_id")
-      .where("feed_authors.banned = FALSE")
-      .order(Arel.sql(<<~SQL.squish))
+      .reorder(Arel.sql(<<~SQL.squish))
         (post_devlogs.likes_count + post_devlogs.comments_count) ASC,
         posts.created_at DESC
       SQL

--- a/app/controllers/home/feeds_controller.rb
+++ b/app/controllers/home/feeds_controller.rb
@@ -3,7 +3,7 @@ class Home::FeedsController < ApplicationController
 
   FEED_LIMIT = 20
   RECOMMENDATION_POOL = 100 # after this, we fallback to SQL
-  TABS = %w[for_you following popular newest].freeze
+  TABS = %w[for_you following popular newest new_builders].freeze
   FeedPage = Struct.new(:page, :limit, :offset, :next, keyword_init: true)
 
   skip_before_action :remember_page
@@ -22,10 +22,11 @@ class Home::FeedsController < ApplicationController
 
   def load_feed
     case @current_tab
-    when "following"  then load_following_feed
-    when "popular"    then paginate_and_filter(popular_scope, "popular")
-    when "newest"     then paginate_and_filter(newest_scope, "newest")
-    else                   load_for_you_feed
+    when "following"     then load_following_feed
+    when "popular"       then paginate_and_filter(popular_scope, "popular")
+    when "newest"        then paginate_and_filter(newest_scope, "newest")
+    when "new_builders"  then paginate_and_filter(new_builders_scope, "new_builders")
+    else                      load_for_you_feed
     end
 
     @liked_devlog_ids = liked_devlog_ids_for(@feed_posts)
@@ -91,6 +92,24 @@ class Home::FeedsController < ApplicationController
 
   def newest_scope
     feed_scope.reorder(created_at: :desc)
+  end
+
+  def new_builders_scope
+    first_devlog_ids = Post.where(postable_type: "Post::Devlog")
+      .group(:user_id)
+      .select("MIN(posts.id)")
+
+    Post.of_devlogs(join: true)
+      .where(id: first_devlog_ids)
+      .where(post_devlogs: { deleted_at: nil })
+      .where("post_devlogs.duration_seconds > 0")
+      .where("posts.created_at >= ?", 7.days.ago)
+      .joins("LEFT JOIN users feed_authors ON feed_authors.id = posts.user_id")
+      .where("feed_authors.banned = FALSE")
+      .order(Arel.sql(<<~SQL.squish))
+        (post_devlogs.likes_count + post_devlogs.comments_count) ASC,
+        posts.created_at DESC
+      SQL
   end
 
   def visible_post?(post)

--- a/app/views/home/feed_pages/_feed_page.html.erb
+++ b/app/views/home/feed_pages/_feed_page.html.erb
@@ -60,7 +60,9 @@
   <% end %>
 
   <p class="feed-home__empty">
-    <% if @current_tab == "following" %>
+    <% if @current_tab == "new_builders" %>
+      No new builders right now. Check back later!
+    <% elsif @current_tab == "following" %>
       Nothing here yet. Follow some people or projects to see their posts here!
     <% elsif current_user.present? %>
       Nothing here yet. Post a devlog or ship your project to start the feed.

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -20,6 +20,7 @@
     <% if Flipper.enabled?(:week_3_release, current_user) %>
       <nav class="feed-tabs" aria-label="Feed filters">
         <button class="feed-tabs__tab feed-tabs__tab--active" data-feed-tabs-target="tab" data-tab="for_you" data-action="feed-tabs#switch">For you</button>
+        <button class="feed-tabs__tab" data-feed-tabs-target="tab" data-tab="new_builders" data-action="feed-tabs#switch">New builders</button>
         <% if current_user.present? %>
           <button class="feed-tabs__tab" data-feed-tabs-target="tab" data-tab="following" data-action="feed-tabs#switch">Following</button>
         <% end %>


### PR DESCRIPTION
<img width="424" height="67" alt="image" src="https://github.com/user-attachments/assets/837a3c73-ebd5-4906-861d-2ced1cc76ea0" />

shows devlog posts that are from the past 7 days, and are first devlogs from new users. prioritizes low-engagement posts