### PR TITLE
Show a builder's Lapse timelapses on the hardware funding review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 # Ignore all environment files.
 /.env*
 
+# Local-only Docker Compose overrides (per-developer ports/env, may hold secrets).
+/docker-compose.override.yml
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -84,6 +84,7 @@
 @use "pages/certification/ships/index" as certification_ships_index;
 @use "pages/certification/ships/show" as certification_ships_show;
 @use "pages/certification/ships/monitor" as certification_ships_monitor;
+@use "pages/certification/lapse_timelapses" as certification_lapse_timelapses;
 @use "pages/certification/mystats" as certification_mystats;
 @use "pages/certification/payouts" as certification_payouts;
 @use "pages/raffle";

--- a/app/assets/stylesheets/pages/certification/_lapse_timelapses.scss
+++ b/app/assets/stylesheets/pages/certification/_lapse_timelapses.scss
@@ -1,0 +1,75 @@
+// Lapse timelapse gallery on the hardware funding review (admin/certification/
+// funding_requests#show). Sits in the details column inside a .ship-review__panel
+// surface (shared with the ship-review layout), so only the gallery internals
+// need styling here.
+
+.lapse-timelapses {
+  &__empty {
+    margin: 0;
+    color: var(--color-space-text-muted, rgba(255, 255, 255, 0.7));
+    font-size: 0.95rem;
+  }
+
+  &__list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: var(--space-m);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  &__item {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
+
+  &__media {
+    position: relative;
+    aspect-ratio: 9 / 16;
+    overflow: hidden;
+    border-radius: 12px;
+    background: var(--color-space-card, rgba(255, 255, 255, 0.04));
+    border: 1px solid var(--color-space-border, rgba(255, 255, 255, 0.1));
+  }
+
+  &__video {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    background: #000;
+  }
+
+  &__processing {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    padding: var(--space-s);
+    color: var(--color-space-text-muted, rgba(255, 255, 255, 0.7));
+    font-size: 0.85rem;
+    text-align: center;
+  }
+
+  &__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  &__name {
+    color: var(--color-space-text);
+    font-size: 0.95rem;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__sub {
+    color: var(--color-space-text-muted, rgba(255, 255, 255, 0.7));
+    font-size: 0.8rem;
+  }
+}

--- a/app/controllers/admin/certification/funding_requests_controller.rb
+++ b/app/controllers/admin/certification/funding_requests_controller.rb
@@ -36,6 +36,7 @@ class Admin::Certification::FundingRequestsController < Admin::Certification::Ap
   def show
     authorize @funding_request
     @reviewed_today = ::Certification::FundingRequest.reviewed_today(current_user)
+    @lapse_timelapses = lapse_timelapses_for_review
   end
 
   def update
@@ -71,6 +72,18 @@ class Admin::Certification::FundingRequestsController < Admin::Certification::Ap
 
   def set_funding_request
     @funding_request = ::Certification::FundingRequest.find(params[:id])
+  end
+
+  # Lapse timelapses the builder recorded for *this* project, joined via the
+  # project's Hackatime keys and the submitter's Hackatime id so reviewers see
+  # the videos tied to the submission rather than the builder's whole library.
+  # Returns [] when the submitter has no Hackatime link or the project has no
+  # linked Hackatime keys.
+  def lapse_timelapses_for_review
+    LapseService.timelapses_for_project(
+      hackatime_user_id: @funding_request.owner&.hackatime_identity&.uid,
+      project_keys: @funding_request.project.hackatime_keys
+    )
   end
 
   # The .app-layout wrapper reserves the sidebar gutter itself; this body class

--- a/app/controllers/admin/certification/funding_requests_controller.rb
+++ b/app/controllers/admin/certification/funding_requests_controller.rb
@@ -48,6 +48,7 @@ class Admin::Certification::FundingRequestsController < Admin::Certification::Ap
                   notice: "#{verb} funding for “#{@funding_request.project.title}.” That's #{count} reviewed today. Keep going!"
     else
       @reviewed_today = ::Certification::FundingRequest.reviewed_today(current_user)
+      @lapse_timelapses = lapse_timelapses_for_review
       render :show, status: :unprocessable_entity
     end
   end

--- a/app/models/certification/funding_request.rb
+++ b/app/models/certification/funding_request.rb
@@ -184,6 +184,13 @@ module Certification
     def final_amount_cents = approved_amount_cents || requested_amount_cents
     def final_amount_dollars = (final_amount_cents || 0) / 100
 
+    # The hardware builder this request belongs to: the project's owner
+    # membership, falling back to the submitting user when no owner membership
+    # remains (mirrors how grants/discounts resolve the recipient).
+    def owner
+      @owner ||= project.memberships.owner.first&.user || user
+    end
+
     # Reviewers enter whole-dollar amounts; we persist cents.
     def approved_amount_dollars
       approved_amount_cents ? approved_amount_cents / 100 : nil

--- a/app/services/lapse_service.rb
+++ b/app/services/lapse_service.rb
@@ -1,0 +1,81 @@
+# Talks to Lapse (Hack Club's timelapse recorder — https://api.lapse.hackclub.com).
+#
+# Used by hardware funding review to surface the timelapses a builder recorded
+# *for the project under review* — not their whole library. Authenticates
+# server-to-server with a Lapse program key (Bearer), scoped to
+# `timelapse:read`/`snapshot:read`.
+#
+# Lapse ties each timelapse to a Hackatime project key, so the join is:
+# our Project's Hackatime keys (Project#hackatime_keys) + the submitter's
+# Hackatime id → `hackatime.timelapsesForProject`.
+class LapseService
+  BASE_URL = Rails.application.credentials.dig(:lapse, :base_url) || ENV.fetch("LAPSE_BASE_URL", "https://api.lapse.hackclub.com")
+  API_KEY  = Rails.application.credentials.dig(:lapse, :api_key) || ENV.fetch("LAPSE_API_KEY", "")
+
+  OPEN_TIMEOUT = 3
+  READ_TIMEOUT = 6
+  # Safety cap so a project with an unusually long key list can't fan out into
+  # an unbounded number of upstream requests on a review page load.
+  MAX_KEYS = 12
+
+  class << self
+    # Timelapses the given Hackatime user recorded against any of `project_keys`
+    # (a project can link more than one Hackatime key). Returns an array of
+    # timelapse hashes (symbolized top-level keys), deduplicated by id and
+    # ordered newest-first, or [] when inputs are blank or the API is
+    # unreachable. Never raises — review pages must render regardless.
+    #
+    # Keys are fetched concurrently: each is an independent upstream call, so
+    # wall-clock stays ~one request instead of N, keeping a slow/unreachable
+    # Lapse from stacking timeouts and hanging the web worker.
+    def timelapses_for_project(hackatime_user_id:, project_keys:)
+      return [] if hackatime_user_id.blank? || project_keys.blank? || API_KEY.blank?
+
+      keys = Array(project_keys).reject(&:blank?).uniq.first(MAX_KEYS)
+      return [] if keys.empty?
+
+      keys
+        .map { |key| Thread.new { timelapses_for_project_key(hackatime_user_id, key) } }
+        .flat_map(&:value)
+        .uniq { |tl| tl[:id] }
+        .sort_by { |tl| -tl[:createdAt].to_i }
+    end
+
+    private
+
+    # GET /hackatime/timelapsesForProject — one Hackatime project key's timelapses.
+    def timelapses_for_project_key(hackatime_user_id, project_key)
+      response = connection.get("api/hackatime/timelapsesForProject",
+                                hackatimeUserId: hackatime_user_id, projectKey: project_key)
+
+      unless response.success?
+        Rails.logger.error "LapseService timelapsesForProject error: #{response.status} - #{response.body}"
+        return []
+      end
+
+      body = JSON.parse(response.body)
+      return [] unless body["ok"]
+
+      Array(body.dig("data", "timelapses")).select { |tl| tl.is_a?(Hash) }.map(&:symbolize_keys)
+    rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
+      Rails.logger.error "LapseService timelapsesForProject timeout: #{e.message}"
+      []
+    rescue => e
+      Rails.logger.error "LapseService timelapsesForProject exception: #{e.message}"
+      []
+    end
+
+    # A fresh connection per call: cheap, and keeps concurrent key fetches from
+    # sharing one Faraday instance across threads.
+    def connection
+      Faraday.new(url: BASE_URL) do |conn|
+        conn.options.open_timeout = OPEN_TIMEOUT
+        conn.options.timeout = READ_TIMEOUT
+        conn.headers["Authorization"] = "Bearer #{API_KEY}"
+        conn.headers["Content-Type"] = "application/json"
+        conn.headers["User-Agent"] = Rails.application.config.user_agent
+        conn.adapter Faraday.default_adapter
+      end
+    end
+  end
+end

--- a/app/views/admin/certification/funding_requests/_lapse_timelapses.html.erb
+++ b/app/views/admin/certification/funding_requests/_lapse_timelapses.html.erb
@@ -1,0 +1,42 @@
+<%# Lapse timelapse videos for the submitter — hardware review only. %>
+<%# `timelapses` is an array of Lapse API hashes (see LapseService). %>
+<div class="ship-review__panel lapse-timelapses">
+  <h2 class="ship-review__panel-title">Lapse timelapses</h2>
+
+  <% if timelapses.blank? %>
+    <p class="lapse-timelapses__empty">No Lapse timelapses found for this project.</p>
+  <% else %>
+    <ul class="lapse-timelapses__list">
+      <% timelapses.each do |tl| %>
+        <% hours, rem = tl[:duration].to_i.divmod(3600) %>
+        <% mins, secs = rem.divmod(60) %>
+        <% clock = hours.positive? ? format("%d:%02d:%02d", hours, mins, secs) : format("%d:%02d", mins, secs) %>
+        <li class="lapse-timelapses__item">
+          <div class="lapse-timelapses__media">
+            <% if tl[:playbackUrl].present? %>
+              <video controls playsinline preload="none"
+                     class="lapse-timelapses__video"
+                     poster="<%= tl[:thumbnailUrl] %>">
+                <source src="<%= tl[:playbackUrl] %>" type="video/mp4">
+                Your browser does not support the video tag.
+              </video>
+            <% else %>
+              <div class="lapse-timelapses__processing">
+                <%= tl[:visibility] == "FAILED_PROCESSING" ? "Processing failed" : "Still processing…" %>
+              </div>
+            <% end %>
+          </div>
+          <div class="lapse-timelapses__meta">
+            <span class="lapse-timelapses__name"><%= tl[:name].presence || "Untitled timelapse" %></span>
+            <span class="lapse-timelapses__sub">
+              <%= clock %>
+              <% if tl[:createdAt].present? %>
+                &middot; <%= l(Time.zone.at(tl[:createdAt].to_i / 1000).to_date, format: :short) %>
+              <% end %>
+            </span>
+          </div>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+</div>

--- a/app/views/admin/certification/funding_requests/show.html.erb
+++ b/app/views/admin/certification/funding_requests/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Funding review: #{@funding_request.project.title}" %>
 
 <%
-  owner = @funding_request.project.memberships.find(&:owner?)&.user
+  owner = @funding_request.owner
   can_review = @funding_request.claim_held_by?(current_user) && @funding_request.pending?
 %>
 
@@ -50,6 +50,8 @@
             <p class="ship-review__description"><%= @funding_request.project.description %></p>
           </div>
         <% end %>
+
+        <%= render "lapse_timelapses", timelapses: @lapse_timelapses %>
 
         <div class="ship-review__panel">
           <h2 class="ship-review__panel-title">Links</h2>

--- a/test/services/lapse_service_test.rb
+++ b/test/services/lapse_service_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class LapseServiceTest < ActiveSupport::TestCase
+  test "timelapses_for_project returns [] for a blank hackatime id without hitting the network" do
+    assert_equal [], LapseService.timelapses_for_project(hackatime_user_id: nil, project_keys: %w[foo])
+    assert_equal [], LapseService.timelapses_for_project(hackatime_user_id: "", project_keys: %w[foo])
+  end
+
+  test "timelapses_for_project returns [] for blank project keys without hitting the network" do
+    assert_equal [], LapseService.timelapses_for_project(hackatime_user_id: "123", project_keys: [])
+    assert_equal [], LapseService.timelapses_for_project(hackatime_user_id: "123", project_keys: nil)
+  end
+
+  test "timelapses_for_project returns [] when every key is blank, without hitting the network" do
+    assert_equal [], LapseService.timelapses_for_project(hackatime_user_id: "123", project_keys: [ "", nil, "  " ])
+  end
+end


### PR DESCRIPTION
## What this does

Hardware reviewers can now see a builder's **Lapse timelapse videos** right on the funding request review page (`admin/certification/funding_requests#show`) — the page you land on when reviewing a hardware funding request.

The videos shown are scoped to the **specific project under review**, not the builder's whole Lapse library.


## Why

When reviewing a hardware funding request, it helps to see the build work the person has actually recorded. Hardware builders capture their progress with Lapse, so surfacing those clips next to the request gives reviewers real context before approving a grant.

## How it stays scoped to the right person and project

Lapse tags every timelapse with a Hackatime project key. Stardance already links Hackatime project keys to a specific project (so build hours get counted). We reuse that link:

- **Person:** the submitter's `hackatime_identity.uid` — the same Hackatime user id Stardance already uses for its stats calls.
- **Project:** the project's linked Hackatime keys (`Project#hackatime_keys`).

Those two go to Lapse's `hackatime/timelapsesForProject` endpoint. Because both sides read from the same Hackatime source of truth, the match is exact — a reviewer can't accidentally see a different person's video or a different project's video. I verified this against live production Lapse data: different project keys return different (and correctly scoped) videos.

## Notes / behavior

- **Empty state is expected and correct** when a builder recorded with Lookout instead of Lapse, hasn't linked their Hackatime project to the Stardance project, or simply has no videos yet. We don't invent an association we can't prove.
- Funding requests are submitted from the **design stage**, so the clips shown are design-phase work (useful for confirming real effort before funding a build).
- Keys are fetched **concurrently** with bounded timeouts and a key cap, so a slow/unreachable Lapse can't hang the review page. The whole section fails soft to the empty state — it never 500s the page.

## Config

Needs the Lapse program key set as the `LAPSE_API_KEY` env var (or the `:lapse, :api_key` Rails credential). The key is scoped to `timelapse:read` + `snapshot:read`. **Not committed** to the repo.

## Files

- `app/services/lapse_service.rb` — new Lapse API client (concurrent project-scoped fetch, fails soft)
- `app/controllers/admin/certification/funding_requests_controller.rb` — loads timelapses on `show`
- `app/views/admin/certification/funding_requests/_lapse_timelapses.html.erb` — the video gallery
- `app/assets/stylesheets/pages/certification/_lapse_timelapses.scss` (+ `application.scss`) — styling, Stardance space theme
- `app/models/certification/funding_request.rb` — added a shared `#owner` method (also de-dupes how the page resolved the owner)
- `test/services/lapse_service_test.rb` — service guard tests

## Testing

- Ran the real `LapseService` against the **live Lapse API**: project-scoped results, concurrent fetch (~0.5s for several keys), dedup, newest-first sort, and graceful empty/error handling all confirmed.
- Confirmed returned `playbackUrl`s stream as `video/mp4` and thumbnails load.
- `ruby -c` / ERB parse clean on all changed files.
- Not yet rendered in a running app instance locally (Docker build blocked in this workspace) — the data path feeding the view is verified, but the literal page render hasn't been eyeballed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Review page loads now depend on an external Lapse API with threaded outbound calls, though access stays admin-reviewer-only and errors degrade to an empty section rather than failing the request.
> 
> **Overview**
> Hardware funding review (`admin/certification/funding_requests#show`) now loads and displays **Lapse timelapse videos** for the builder and project under review, not their full library.
> 
> A new **`LapseService`** calls Lapse’s `hackatime/timelapsesForProject` using the funding request **`#owner`**’s Hackatime uid and the project’s **`hackatime_keys`**, with concurrent per-key fetches, timeouts, a key cap, dedup, and **fail-soft** behavior (empty gallery, no page error). The controller sets `@lapse_timelapses` on `show`; a partial renders a grid of videos (or processing/empty states) with new certification page styles wired through **`application.scss`**.
> 
> **`Certification::FundingRequest#owner`** centralizes owner resolution (project owner membership, else submitter); the review page uses it for the submitter display and for Lapse lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79d76d863aeda49f2557fbe2e805905e626827b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->