### PR TITLE
Fix vertical/portrait media getting cropped in single-attachment posts

### DIFF
--- a/app/assets/stylesheets/components/_feed.scss
+++ b/app/assets/stylesheets/components/_feed.scss
@@ -902,9 +902,14 @@
     grid-template-columns: 1fr;
   }
 
+  // A single attachment keeps its own aspect ratio (height-capped) instead of
+  // being forced into a 16:9 box. A forced landscape box cropped portrait /
+  // vertical videos to their top slice and clipped the native video controls
+  // out of reach via overflow: hidden.
   &__media[data-count="1"] &__media-slide {
-    aspect-ratio: 16 / 9;
-    max-height: 420px;
+    aspect-ratio: auto;
+    max-height: min(70vh, 560px);
+    overflow: visible;
   }
 
   &__media[data-count="3"] &__media-slide:first-child {
@@ -918,6 +923,14 @@
     height: 100%;
     display: block;
     object-fit: contain;
+  }
+
+  // For the single-attachment case, follow the media's natural height (capped)
+  // so nothing is cropped; multi-item grids still fill their square slots above.
+  &__media[data-count="1"] &__image,
+  &__media[data-count="1"] &__video {
+    height: auto;
+    max-height: min(70vh, 560px);
   }
 
   &__file {


### PR DESCRIPTION
## What & why

Closes #627 and #635.

A devlog/post with a **single attachment** rendered its media into a fixed **16:9 slide** (`aspect-ratio: 16 / 9; max-height: 420px`) with `object-fit: contain` and `overflow: hidden` on the slide. For portrait images and vertical videos this:

- cropped the asset to its **top slice only** (#627, #635), and
- clipped the native **video controls** out of the box so they were unreachable (#627).

This matches @maxwofford's diagnosis on #627 that `feed-post-card__video` had an overflow cutoff it shouldn't have.

## The fix

For the single-attachment case only (`[data-count="1"]`), let the media keep its **own aspect ratio**, height-capped at `min(70vh, 560px)`, and set `overflow: visible` on the slide so video controls stay reachable. Multi-attachment grids are untouched (they still fill their square/16:9 slots).

```scss
&__media[data-count="1"] &__media-slide {
  aspect-ratio: auto;
  max-height: min(70vh, 560px);
  overflow: visible;
}

&__media[data-count="1"] &__image,
&__media[data-count="1"] &__video {
  height: auto;
  max-height: min(70vh, 560px);
}
```

Only `app/assets/stylesheets/components/_feed.scss` changes. The single render path is `app/views/shared/_post_media.html.erb`, used by both the feed and devlog detail pages, so the fix covers both surfaces.

## Verification

Reproduced the crop and validated the fix in an isolated harness using the exact compiled rules, against a 9:16 portrait, a 16:9 landscape, and a 2-up grid:

- **Portrait** — before: only the top ~16:9 slice visible, controls clipped. After: full asset visible, controls reachable. ✅
- **Landscape** — visually identical before/after (no regression). ✅
- **Multi-image grid** — unchanged. ✅

## Open questions

- `min(70vh, 560px)` is a judgement call for the height cap; happy to tune to whatever the team prefers.