### PR TITLE
Label each recording tile with its source (Lapse / Lookout)

### DIFF
--- a/app/assets/stylesheets/pages/certification/_recording_gallery.scss
+++ b/app/assets/stylesheets/pages/certification/_recording_gallery.scss
@@ -34,6 +34,21 @@
     border: 1px solid var(--color-space-border, rgba(255, 255, 255, 0.1));
   }
 
+  // Which tool captured the clip (Lapse / Lookout), overlaid on the thumbnail
+  // so a reviewer can tell the source at a glance in the merged gallery.
+  &__source {
+    position: absolute;
+    top: var(--space-xs);
+    left: var(--space-xs);
+    z-index: 1;
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    background: rgba(8, 6, 30, 0.78);
+    color: var(--color-brand-mint);
+    font-size: 0.7rem;
+    font-weight: 600;
+  }
+
   &__video {
     width: 100%;
     height: 100%;

--- a/app/views/admin/certification/funding_requests/_recording_gallery.html.erb
+++ b/app/views/admin/certification/funding_requests/_recording_gallery.html.erb
@@ -1,8 +1,8 @@
 <%# Reusable video-gallery panel for the hardware funding review. Locals:
       title:      panel heading
       empty_text: shown when items is blank
-      items:      array of { video_url:, poster_url:, processing:, name:,
-                  duration: (seconds), recorded_at: (Time or nil) } %>
+      items:      array of { source:, video_url:, poster_url:, processing:,
+                  name:, duration: (seconds), recorded_at: (Time or nil) } %>
 <div class="ship-review__panel recording-gallery">
   <h2 class="ship-review__panel-title"><%= title %></h2>
 
@@ -13,6 +13,9 @@
       <% items.each do |item| %>
         <li class="recording-gallery__item">
           <div class="recording-gallery__media">
+            <% if item[:source].present? %>
+              <span class="recording-gallery__source"><%= item[:source] %></span>
+            <% end %>
             <% if item[:video_url].present? %>
               <video controls playsinline preload="none"
                      class="recording-gallery__video"

--- a/app/views/admin/certification/funding_requests/_recordings.html.erb
+++ b/app/views/admin/certification/funding_requests/_recordings.html.erb
@@ -6,6 +6,7 @@
 <%
   items = Array(timelapses).map do |tl|
     {
+      source: "Lapse",
       video_url: tl[:playbackUrl],
       poster_url: tl[:thumbnailUrl],
       name: tl[:name].presence || "Untitled recording",
@@ -17,6 +18,7 @@
 
   items += Array(recordings).map do |rec|
     {
+      source: "Lookout",
       video_url: rec[:video_url],
       poster_url: rec[:thumbnail_url],
       name: rec[:mode].present? ? "#{rec[:mode].capitalize} recording" : "Screen recording",


### PR DESCRIPTION
## What this does

Adds a small **source badge** ("Lapse" or "Lookout") to each tile in the **Recordings** gallery on the hardware funding review page, so a reviewer can tell at a glance which tool captured each clip.

This is a follow-up to the merged Lookout work (PR #673): that PR combined Lapse timelapses and Lookout screen recordings into a single, date-sorted "Recordings" gallery. This adds back the per-video source label that the merge dropped — keeping the unified gallery, just tagging each tile.

## Why a separate PR

This commit was made right after #673 had already merged, so it landed on a dead branch instead of in main. Cherry-picked cleanly onto current `main` here so it can ship.

## How

- Each item is tagged `source: "Lapse"` / `"Lookout"` when the two sources are merged in the `_recordings` partial.
- The badge is a small mint pill overlaid on the top-left of each thumbnail, styled with Stardance tokens.

## Testing

- Verified live earlier: 13 tiles rendered with **11 Lapse + 2 Lookout** badges, on the merged gallery.
- ERB syntax clean; view/CSS-only change (no model/schema/migration touched).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> View and CSS-only change on an admin certification page; no auth, data, or API behavior changes.
> 
> **Overview**
> Restores **per-tile source labels** on the merged hardware funding **Recordings** gallery so reviewers can see whether each clip came from **Lapse** or **Lookout** without splitting the list.
> 
> When timelapses and Lookout recordings are combined in `_recordings`, each item now carries `source: "Lapse"` or `"Lookout"`. The shared `_recording_gallery` partial renders that value as a small mint pill on the top-left of the thumbnail when present, with new `.recording-gallery__source` styles on the existing media container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f62be94aee0db1ac9d7d39d1f1279e6c53506ac5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->