### PR TITLE
feat(funnel): nudge the first incomplete step, not the furthest reached

### DIFF
--- a/app/models/user/funnel.rb
+++ b/app/models/user/funnel.rb
@@ -1,7 +1,11 @@
 # The product activation funnel, in order. Each step maps to the timestamp at
-# which the user first reached it (nil if not reached yet). A user's current
-# stage is the furthest step they've reached; they are "stuck" once they've sat
-# at that step without advancing.
+# which the user first reached it (nil if not reached yet). funnel_stage is the
+# earliest step they HAVEN'T completed — the next action to nudge them toward —
+# and funnel_stage_entered_at is when they last made forward progress (their
+# "stuck since"). Because steps can be completed out of order (e.g. HCA can be
+# linked before a project exists), we report the first *gap* rather than the
+# furthest step reached, so a user who skipped an earlier step still gets
+# nudged to fill it. Once every step is done the stage is :completed.
 #
 # Rails only reports *which* stage and *when* it was entered — it deliberately
 # does not decide "stuck for 2 days" or send anything. That lives downstream:
@@ -32,12 +36,12 @@ module User::Funnel
     after_update_commit :flag_for_resync!, if: :saved_change_to_onboarded_at?
   end
 
-  # Symbol of the furthest funnel step the user has reached (always at least
-  # :signed_up, since every user has a created_at).
-  def funnel_stage = current_funnel_step.first
+  # The earliest funnel step the user hasn't completed — the next action to
+  # nudge them toward — or :completed once every step is done.
+  def funnel_stage = funnel_progress.first
 
-  # When the user reached their current stage — i.e. when they got "stuck".
-  def funnel_stage_entered_at = current_funnel_step.last
+  # When the user last made forward progress — their "stuck since".
+  def funnel_stage_entered_at = funnel_progress.last
 
   # Force this user to the front of the Airtable sync queue: records_to_sync
   # orders by `synced_at ASC NULLS FIRST`, so nulling it makes the next
@@ -49,11 +53,13 @@ module User::Funnel
 
   private
 
-  # [stage, reached_at] for the highest-ordered step with a timestamp.
-  def current_funnel_step
-    funnel_step_timestamps
-      .compact
-      .max_by { |stage, _at| STAGES.index(stage) }
+  # [next_incomplete_step, last_progress_at]. signed_up is always present
+  # (created_at), so the gap is never :signed_up; when there's no gap left the
+  # user has finished the funnel and the stage is :completed.
+  def funnel_progress
+    timestamps = funnel_step_timestamps
+    next_step = STAGES.find { |stage| timestamps[stage].nil? } || :completed
+    [ next_step, timestamps.values.compact.max ]
   end
 
   def funnel_step_timestamps

--- a/test/models/user/funnel_test.rb
+++ b/test/models/user/funnel_test.rb
@@ -3,40 +3,42 @@ require "test_helper"
 class User::FunnelTest < ActiveSupport::TestCase
   setup { @user = users(:one) }
 
-  test "a brand-new user is at :signed_up, entered at created_at" do
+  test "a brand-new user is nudged to onboard, stuck since signup" do
     created = @user.created_at
     stub_funnel(signed_up: created) do
-      assert_equal :signed_up, @user.funnel_stage
+      assert_equal :onboarded, @user.funnel_stage
       assert_equal created, @user.funnel_stage_entered_at
     end
   end
 
-  test "reports the furthest reached step and when it was entered" do
-    devlog_at = 3.days.ago
-    stub_funnel(
-      signed_up: 10.days.ago,
-      onboarded: 9.days.ago,
-      project_created: 5.days.ago,
-      devlog_posted: devlog_at
-    ) do
-      assert_equal :devlog_posted, @user.funnel_stage
-      assert_equal devlog_at, @user.funnel_stage_entered_at
+  test "reports the first incomplete step and when they last progressed" do
+    onboarded_at = 4.days.ago
+    stub_funnel(signed_up: 10.days.ago, onboarded: onboarded_at) do
+      assert_equal :project_created, @user.funnel_stage
+      assert_equal onboarded_at, @user.funnel_stage_entered_at
     end
   end
 
-  test "picks the highest-ordered step even when earlier steps were skipped" do
+  test "an out-of-order step does not skip an earlier gap" do
     hca_at = 2.days.ago
-    # HCA linked but no project created — funnel order, not recency, decides.
-    stub_funnel(signed_up: 8.days.ago, hca_linked: hca_at) do
-      assert_equal :hca_linked, @user.funnel_stage
+    # HCA linked but no project — they should still be nudged to create one,
+    # and be "stuck" since their most recent progress (linking HCA).
+    stub_funnel(signed_up: 8.days.ago, onboarded: 6.days.ago, hca_linked: hca_at) do
+      assert_equal :project_created, @user.funnel_stage
       assert_equal hca_at, @user.funnel_stage_entered_at
+    end
+  end
+
+  test "a user who finished every step is :completed" do
+    stub_funnel(User::Funnel::STAGES.index_with { 1.day.ago }) do
+      assert_equal :completed, @user.funnel_stage
     end
   end
 
   private
 
   # The per-step timestamps come from six different associations; stub them so
-  # the test exercises the ordering logic, not fixture plumbing. Assertions run
+  # the test exercises the gap logic, not fixture plumbing. Assertions run
   # inside the yielded block, while the stub is in place.
   def stub_funnel(timestamps, &block)
     full = User::Funnel::STAGES.index_with { nil }.merge(timestamps)


### PR DESCRIPTION
## what's this do?

previously, a user was tagged as the funnel category they were the farthest into. Because there are some parallel tasks, this would occasionally nudge people to complete a task that they were unable to complete because they had not completed the prior task. Now, users are categorized based on their first uncompleted task, allowing us to nudge based on the closest next step.

## ai?

claude
