### PR TITLE
Add a Hackpad filter to the funding review queue

### DIFF
--- a/app/assets/stylesheets/pages/certification/ships/_index.scss
+++ b/app/assets/stylesheets/pages/certification/ships/_index.scss
@@ -507,6 +507,22 @@
     gap: var(--space-xs);
   }
 
+  // Category tag on a queue row (e.g. Hackpad) — a pill, not a status.
+  &__tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 8px;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 700;
+    white-space: nowrap;
+
+    &--hackpad {
+      background: rgba(235, 183, 255, 0.18);
+      color: var(--color-brand-lilac);
+    }
+  }
+
   // Submitter, relative age, and the claim flag all share one meta line under
   // the project title — keeps the table to three columns with no dead space.
   &__project-meta {

--- a/app/controllers/admin/certification/funding_requests_controller.rb
+++ b/app/controllers/admin/certification/funding_requests_controller.rb
@@ -26,6 +26,13 @@ class Admin::Certification::FundingRequestsController < Admin::Certification::Ap
                                     scope.order(created_at: @sort == "newest" ? :desc : :asc),
                                     limit: 25)
 
+    # Which of the displayed rows are Hackpad projects (one query, so the view
+    # can flag them without an N+1 of Project#current_mission per row).
+    @hackpad_project_ids = hackpad_project_ids
+                             .where(project_id: @funding_requests.map(&:project_id))
+                             .pluck(:project_id)
+                             .to_set
+
     @stats = ::Certification::FundingRequest.dashboard_stats
     @lb_period = params[:lb].presence_in(%w[daily weekly alltime]) || "daily"
     @leaderboards = {

--- a/app/controllers/admin/certification/funding_requests_controller.rb
+++ b/app/controllers/admin/certification/funding_requests_controller.rb
@@ -10,6 +10,7 @@ class Admin::Certification::FundingRequestsController < Admin::Certification::Ap
     @status = params[:status].presence_in(%w[pending approved returned all]) || "pending"
     @sort = params[:sort] == "newest" ? "newest" : "oldest"
     @search = params[:search].to_s.strip
+    @project_kind = params[:project_kind].presence_in(%w[all hackpad]) || "all"
     @from = parse_date(params[:from])
     @to = parse_date(params[:to])
 
@@ -19,6 +20,7 @@ class Admin::Certification::FundingRequestsController < Admin::Certification::Ap
     scope = scope.where("certification_funding_requests.created_at >= ?", @from.beginning_of_day) if @from
     scope = scope.where("certification_funding_requests.created_at <= ?", @to.end_of_day) if @to
     scope = apply_search(scope) if @search.present?
+    scope = scope.where(project_id: hackpad_project_ids) if @project_kind == "hackpad"
 
     @pagy, @funding_requests = pagy(:offset,
                                     scope.order(created_at: @sort == "newest" ? :desc : :asc),
@@ -75,6 +77,16 @@ class Admin::Certification::FundingRequestsController < Admin::Certification::Ap
 
   def set_funding_request
     @funding_request = ::Certification::FundingRequest.find(params[:id])
+  end
+
+  # Project ids whose current (active, non-detached) mission is the Hackpad
+  # mission — i.e. "hackpad projects" (mirrors Project#current_mission, which a
+  # project has at most one of). Used to filter the funding queue.
+  def hackpad_project_ids
+    Project::MissionAttachment.active
+      .joins(:mission)
+      .where(missions: { slug: "hackpad" })
+      .select(:project_id)
   end
 
   # Both fetches below fan out to live HTTP (per Hackatime key / Lookout session)

--- a/app/views/admin/certification/funding_requests/index.html.erb
+++ b/app/views/admin/certification/funding_requests/index.html.erb
@@ -205,6 +205,9 @@
                   <div class="ship-queue__project-head">
                     <%= link_to fr.project.title, admin_certification_funding_request_path(fr), class: "ship-queue__project-title" %>
                     <span class="ship-queue__project-id">#<%= fr.id %></span>
+                    <% if @hackpad_project_ids.include?(fr.project_id) %>
+                      <span class="ship-queue__tag ship-queue__tag--hackpad">Hackpad</span>
+                    <% end %>
                   </div>
                   <div class="ship-queue__project-meta">
                     <span>by <%= owner&.display_name || "—" %></span>
@@ -235,7 +238,12 @@
           <% owner = fr.project.memberships.find(&:owner?)&.user %>
           <%= link_to admin_certification_funding_request_path(fr), class: "ship-queue__card" do %>
             <div class="ship-queue__card-top">
-              <span class="ship-queue__project-title"><%= fr.project.title %></span>
+              <span class="ship-queue__project-title">
+                <%= fr.project.title %>
+                <% if @hackpad_project_ids.include?(fr.project_id) %>
+                  <span class="ship-queue__tag ship-queue__tag--hackpad">Hackpad</span>
+                <% end %>
+              </span>
               <span class="status-pill status-pill--<%= fr.status %>"><%= fr.status.capitalize %></span>
             </div>
             <div class="ship-queue__project-meta">

--- a/app/views/admin/certification/funding_requests/index.html.erb
+++ b/app/views/admin/certification/funding_requests/index.html.erb
@@ -148,6 +148,13 @@
               data: { action: "change->certification--queue#submit" } %>
       </div>
       <div class="ship-queue__filter">
+        <label for="filter-project-kind">Project</label>
+        <%= select_tag :project_kind,
+              options_for_select([["All projects", "all"], ["Hackpad", "hackpad"]], @project_kind),
+              id: "filter-project-kind", class: "ship-queue__select",
+              data: { action: "change->certification--queue#submit" } %>
+      </div>
+      <div class="ship-queue__filter">
         <label for="filter-sort">Sort</label>
         <%= select_tag :sort,
               options_for_select([["Oldest first", "oldest"], ["Newest first", "newest"]], @sort),


### PR DESCRIPTION
## What this does

Adds a **Hackpad** filter to the hardware funding review queue (`admin/certification/funding_requests#index`). Reviewers can now narrow the queue to **Hackpad projects** — projects whose current (active) mission is the Hackpad mission.

## How

- New **"Project"** filter select (`All projects` / `Hackpad`) next to the existing Status/Sort/Date filters, auto-submitting on change like the others.
- A project is "Hackpad" when it has an active (non-detached) mission attachment to the mission with slug `hackpad` — this mirrors `Project#current_mission` (a project has at most one active mission attachment, enforced by a unique index).
- The controller scopes funding requests by those project ids when the filter is set.

## Testing

Verified locally against a seeded scenario: attaching the Hackpad mission to a project makes its funding request appear under the filter (count 1); detaching it drops it back out (count 0). The page renders 200 with the filter control, and the dropdown reflects the active selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Admin-only queue filtering and display; no changes to approval logic or the “Start reviewing” flow.
> 
> **Overview**
> Adds a **Project** filter on the hardware **funding review queue** so reviewers can show **All projects** or **Hackpad only**. Hackpad rows are projects whose active mission attachment is the mission with slug `hackpad` (same idea as `Project#current_mission`).
> 
> The index action reads `project_kind`, scopes funding requests to those project ids when Hackpad is selected, and preloads a set of Hackpad project ids for the current page so the table and mobile cards can show a **Hackpad** pill without per-row mission lookups. Styling adds a lilac `ship-queue__tag` pill on queue rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 228e53fae6a734c13fe922c56b1a6887234eb326. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->