### PR TITLE
fix(certification): fix broken changes requested button on YSWS returned projects

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -407,7 +407,7 @@ class Project < ApplicationRecord
     end
 
     event :return_for_changes do
-      transitions from: :under_review, to: :needs_changes
+      transitions from: [ :under_review, :approved ], to: :needs_changes
     end
 
     event :resubmit_for_review do


### PR DESCRIPTION
When a project was approved but later returned by YSWS and then sent back by Shipwrights again, the state machine failed to transition because `return_for_changes` only allowed transitions from the :under_review state. This left the project in :approved, which hid the recertification modal and disabled the "Changes requested" button.

So I updated the AASM configuration to allow the return_for_changes transition from both :under_review and :approved states.