### PR TITLE
Fix: changed cachet.hackclub.com to dunkirk.sh host since the images have not propogated

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -111,6 +111,6 @@ class SearchController < ApplicationController
 
   def avatar_for(slack_id)
     return nil if slack_id.blank?
-    "https://cachet.hackclub.com/users/#{slack_id}/r"
+    "https://cachet.dunkirk.sh/users/#{slack_id}/r"
   end
 end

--- a/app/javascript/controllers/mention_autocomplete_controller.js
+++ b/app/javascript/controllers/mention_autocomplete_controller.js
@@ -250,7 +250,7 @@ export default class extends Controller {
   _avatarUrl(user) {
     if (user.avatar) return user.avatar;
     if (user.slack_id)
-      return `https://cachet.hackclub.com/users/${user.slack_id}/r`;
+      return `https://cachet.dunkirk.sh/users/${user.slack_id}/r`;
     return "";
   }
 

--- a/app/models/user/profile.rb
+++ b/app/models/user/profile.rb
@@ -12,7 +12,7 @@ module User::Profile
       variant = GUEST_AVATAR_VARIANTS[(id || 0) % GUEST_AVATAR_VARIANTS.size]
       ActionController::Base.helpers.image_path("avatars/#{variant}.png")
     else
-      "https://cachet.hackclub.com/users/#{slack_id}/r"
+      "https://cachet.dunkirk.sh/users/#{slack_id}/r"
     end
   end
 end


### PR DESCRIPTION
# Fix: Resolve default profile pictures by reverting CDN host to dunkirk.sh

This PR addresses a visual bug where user profile pictures (pfps) are displaying as the default green Slack avatars instead of the actual user images.
Root Cause

The caching CDN for Hack Club's Slack data is currently being onboarded to a new domain (https://cachet.hackclub.com). This new domain routes to a separate storage bucket where the profile photos have not yet fully propagated, causing the system to fall back to the default Slack avatars.

Reverted the host URL from cachet.hackclub.com back to the original https://cachet.dunkirk.sh. This routes the requests back to the Slack edge where the images are successfully cached, restoring the correct profile pictures while the new bucket finishes propagating.

This update modifies the base CDN URL string across our Ruby and JavaScript controllers. This change only affects the application at runtime when fetching images. Because the avatar URLs are constructed dynamically on-the-fly using the user's slack_id (e.g., `https://cachet.dunkirk.sh/users/${user.slack_id}/r`), it does not impact any build-time assets or static file compilation.

Files Changed:

    app/controllers/search_controller.rb

    app/javascript/controllers/mention_autocomplete_controller.js

    app/models/user/profile.rb