### PR TITLE
Fix admin Adjust Balance button hidden behind pending-orders check

### DIFF
--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -272,80 +272,7 @@
             </div>
           </form>
         <% end %>
-        <% if policy(@user).impersonate? && !impersonating? %>
-          <%= button_to "Impersonate", admin_user_impersonation_path(@user), method: :post,
-              data: { confirm: "Impersonate #{@user.display_name}?" } %>
-        <% end %>
-        <%= button_to "🔄 Sync Hackatime", admin_user_hackatime_sync_path(@user), method: :post %>
-        <%= button_to "🔄 Refresh Verification", admin_user_verification_path(@user), method: :post,
-            data: { confirm: "Refresh verification for #{@user.display_name}?" } %>
-
-        <% if current_user.admin? %>
-          <%
-            all_roles = [
-              { name: 'fraud_dept',         disabled: !current_user&.admin? },
-              { name: 'fulfillment_person', disabled: !current_user&.admin? },
-              { name: 'project_certifier',  disabled: !current_user&.admin? },
-              { name: 'helper',             disabled: !current_user&.admin? },
-              { name: 'shop_manager',       disabled: !current_user&.admin? },
-              { name: 'admin',              disabled: !current_user&.super_admin? },
-            ]
-            promotable_roles = all_roles.reject { |r| @user.has_role?(r[:name]) }
-            demotable_roles  = all_roles.select { |r| @user.has_role?(r[:name]) }
-          %>
-          <% if promotable_roles.any? %>
-            <div class="role-dropdown">
-              <button type="button" data-role-dropdown-toggle>⬆ Promote to…</button>
-              <div class="role-dropdown__menu">
-                <% promotable_roles.each do |role| %>
-                  <%= button_to role[:name].titleize, admin_user_roles_path(@user),
-                      method: :post, params: { role_name: role[:name] }, disabled: role[:disabled],
-                      class: "role-dropdown__item" %>
-                <% end %>
-              </div>
-            </div>
-          <% end %>
-          <% if demotable_roles.any? %>
-            <div class="role-dropdown">
-              <button type="button" data-role-dropdown-toggle>⬇ Demote from…</button>
-              <div class="role-dropdown__menu">
-                <% demotable_roles.each do |role| %>
-                  <%= button_to role[:name].titleize, admin_user_role_path(@user, role[:name]),
-                      method: :delete, params: { role_name: role[:name] }, disabled: role[:disabled],
-                      class: "role-dropdown__item" %>
-                <% end %>
-              </div>
-            </div>
-          <% end %>
-          <script>
-            document.querySelectorAll("[data-role-dropdown-toggle]").forEach(function(btn) {
-              btn.addEventListener("click", function() {
-                var menu = btn.nextElementSibling;
-                var isOpen = menu.classList.contains("role-dropdown__menu--open");
-                document.querySelectorAll(".role-dropdown__menu--open").forEach(function(m) { m.classList.remove("role-dropdown__menu--open"); });
-                if (!isOpen) menu.classList.add("role-dropdown__menu--open");
-              });
-            });
-            document.addEventListener("click", function(e) {
-              if (!e.target.closest(".role-dropdown")) {
-                document.querySelectorAll(".role-dropdown__menu--open").forEach(function(m) { m.classList.remove("role-dropdown__menu--open"); });
-              }
-            });
-          </script>
-        <% end %>
-
-        <% if @user.shop_orders.where(aasm_state: %w[pending awaiting_periodical_fulfillment]).any? %>
-          <button type="button" onclick="document.getElementById('reject-modal-orders').showModal()">✗ Reject Orders</button>
-          <%= render layout: "shared/modal", locals: { id: "reject-modal-orders", title: "Reject All Orders", description: "Reject all pending orders for #{@user.display_name}." } do %>
-            <form action="<%= admin_user_order_rejection_path(@user) %>" method="post">
-              <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
-              <%= label_tag :reason, "Reason (optional)" %>
-              <%= text_area_tag :reason, "", placeholder: "Enter reason..." %>
-              <button type="submit">Confirm</button>
-              <button type="button" onclick="document.getElementById('reject-modal-orders').close()">Cancel</button>
-            </form>
-          <% end %>
-        <% end %>
+      <% end %>
 
         <% if policy(@user).adjust_balance? %>
           <button type="button" onclick="document.getElementById('adjust-balance-modal').showModal()">💰 Adjust Balance</button>
@@ -454,7 +381,6 @@
         <button type="submit">Save Notes</button>
       </form>
     </div>
-  <% end %>
 
   <%= render Admin::PastOrdersComponent.new(user: @user, title: "Shop Orders") %>
   <%= render "admin/shared/ledger_log", entries: @user.ledger_entries, title: "Ledger History" %>


### PR DESCRIPTION
## what's this do?

Fixes the admin "💰 Adjust Balance" button (for granting/deducting a user's stardust) that had gone missing from user admin pages. A bad merge had accidentally wrapped it — along with View Votes, Set Vote Balance, Cancel HCB Grants, the Flipper Features panel, and Internal Notes — inside an "if this user has pending shop orders" check, so those controls only showed up for users who happened to have pending orders. That same merge also left duplicate Impersonate / Sync / Refresh / role-management / Reject Orders blocks inside the same check. This PR keeps Reject Orders gated by pending orders (where it belongs), deletes the duplicate blocks, and un-nests everything else so admins can always adjust a user's stardust.

## show it works

On any user's admin page (`/admin/users/:id`), an admin now always sees the 💰 Adjust Balance button regardless of whether the user has pending orders. Verified the ERB if/do/end nesting is balanced after the change. Worth a quick manual check on a real admin login.

## ai?

Yes — Claude Code (Opus 4.8) diagnosed the merge bug and made the edit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> View-only template restructuring with no controller or authorization logic changes; main risk is a markup nesting mistake, which this PR is meant to correct.
> 
> **Overview**
> Fixes **broken ERB nesting** on the admin user show page so routine controls are no longer tied to “has pending shop orders.”
> 
> The pending-orders `if` now wraps only **Reject Orders** and its modal. Removed a large duplicate block (second Impersonate, Hackatime sync, verification refresh, role promote/demote dropdowns, inline dropdown script, and a second Reject Orders UI) that had been nested inside that check. Also drops an extra closing `<% end %>` so **Adjust Balance**, vote tools, Flipper, Internal Notes, and lower-page sections render for every user again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 290128e94d9d99dbcdc127770b06026bd7fd5672. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->