### PR TITLE
feat(emails): add funnel stage to be able to send drip campaigns

### DIFF
--- a/app/jobs/airtable/user_sync_job.rb
+++ b/app/jobs/airtable/user_sync_job.rb
@@ -19,6 +19,8 @@ class Airtable::UserSyncJob < Airtable::BaseSyncJob
       "has_some_role_of_access" => user.roles.any?,
       "hours" => user.all_time_coding_seconds&.fdiv(3600),
       "verification_status" => user.verification_status.to_s,
+      "funnel_stage" => user.funnel_stage.to_s,
+      "funnel_stage_entered_at" => user.funnel_stage_entered_at,
       "created_at" => user.created_at,
       "synced_at" => Time.now,
       "is_banned" => user.banned,

--- a/app/jobs/airtable/user_sync_job.rb
+++ b/app/jobs/airtable/user_sync_job.rb
@@ -6,6 +6,14 @@ class Airtable::UserSyncJob < Airtable::BaseSyncJob
 
   def primary_key_field = "email"
 
+  # Backstop round-robin for the funnel-stuck nudges. Freshness for users who
+  # actually advance is handled event-driven by FunnelResyncTrigger (their
+  # synced_at is nulled, jumping them to the front); this limit just bounds how
+  # long anything those hooks miss can stay stale. 100/min cycles ~29k users in
+  # ~5h — well under the 2-day nudge window. Norairrecord's Faraday middleware
+  # paces requests to Airtable's 5 req/s per-base limit on its own.
+  def sync_limit = 100
+
   def field_mapping(user)
     address = user.addresses.first
 

--- a/app/jobs/one_time/backfill_user_funnel_sync_job.rb
+++ b/app/jobs/one_time/backfill_user_funnel_sync_job.rb
@@ -1,0 +1,33 @@
+module OneTime
+  # One-shot full backfill of every user's funnel fields into Airtable. Unlike
+  # the steady Airtable::UserSyncJob round-robin (capped at sync_limit/min so it
+  # stays gentle), this pages through *all* users and upserts them as fast as
+  # Airtable allows. Run once after deploying the funnel sync, or any time the
+  # Airtable mirror needs a full rebuild:
+  #
+  #   OneTime::BackfillUserFunnelSyncJob.perform_later
+  #
+  # Pacing: Norairrecord's rate limiter is per-process and caps us at Airtable's
+  # 5 req/s per base (10 records/request = ~50 users/s), so ~29k users take
+  # ~10 min. Keep it a SINGLE job — fanning out across worker processes would
+  # each get their own 5 req/s budget and collectively trip Airtable's limit.
+  # Idempotent (upsert by email), so it's safe to re-run if a batch fails.
+  class BackfillUserFunnelSyncJob < Airtable::UserSyncJob
+    BATCH_SIZE = 500
+
+    def perform
+      records.find_in_batches(batch_size: BATCH_SIZE) do |batch|
+        airtable_records = batch
+          .map { |user| table.new(field_mapping(user)) }
+          .reject { |record| record.fields[primary_key_field].blank? }
+          .uniq { |record| record.fields[primary_key_field] }
+        next if airtable_records.empty?
+
+        table.batch_upsert(airtable_records, primary_key_field)
+        records.unscoped.where(id: batch.map(&:id)).update_all(synced_at_field => Time.now)
+      rescue Norairrecord::Error => e
+        Rails.logger.error("[#{self.class.name}] batch failed (#{e.message}); continuing — re-run to retry")
+      end
+    end
+  end
+end

--- a/app/models/concerns/funnel_resync_trigger.rb
+++ b/app/models/concerns/funnel_resync_trigger.rb
@@ -1,0 +1,17 @@
+# Mixed into the models whose creation can advance a user's funnel stage (see
+# User::Funnel). Creating one pushes the owning user to the front of the
+# Airtable sync queue so the new stage reaches Airtable -> Loops within ~a
+# minute instead of waiting for UserSyncJob's slow round-robin — which is what
+# keeps re-engagement emails from firing on a stale stage.
+module FunnelResyncTrigger
+  extend ActiveSupport::Concern
+
+  included do
+    after_create_commit { user&.flag_for_resync! if funnel_milestone? }
+  end
+
+  # Whether this record advances the funnel. True by default (the model only
+  # exists at the funnel step it represents); models where only some records
+  # count — e.g. Post — override it.
+  def funnel_milestone? = true
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -25,6 +25,7 @@
 #
 class Post < ApplicationRecord
     include Gorse::SyncablePost
+    include FunnelResyncTrigger
 
     has_paper_trail
 
@@ -99,6 +100,10 @@ class Post < ApplicationRecord
     def repost?
       postable_type == "Post::Repost"
     end
+
+    # Only a first devlog or ship advances the funnel (see FunnelResyncTrigger);
+    # comments, reposts, fire events, etc. don't.
+    def funnel_milestone? = %w[Post::Devlog Post::ShipEvent].include?(postable_type)
 
     # Reposts surface the original post's content, so a view of the repost
     # also counts as a unique view of the original.

--- a/app/models/project/membership.rb
+++ b/app/models/project/membership.rb
@@ -21,6 +21,8 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Project::Membership < ApplicationRecord
+  include FunnelResyncTrigger
+
   has_paper_trail
 
   belongs_to :user

--- a/app/models/shop_order.rb
+++ b/app/models/shop_order.rb
@@ -62,6 +62,7 @@ class ShopOrder < ApplicationRecord
 
   include AASM
   include Ledgerable
+  include FunnelResyncTrigger
 
   belongs_to :user
   belongs_to :shop_item

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -239,6 +239,7 @@ class User < ApplicationRecord
   include User::Preferences
   include User::UsernameBloomSync
   include User::Streakable
+  include User::Funnel
 
   # Tracks platform signups/verifications for the raffle referral program
   # (no-ops unless the signup carried a raffle referral code). See the engine.

--- a/app/models/user/funnel.rb
+++ b/app/models/user/funnel.rb
@@ -25,12 +25,27 @@ module User::Funnel
     shipped
   ].freeze
 
+  included do
+    # Onboarding is the only funnel step recorded on the user record itself
+    # (the rest are separate records — see FunnelResyncTrigger). Push the user
+    # to the front of the Airtable sync queue when it flips.
+    after_update_commit :flag_for_resync!, if: :saved_change_to_onboarded_at?
+  end
+
   # Symbol of the furthest funnel step the user has reached (always at least
   # :signed_up, since every user has a created_at).
   def funnel_stage = current_funnel_step.first
 
   # When the user reached their current stage — i.e. when they got "stuck".
   def funnel_stage_entered_at = current_funnel_step.last
+
+  # Force this user to the front of the Airtable sync queue: records_to_sync
+  # orders by `synced_at ASC NULLS FIRST`, so nulling it makes the next
+  # UserSyncJob run pick them up ahead of the round-robin. Called whenever a
+  # funnel-advancing record is created (FunnelResyncTrigger) or onboarding
+  # completes, so a stage change can't sit stale long enough to mis-fire a
+  # re-engagement email. update_column = one cheap UPDATE, no callbacks.
+  def flag_for_resync! = update_column(:synced_at, nil)
 
   private
 

--- a/app/models/user/funnel.rb
+++ b/app/models/user/funnel.rb
@@ -1,0 +1,57 @@
+# The product activation funnel, in order. Each step maps to the timestamp at
+# which the user first reached it (nil if not reached yet). A user's current
+# stage is the furthest step they've reached; they are "stuck" once they've sat
+# at that step without advancing.
+#
+# Rails only reports *which* stage and *when* it was entered — it deliberately
+# does not decide "stuck for 2 days" or send anything. That lives downstream:
+# Airtable::UserSyncJob mirrors these two fields into the `_users` table, an
+# Airtable formula derives days-in-stage, and the existing Airtable -> Loops
+# sync sends a one-per-stage re-engagement nudge. Keeping the threshold out of
+# Rails means no "have we already notified?" bookkeeping here.
+module User::Funnel
+  extend ActiveSupport::Concern
+
+  # Canonical order. Mirrors the signup-funnel dashboard.
+  STAGES = %i[
+    signed_up
+    onboarded
+    project_created
+    hca_linked
+    hackatime_connected
+    hackatime_project_linked
+    devlog_posted
+    shop_order_placed
+    shipped
+  ].freeze
+
+  # Symbol of the furthest funnel step the user has reached (always at least
+  # :signed_up, since every user has a created_at).
+  def funnel_stage = current_funnel_step.first
+
+  # When the user reached their current stage — i.e. when they got "stuck".
+  def funnel_stage_entered_at = current_funnel_step.last
+
+  private
+
+  # [stage, reached_at] for the highest-ordered step with a timestamp.
+  def current_funnel_step
+    funnel_step_timestamps
+      .compact
+      .max_by { |stage, _at| STAGES.index(stage) }
+  end
+
+  def funnel_step_timestamps
+    {
+      signed_up: created_at,
+      onboarded: onboarded_at,
+      project_created: projects.minimum(:created_at),
+      hca_linked: hack_club_identity&.created_at,
+      hackatime_connected: hackatime_identity&.created_at,
+      hackatime_project_linked: hackatime_projects.minimum(:created_at),
+      devlog_posted: Post.where(user_id: id, postable_type: "Post::Devlog").minimum(:created_at),
+      shop_order_placed: shop_orders.minimum(:created_at),
+      shipped: Post.where(user_id: id, postable_type: "Post::ShipEvent").minimum(:created_at)
+    }
+  end
+end

--- a/app/models/user/hackatime_project.rb
+++ b/app/models/user/hackatime_project.rb
@@ -22,6 +22,8 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class User::HackatimeProject < ApplicationRecord
+  include FunnelResyncTrigger
+
   belongs_to :user
   belongs_to :project, optional: true
 

--- a/app/models/user/identity.rb
+++ b/app/models/user/identity.rb
@@ -26,6 +26,8 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class User::Identity < ApplicationRecord
+  include FunnelResyncTrigger
+
   belongs_to :user
   has_encrypted :access_token, :refresh_token
   blind_index :access_token, :refresh_token, slow: true

--- a/test/models/user/funnel_test.rb
+++ b/test/models/user/funnel_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class User::FunnelTest < ActiveSupport::TestCase
+  setup { @user = users(:one) }
+
+  test "a brand-new user is at :signed_up, entered at created_at" do
+    created = @user.created_at
+    stub_funnel(signed_up: created) do
+      assert_equal :signed_up, @user.funnel_stage
+      assert_equal created, @user.funnel_stage_entered_at
+    end
+  end
+
+  test "reports the furthest reached step and when it was entered" do
+    devlog_at = 3.days.ago
+    stub_funnel(
+      signed_up: 10.days.ago,
+      onboarded: 9.days.ago,
+      project_created: 5.days.ago,
+      devlog_posted: devlog_at
+    ) do
+      assert_equal :devlog_posted, @user.funnel_stage
+      assert_equal devlog_at, @user.funnel_stage_entered_at
+    end
+  end
+
+  test "picks the highest-ordered step even when earlier steps were skipped" do
+    hca_at = 2.days.ago
+    # HCA linked but no project created — funnel order, not recency, decides.
+    stub_funnel(signed_up: 8.days.ago, hca_linked: hca_at) do
+      assert_equal :hca_linked, @user.funnel_stage
+      assert_equal hca_at, @user.funnel_stage_entered_at
+    end
+  end
+
+  private
+
+  # The per-step timestamps come from six different associations; stub them so
+  # the test exercises the ordering logic, not fixture plumbing. Assertions run
+  # inside the yielded block, while the stub is in place.
+  def stub_funnel(timestamps, &block)
+    full = User::Funnel::STAGES.index_with { nil }.merge(timestamps)
+    @user.stub(:funnel_step_timestamps, full, &block)
+  end
+end


### PR DESCRIPTION
## what's this do?

adds a funnel stage and timestamp to the airtable sync

## ai?

claude
