### PR TITLE
fix: only be able to order enabled shop items!

### DIFF
--- a/app/controllers/shop/orders_controller.rb
+++ b/app/controllers/shop/orders_controller.rb
@@ -19,7 +19,7 @@ class Shop::OrdersController < Shop::BaseController
     @shop_item = ShopItem.find(params[:shop_item_id])
     @mission_submission = load_redeemable_submission(@shop_item)
 
-    unless @shop_item.enabled? || @mission_submission.present?
+    unless @shop_item.enabled?
       redirect_to shop_path, alert: "This item cannot be ordered."
       return
     end

--- a/app/models/shop_order.rb
+++ b/app/models/shop_order.rb
@@ -85,6 +85,7 @@ class ShopOrder < ApplicationRecord
 
   validates :quantity, presence: true, numericality: { only_integer: true, greater_than: 0 }, on: :create
   validates :frozen_address, presence: true, on: :create
+  validate :check_item_globally_available, on: :create
   validate :check_one_per_person_ever_limit, on: :create
   validate :check_max_quantity_limit, on: :create
   validate :check_user_balance, on: :create
@@ -342,6 +343,12 @@ class ShopOrder < ApplicationRecord
     # price for ordinary items.
     order_region = region.presence || Shop::Regionalizable.country_to_region(frozen_address&.dig("country"))
     self.frozen_item_price = shop_item.price_for_user(user, order_region || "XX")
+  end
+
+  def check_item_globally_available
+    return if shop_item.blank?
+
+    errors.add(:base, "This item is not available for purchase.") unless shop_item.enabled?
   end
 
   def check_one_per_person_ever_limit


### PR DESCRIPTION
## what's this do?
You wont be able to order mission only shop items if they are disabled (or any shop items)

## show it works
<img width="1233" height="145" alt="image" src="https://github.com/user-attachments/assets/62fba13a-2c1b-407e-ab73-052d481818f1" />
(the shop item is disabled)

## ai?
Claude