### PR TITLE
Exclude hardware from ship certification queue

### DIFF
--- a/app/controllers/admin/certification/ships/claims_controller.rb
+++ b/app/controllers/admin/certification/ships/claims_controller.rb
@@ -7,12 +7,12 @@ class Admin::Certification::Ships::ClaimsController < Admin::Certification::Appl
   def create
     authorize @ship, policy_class: Admin::Certification::Ships::ClaimPolicy
 
-    ::Certification::Ship.release_all_for(current_user)
+    release_surface_claims
     claimed = ::Certification::Ship.atomic_claim!(@ship.id, current_user)
     if claimed
-      redirect_to hardware_redirect? ? hardware_review_path : admin_certification_ship_path(claimed)
+      redirect_to hardware_surface? ? hardware_review_path : admin_certification_ship_path(claimed)
     else
-      redirect_to hardware_redirect? ? hardware_review_path : admin_certification_ships_path,
+      redirect_to hardware_surface? ? hardware_review_path : admin_certification_ships_path,
                   alert: "Couldn't claim that review, someone else got it"
     end
   end
@@ -22,7 +22,7 @@ class Admin::Certification::Ships::ClaimsController < Admin::Certification::Appl
     authorize @ship, policy_class: Admin::Certification::Ships::ClaimPolicy
 
     @ship.release_claim!
-    redirect_to hardware_redirect? ? hardware_review_path : admin_certification_ship_path(@ship),
+    redirect_to hardware_surface? ? hardware_review_path : admin_certification_ship_path(@ship),
                 notice: "Unclaimed review for \u201c#{@ship.project.title}.\u201d"
   end
 
@@ -36,6 +36,20 @@ class Admin::Certification::Ships::ClaimsController < Admin::Certification::Appl
   # the reviewer sent back to it rather than to the ship queue.
   def hardware_redirect?
     params[:redirect_to_hardware].present?
+  end
+
+  def hardware_surface?
+    hardware_redirect? || @ship.project&.hardware?
+  end
+
+  def release_surface_claims
+    scope = if hardware_surface?
+      ::Certification::Ship.joins(:project).where.not(projects: { hardware_stage: nil })
+    else
+      ::Certification::Ship.non_hardware
+    end
+
+    scope.release_all_for(current_user)
   end
 
   def hardware_review_path

--- a/app/controllers/admin/certification/ships_controller.rb
+++ b/app/controllers/admin/certification/ships_controller.rb
@@ -1,6 +1,7 @@
 class Admin::Certification::ShipsController < Admin::Certification::ApplicationController
   before_action :release_other_claims, only: [ :next ]
   before_action :set_ship, only: [ :show, :update, :set_project_type, :report_fraud ]
+  before_action :redirect_hardware_ship_review, only: [ :show ]
   before_action :set_submitter_context, only: [ :show, :update ]
   before_action :set_body_class, only: [ :index, :show, :update, :logs ]
 
@@ -14,7 +15,7 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
     @to           = parse_date(params[:to])
     @project_type = params[:project_type].presence
 
-    scope = policy_scope(::Certification::Ship)
+    scope = policy_scope(::Certification::Ship).merge(::Certification::Ship.non_hardware)
     scope = scope.where(status: @status) unless @status == "all"
     scope = scope.where("certification_ship_reviews.created_at >= ?", @from.beginning_of_day) if @from
     scope = scope.where("certification_ship_reviews.created_at <= ?", @to.end_of_day) if @to
@@ -36,12 +37,12 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
 
     @own_project_ids = current_user.memberships.pluck(:project_id).to_set
 
-    @stats = ::Certification::Ship.dashboard_stats
+    @stats = ::Certification::Ship.non_hardware.dashboard_stats
     @lb_period = params[:lb].presence_in(%w[daily weekly alltime]) || "daily"
     @leaderboards = {
-      "daily" => ::Certification::Ship.leaderboard(:daily),
-      "weekly" => ::Certification::Ship.leaderboard(:weekly),
-      "alltime" => ::Certification::Ship.leaderboard(:alltime)
+      "daily" => ::Certification::Ship.non_hardware.leaderboard(:daily),
+      "weekly" => ::Certification::Ship.non_hardware.leaderboard(:weekly),
+      "alltime" => ::Certification::Ship.non_hardware.leaderboard(:alltime)
     }
   end
 
@@ -55,6 +56,7 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
     @to = parse_date(params[:to])
 
     scope = policy_scope(::Certification::Ship)
+              .merge(::Certification::Ship.non_hardware)
               .where.not(status: :pending)
               .includes(:reviewer, project: { memberships: :user })
 
@@ -139,7 +141,7 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
   def next
     authorize ::Certification::Ship
     skip_ids = parse_skip_ids
-    candidate = ::Certification::Ship.next_eligible(current_user, skip_ids: skip_ids)
+    candidate = ::Certification::Ship.non_hardware.next_eligible(current_user, skip_ids: skip_ids)
     if candidate.nil?
       redirect_to admin_certification_ships_path, notice: "Queue is empty." and return
     end
@@ -163,6 +165,16 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
 
   def set_ship
     @ship = ::Certification::Ship.find(params[:id])
+  end
+
+  def redirect_hardware_ship_review
+    return unless @ship.project&.hardware?
+
+    if Flipper.enabled?(:hardware_flow, current_user)
+      redirect_to admin_certification_hardware_review_path(@ship.project_id)
+    else
+      head :not_found
+    end
   end
 
   def ship_redirect_path
@@ -199,7 +211,7 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
   end
 
   def release_other_claims
-    ::Certification::Ship.release_all_for(current_user) if current_user.present?
+    ::Certification::Ship.non_hardware.release_all_for(current_user) if current_user.present?
   end
 
   def parse_skip_ids

--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -103,6 +103,10 @@ module Certification
         .where.not(project_id: user.memberships.select(:project_id))
     }
 
+    scope :non_hardware, -> {
+      joins(:project).where(projects: { hardware_stage: nil })
+    }
+
     scope :by_project_type, ->(type) {
       type == "unclassified" \
         ? joins(:project).where(projects: { project_type: nil })
@@ -123,6 +127,7 @@ module Certification
     # (every reviewer shares one queue), so this is intentionally not scoped
     # to the current user the way the listing is.
     def self.dashboard_stats(now: Time.current)
+      ships_table = table_name
       today = now.beginning_of_day
       week = now.beginning_of_week
       approved_count = where(status: :approved).count
@@ -138,7 +143,7 @@ module Certification
       end
 
       avg_decision_secs = decided.where.not(decided_at: nil)
-        .average(Arel.sql("EXTRACT(EPOCH FROM (decided_at - created_at))"))
+        .average(Arel.sql("EXTRACT(EPOCH FROM (#{ships_table}.decided_at - #{ships_table}.created_at))"))
       avg_decision_hours = avg_decision_secs ? (avg_decision_secs / 3600.0).round(1) : nil
 
       {
@@ -154,7 +159,7 @@ module Certification
         oldest_pending: where(status: :pending).order(created_at: :asc).first,
         queue_target: QUEUE_TARGET,
         sla_days: SLA_DAYS,
-        overdue_pending: where(status: :pending).where("created_at < ?", now - SLA_DAYS.days).count,
+        overdue_pending: where(status: :pending).where("#{ships_table}.created_at < ?", now - SLA_DAYS.days).count,
         median_pending_wait_hours: median_pending_wait,
         avg_decision_hours: avg_decision_hours
       }


### PR DESCRIPTION
## Summary
- add a non_hardware scope for ship certification reviews
- exclude hardware projects from /admin/certification/ship index, logs, stats, leaderboard, and next-review claiming
- redirect direct hardware ship review GETs into the hardware review page
- isolate ship claim release behavior so normal ship claims do not release hardware build claims, and hardware claims do not release normal ship claims

## Base
Stacked on #688 (`valencia`). Merge #688 first, then this PR.

## Verification
- bin/lint
- bin/rails test test/models/certification/ship_test.rb test/policies/admin/certification/ship_policy_test.rb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reviewer routing, queue composition, and claim lifecycle for certification—wrong scoping could hide reviews or drop claims—but behavior is localized to admin certification controllers with a clear Flipper gate on redirects.
> 
> **Overview**
> Hardware ship certification is split from the standard Shipwright queue so reviewers use the dedicated hardware flow instead of the general ship list and “next review” path.
> 
> **`Certification::Ship.non_hardware`** filters reviews to projects with no `hardware_stage`. That scope is applied to the ship **index**, **logs**, **dashboard stats**, **leaderboards**, **`next`**, and **`release_other_claims`** so queue metrics and claiming only reflect software ships.
> 
> **Direct visits** to a hardware ship review **`show`** redirect to **`admin_certification_hardware_review`** when `:hardware_flow` is enabled; otherwise the response is **404**.
> 
> **Claim release** no longer clears every ship claim for the user. **`release_surface_claims`** releases only hardware-tagged ship claims on the hardware surface (redirect param or hardware project) and only **`non_hardware`** claims on the normal surface, so hardware and software claims do not stomp each other. Redirect helpers were renamed from **`hardware_redirect?`** to **`hardware_surface?`** for the same behavior plus hardware projects.
> 
> **`dashboard_stats`** qualifies `created_at` / `decided_at` with the ship table name so averages and overdue counts stay correct when the relation is merged with other joins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aede5ac6b8d83def94d1aabab75824db24cd2de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->