### PR TITLE
Reject-and-detach option for mission submissions

### DIFF
--- a/app/assets/stylesheets/pages/admin/_mission_submissions.scss
+++ b/app/assets/stylesheets/pages/admin/_mission_submissions.scss
@@ -830,6 +830,26 @@
     resize: vertical;
   }
 
+  &__detach {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xxs);
+  }
+
+  &__detach-option {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    cursor: pointer;
+    font-size: 0.95rem;
+  }
+
+  &__detach-hint {
+    font-size: 0.85rem;
+    color: var(--muted);
+    margin: 0;
+  }
+
   &__payout-note {
     font-size: 0.9rem;
     color: var(--color-brand-yellow);

--- a/app/controllers/admin/missions/submissions_controller.rb
+++ b/app/controllers/admin/missions/submissions_controller.rb
@@ -3,6 +3,10 @@ module Admin
     class SubmissionsController < BaseController
       layout "application"
 
+      # Stardust deducted from the builder when a reviewer rejects and detaches
+      # their project from the mission.
+      DETACH_PENALTY = 5
+
       skip_before_action :authorize_mission_management
       before_action :release_other_claims, only: [ :next, :claim ]
       before_action :set_submission, only: [ :show, :update, :claim, :undo ]
@@ -93,6 +97,10 @@ module Admin
                       alert: "This submission can't be #{new_status} right now." and return
         end
 
+        detach_requested = new_status == "rejected" &&
+                           ActiveModel::Type::Boolean.new.cast(params.dig(:mission_submission, :detach_project))
+        detached = false
+
         Mission::Submission.transaction do
           if new_status == "approved"
             @submission.update!(reviewed_by: current_user, reviewed_at: Time.current, rejection_message: nil)
@@ -102,14 +110,16 @@ module Admin
           else
             @submission.update!(reviewed_by: current_user, reviewed_at: Time.current, rejection_message: feedback)
             @submission.reject!
+            detached = detach_submission_project! if detach_requested
           end
         end
 
         notify_builder(new_status)
 
         reviewed = Mission::Submission.reviewed_today(current_user, mission: @mission)
+        verdict = detached ? "Rejected and detached the project (−#{DETACH_PENALTY} stardust)" : new_status.titleize
         redirect_to next_admin_mission_submissions_path(mission_slug),
-                    notice: "#{new_status.titleize}. That's #{reviewed} reviewed today."
+                    notice: "#{verdict}. That's #{reviewed} reviewed today."
       end
 
       def next
@@ -278,6 +288,35 @@ module Admin
           amount: -net,
           reason: "Mission reversal: #{@submission.mission.name}",
           created_by: "mission_submission:#{@submission.id} undo (#{current_user.id})"
+        )
+      end
+
+      # Detaches the submission's project from the mission it was rejected on,
+      # but only while that mission is still the project's current one — so we
+      # never yank a mission the builder has since swapped to. Charges the
+      # builder DETACH_PENALTY stardust when it actually detaches, and returns
+      # whether a detach happened. The MissionAttachment change is versioned by
+      # PaperTrail and the ledger entry writes its own balance_adjustment audit
+      # (whodunnit set in the admin controller chain).
+      def detach_submission_project!
+        project = @submission.ship_event&.post&.project
+        return false unless project
+        return false unless project.current_mission == @submission.mission
+
+        project.detach_mission!
+        charge_detach_penalty
+        true
+      end
+
+      def charge_detach_penalty
+        builder = @submission.ship_event&.post&.user
+        return unless builder
+
+        builder.ledger_entries.create!(
+          amount: -DETACH_PENALTY,
+          reason: "Mission detach penalty: #{@submission.mission.name}",
+          created_by: "mission_submission:#{@submission.id} detach (#{current_user.id})",
+          ledgerable: builder
         )
       end
 

--- a/app/controllers/admin/missions/submissions_controller.rb
+++ b/app/controllers/admin/missions/submissions_controller.rb
@@ -3,10 +3,6 @@ module Admin
     class SubmissionsController < BaseController
       layout "application"
 
-      # Stardust deducted from the builder when a reviewer rejects and detaches
-      # their project from the mission.
-      DETACH_PENALTY = 5
-
       skip_before_action :authorize_mission_management
       before_action :release_other_claims, only: [ :next, :claim ]
       before_action :set_submission, only: [ :show, :update, :claim, :undo ]
@@ -117,7 +113,7 @@ module Admin
         notify_builder(new_status)
 
         reviewed = Mission::Submission.reviewed_today(current_user, mission: @mission)
-        verdict = detached ? "Rejected and detached the project (−#{DETACH_PENALTY} stardust)" : new_status.titleize
+        verdict = detached ? "Rejected and detached the project" : new_status.titleize
         redirect_to next_admin_mission_submissions_path(mission_slug),
                     notice: "#{verdict}. That's #{reviewed} reviewed today."
       end
@@ -293,31 +289,16 @@ module Admin
 
       # Detaches the submission's project from the mission it was rejected on,
       # but only while that mission is still the project's current one — so we
-      # never yank a mission the builder has since swapped to. Charges the
-      # builder DETACH_PENALTY stardust when it actually detaches, and returns
-      # whether a detach happened. The MissionAttachment change is versioned by
-      # PaperTrail and the ledger entry writes its own balance_adjustment audit
-      # (whodunnit set in the admin controller chain).
+      # never yank a mission the builder has since swapped to. Returns whether
+      # a detach actually happened. The MissionAttachment change is versioned
+      # by PaperTrail (whodunnit set in the admin controller chain).
       def detach_submission_project!
         project = @submission.ship_event&.post&.project
         return false unless project
         return false unless project.current_mission == @submission.mission
 
         project.detach_mission!
-        charge_detach_penalty
         true
-      end
-
-      def charge_detach_penalty
-        builder = @submission.ship_event&.post&.user
-        return unless builder
-
-        builder.ledger_entries.create!(
-          amount: -DETACH_PENALTY,
-          reason: "Mission detach penalty: #{@submission.mission.name}",
-          created_by: "mission_submission:#{@submission.id} detach (#{current_user.id})",
-          ledgerable: builder
-        )
       end
 
       def notify_builder(status)

--- a/app/views/admin/missions/submissions/_form.html.erb
+++ b/app/views/admin/missions/submissions/_form.html.erb
@@ -21,6 +21,17 @@
           placeholder: "Required for rejections. Optional for approvals." %>
   </label>
 
+  <div class="mission-review__detach">
+    <label class="mission-review__detach-option">
+      <%= check_box_tag "mission_submission[detach_project]", "1", false %>
+      Also detach this project from the mission
+    </label>
+    <p class="mission-review__detach-hint">
+      Only applies when rejecting. Frees the project from <%= mission.name %> so
+      the builder can pick a different mission, and deducts 5 stardust from them.
+    </p>
+  </div>
+
   <% grants = [] %>
   <% if submission.payout_path == "static_prize" %>
     <% grants << "#{mission.fixed_stardust_payout} stardust" if mission.fixed_stardust_payout&.positive? %>

--- a/app/views/admin/missions/submissions/_form.html.erb
+++ b/app/views/admin/missions/submissions/_form.html.erb
@@ -28,7 +28,7 @@
     </label>
     <p class="mission-review__detach-hint">
       Only applies when rejecting. Frees the project from <%= mission.name %> so
-      the builder can pick a different mission, and deducts 5 stardust from them.
+      the builder can pick a different mission.
     </p>
   </div>
 

--- a/test/controllers/admin/missions/submissions_controller_test.rb
+++ b/test/controllers/admin/missions/submissions_controller_test.rb
@@ -44,28 +44,24 @@ class Admin::Missions::SubmissionsControllerTest < ActionDispatch::IntegrationTe
     assert @submission.reload.pending?
   end
 
-  test "plain reject leaves the project attached and the balance untouched" do
+  test "plain reject leaves the project attached to the mission" do
     sign_in @reviewer
     Mission::Submission.atomic_claim!(@submission.id, @reviewer)
 
-    assert_no_difference -> { @builder.reload.balance } do
-      patch admin_mission_submission_path(@mission.slug, @submission),
-            params: { mission_submission: { status: "rejected", feedback: "Needs work" } }
-    end
+    patch admin_mission_submission_path(@mission.slug, @submission),
+          params: { mission_submission: { status: "rejected", feedback: "Needs work" } }
 
     assert_redirected_to next_admin_mission_submissions_path(@mission.slug)
     assert @submission.reload.rejected?
     assert_equal @mission, @project.reload.current_mission
   end
 
-  test "reject and detach frees the project and deducts 5 stardust" do
+  test "reject and detach frees the project from the mission" do
     sign_in @reviewer
     Mission::Submission.atomic_claim!(@submission.id, @reviewer)
 
-    assert_difference -> { @builder.reload.balance }, -5 do
-      patch admin_mission_submission_path(@mission.slug, @submission),
-            params: { mission_submission: { status: "rejected", feedback: "Needs work", detach_project: "1" } }
-    end
+    patch admin_mission_submission_path(@mission.slug, @submission),
+          params: { mission_submission: { status: "rejected", feedback: "Needs work", detach_project: "1" } }
 
     assert_redirected_to next_admin_mission_submissions_path(@mission.slug)
     assert @submission.reload.rejected?
@@ -76,10 +72,8 @@ class Admin::Missions::SubmissionsControllerTest < ActionDispatch::IntegrationTe
     sign_in @reviewer
     Mission::Submission.atomic_claim!(@submission.id, @reviewer)
 
-    assert_no_difference -> { @builder.reload.balance } do
-      patch admin_mission_submission_path(@mission.slug, @submission),
-            params: { mission_submission: { status: "approved", detach_project: "1" } }
-    end
+    patch admin_mission_submission_path(@mission.slug, @submission),
+          params: { mission_submission: { status: "approved", detach_project: "1" } }
 
     assert @submission.reload.approved?
     assert_equal @mission, @project.reload.current_mission

--- a/test/controllers/admin/missions/submissions_controller_test.rb
+++ b/test/controllers/admin/missions/submissions_controller_test.rb
@@ -44,6 +44,47 @@ class Admin::Missions::SubmissionsControllerTest < ActionDispatch::IntegrationTe
     assert @submission.reload.pending?
   end
 
+  test "plain reject leaves the project attached and the balance untouched" do
+    sign_in @reviewer
+    Mission::Submission.atomic_claim!(@submission.id, @reviewer)
+
+    assert_no_difference -> { @builder.reload.balance } do
+      patch admin_mission_submission_path(@mission.slug, @submission),
+            params: { mission_submission: { status: "rejected", feedback: "Needs work" } }
+    end
+
+    assert_redirected_to next_admin_mission_submissions_path(@mission.slug)
+    assert @submission.reload.rejected?
+    assert_equal @mission, @project.reload.current_mission
+  end
+
+  test "reject and detach frees the project and deducts 5 stardust" do
+    sign_in @reviewer
+    Mission::Submission.atomic_claim!(@submission.id, @reviewer)
+
+    assert_difference -> { @builder.reload.balance }, -5 do
+      patch admin_mission_submission_path(@mission.slug, @submission),
+            params: { mission_submission: { status: "rejected", feedback: "Needs work", detach_project: "1" } }
+    end
+
+    assert_redirected_to next_admin_mission_submissions_path(@mission.slug)
+    assert @submission.reload.rejected?
+    assert_nil @project.reload.current_mission
+  end
+
+  test "detach flag is ignored when approving" do
+    sign_in @reviewer
+    Mission::Submission.atomic_claim!(@submission.id, @reviewer)
+
+    assert_no_difference -> { @builder.reload.balance } do
+      patch admin_mission_submission_path(@mission.slug, @submission),
+            params: { mission_submission: { status: "approved", detach_project: "1" } }
+    end
+
+    assert @submission.reload.approved?
+    assert_equal @mission, @project.reload.current_mission
+  end
+
   test "claims are exclusive while fresh and stealable when expired" do
     other = User.create!(email: "other-#{SecureRandom.hex(4)}@example.test",
                          display_name: "other-#{SecureRandom.hex(4)}",


### PR DESCRIPTION
## What & why

On `/admin/missions/<mission>/submissions` the reviewer could only **Approve** or **Reject**. When a submission was rejected the project stayed attached to that mission, so the builder was stuck on the mission they'd just been rejected from with no clean way to move on.

This adds a third path: **reject *and* detach the project from the mission**, freeing the builder to pick a different mission.

## The flow

The verdict form now has a "Also detach this project from the mission" checkbox. It only takes effect on **rejections** (ignored on approve):

- **Plain reject** — rejects the submission, project keeps its mission. Unchanged behaviour.
- **Reject + detach** — rejects and detaches the project from the mission so the builder can pick a different one.

## How it works

- Detach reuses the existing `Project#detach_mission!` (soft-detaches the `MissionAttachment`).
- The detach is **guarded**: it only fires while the rejected mission is still the project's *current* mission, so a mission the builder has since swapped to is never yanked.
- Runs inside the existing reject transaction.

## Audit / papertrail

- `Project::MissionAttachment` has `has_paper_trail`, so the detach is versioned, with whodunnit set via the admin controller chain (attributed to the reviewer).

No migration — reuses the existing soft-detach column.

## Tests

- Plain reject → project keeps mission
- Reject + detach → project freed from the mission
- Detach flag ignored when approving

```
3 runs, 12 assertions, 0 failures, 0 errors
```
(Rubocop clean on the changed files.)

## Notes

- **Undo:** `undo` moves a submission back to pending but does **not** re-attach the mission. Detach is intentionally a one-way reviewer action; flag if you want undo to reverse it too.
- **Fallback mission:** `detach_mission!` re-attaches a fallback if the project previously shipped (non-rejected) to another mission — a shipped project never goes mission-less. For a typical first rejection there's no fallback, so the project just becomes mission-free.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission attachment state on reject (guarded to current mission only) inside the existing transaction; undo does not re-attach per PR notes.
> 
> **Overview**
> Mission reviewers can optionally **detach the builder's project from the mission** when rejecting a submission, so the builder is not stuck on a mission they failed.
> 
> The review verdict form adds an **"Also detach this project from the mission"** checkbox (with hint copy and styling). On **reject**, if that flag is set, the update action calls new **`detach_submission_project!`**, which uses existing **`Project#detach_mission!`** only when the submission's mission is still the project's **current** mission. **Approve** ignores the flag; plain reject behavior is unchanged. The flash notice reflects when a detach actually occurred.
> 
> Controller tests cover plain reject, reject+detach, and detach ignored on approve.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e62b7ff73953a674d7d212fead90ec4b70825ee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->