### PR TITLE
chore: update slack channel id for feederboard

### DIFF
--- a/app/models/ledger_entry.rb
+++ b/app/models/ledger_entry.rb
@@ -91,7 +91,7 @@ class LedgerEntry < ApplicationRecord
 
     # Audit broadcast to the finance review channel — not a user notification,
     # not preference-gated, intentional separate path.
-    SendSlackDmJob.perform_later("C0A3JN1CMNE", "<@#{user.slack_id}>: #{message}") if user.slack_id.present?
+    SendSlackDmJob.perform_later("C0B6NCD8MD5", "<@#{user.slack_id}>: #{message}") if user.slack_id.present?
   end
 
   def invalidate_user_balance_cache = user.invalidate_balance_cache!


### PR DESCRIPTION
## what's this do?

change which channel feederboard (balance notifications) are posted in

## show it works

https://github.com/user-attachments/assets/34d8c420-e090-4ec8-87fe-aaf887d81af2


## ai?
no