### PR TITLE
fix: disable link to devlog on devlog page

### DIFF
--- a/app/components/posts/card_component.rb
+++ b/app/components/posts/card_component.rb
@@ -4,9 +4,9 @@ module Posts
   class CardComponent < ViewComponent::Base
     delegate :inline_svg_tag, to: :helpers
 
-    attr_reader :post, :current_user, :theme, :compact, :show_likes, :show_comments, :show_reposts, :show_actions, :source, :position, :page, :feed_request_id, :track_engagement, :current_user_reposted_post_ids, :show_views
+    attr_reader :post, :current_user, :theme, :compact, :show_likes, :show_comments, :show_reposts, :show_actions, :source, :position, :page, :feed_request_id, :track_engagement, :current_user_reposted_post_ids, :show_views, :clickable
 
-    def initialize(post:, current_user: nil, theme: :feed, compact: false, show_likes: true, show_comments: true, show_reposts: true, show_actions: true, source: nil, position: nil, page: nil, feed_request_id: nil, track_engagement: true, current_user_reposted_post_ids: nil, show_views: nil)
+    def initialize(post:, current_user: nil, theme: :feed, compact: false, show_likes: true, show_comments: true, show_reposts: true, show_actions: true, source: nil, position: nil, page: nil, feed_request_id: nil, track_engagement: true, current_user_reposted_post_ids: nil, show_views: nil, clickable: true)
       @post = post
       @current_user = current_user
       @theme = theme
@@ -22,6 +22,7 @@ module Posts
       @track_engagement = track_engagement
       @current_user_reposted_post_ids = current_user_reposted_post_ids
       @show_views = show_views
+      @clickable = clickable
     end
 
     def render?
@@ -47,7 +48,7 @@ module Posts
     def card_classes
       class_names(
         "feed-post-card",
-        "feed-post-card--linked": card_link_url.present?,
+        "feed-post-card--linked": card_link_url.present? && clickable,
         "feed-post-card--compact": compact,
         "feed-post-card--quote-repost": quote_repost?,
         "feed-post-card--#{theme}": theme.present?
@@ -60,7 +61,9 @@ module Posts
       return data if url.blank?
 
       controllers = [ data[:controller], "card-link" ].compact.join(" ")
-      actions = [ data[:action], "click->card-link#navigate auxclick->card-link#navigate" ].compact.join(" ")
+      if clickable
+        actions = [ data[:action], "click->card-link#navigate auxclick->card-link#navigate" ].compact.join(" ")
+      end
 
       data.merge(
         controller: controllers,

--- a/app/views/projects/devlogs/show.html.erb
+++ b/app/views/projects/devlogs/show.html.erb
@@ -24,7 +24,8 @@
               post: @post,
               current_user: current_user,
               show_comments: false,
-              show_actions: current_user.present?
+              show_actions: current_user.present?,
+              clickable: false
             ) %>
       </article>
 


### PR DESCRIPTION
## what's this do?

On a devlog page, the devlog was originally clickable, which meant it would link to itself.

I added a `clickable` parameter which disables the link, it defaults to true so will not affect other areas of code.

## show it works

https://github.com/user-attachments/assets/9d10eef8-a341-4a27-ae16-6e90c1d43613


## ai?

nope
