### PR TITLE
fix(outpost): change presentable hardware project to super hardware builder

### DIFF
--- a/app/models/achievement.rb
+++ b/app/models/achievement.rb
@@ -37,7 +37,7 @@ Achievement = Data.define(:slug, :name, :description, :icon, :earned_check, :pro
     ),
     new(
       slug: :manual_outpost_ticket_approval,
-      name: "Presentable Hardware Project",
+      name: "Super Hardware Builder",
       description: "Got a hardware project polished enough to show off. Unlocks the Outpost Ticket.",
       icon: "rocket",
       # Manual-only: an admin grants/revokes this via the Outpost Ticket toggle

--- a/db/seeds/outpost_ticket.rb
+++ b/db/seeds/outpost_ticket.rb
@@ -1,7 +1,7 @@
 hq_source = ShopSource.find_by!(slug: "hq")
 
 outpost_ticket = ShopItem::OutpostTicket.find_or_create_by!(name: "Outpost Ticket") do |item|
-  item.description = "Your ticket to the Outpost. Unlocked once you have a presentable hardware project."
+  item.description = "Your ticket to the Outpost. Unlocked once you have Super Hardware Builder."
   item.long_description = "Earn this by building a hardware project worth showing off. Getting your design funded discounts the ticket by your tier — 30% at B, 50% at A, and 100% at S and X — and any overflow goes toward a flight stipend."
   item.ticket_cost = User::OUTPOST_TICKET_BASE
   item.enabled = true


### PR DESCRIPTION
## what's this do?

changes the text presentable hardware project to super hardware builder

## show it works

shop:
<img width="1829" height="850" alt="image" src="https://github.com/user-attachments/assets/fcf9d6c9-7355-4955-95df-b5b266e01737" />

achievement notification:
<img width="1085" height="132" alt="image" src="https://github.com/user-attachments/assets/fc70311a-272e-4216-af0e-39575a357576" />

## ai?

nope