### PR TITLE
feat(projects): Button that opens a projects linked github

### DIFF
--- a/app/assets/stylesheets/pages/projects/_show.scss
+++ b/app/assets/stylesheets/pages/projects/_show.scss
@@ -714,6 +714,16 @@ turbo-frame#project_hero {
   }
 }
 
+.project-show__pill--github {
+  gap: 6px;
+}
+
+.project-show__github-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
 // Author avatars stack horizontally with a slight overlap, like a multi-user
 // chip in chat apps.
 .project-show__byline {

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -440,6 +440,17 @@
               <div class="project-show__panel-actions">
                 <%= render "projects/fire_controls", project: @project %>
 
+                <% if @project.repo_url.present? %>
+                  <%= link_to @project.repo_url,
+                              class: "project-show__pill project-show__pill--outline project-show__pill--github",
+                              target: "_blank",
+                              rel: "noopener noreferrer",
+                              aria: { label: "View source on GitHub" } do %>
+                    <%= inline_svg_tag "icons/github.svg", class: "project-show__github-icon" %>
+                    Source
+                  <% end %>
+                <% end %>
+
                 <% if can_edit_project %>
                   <%= link_to "Edit project", project_path(@project, editing: true),
                               class: "project-show__pill project-show__pill--outline",

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -440,8 +440,8 @@
               <div class="project-show__panel-actions">
                 <%= render "projects/fire_controls", project: @project %>
 
-                <% if @project.repo_url.present? %>
-                  <%= link_to @project.repo_url,
+                <% if (safe_repo_url = safe_external_url(@project.repo_url)) %>
+                  <%= link_to safe_repo_url,
                               class: "project-show__pill project-show__pill--outline project-show__pill--github",
                               target: "_blank",
                               rel: "noopener noreferrer",


### PR DESCRIPTION
## what's this do?

if a project has a github linked, a button will show on its project page to go to it. implementing [this](https://hackclub.slack.com/archives/C0AR0M43H61/p1782420829883239?thread_ts=1782420093.035289&cid=C0AR0M43H61)

## show it works

<img width="1084" height="605" alt="image" src="https://github.com/user-attachments/assets/3889ace0-099c-4a86-9c0f-2171817487e5" />

## ai?

a bit of sonnet because erb is weird