### PR TITLE
fix(hardware): Fix hackpad flow & UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,4 +79,4 @@ vendor
 
 .venv
 
-staff-search
+staff-search.worktrees/

--- a/app/assets/stylesheets/pages/_hardware_funding.scss
+++ b/app/assets/stylesheets/pages/_hardware_funding.scss
@@ -273,7 +273,9 @@ $outpost-teal: #34e0ba;
   font-size: 0.9rem;
   color: $outpost-ink;
   cursor: pointer;
-  transition: border-color 0.12s ease, background 0.12s ease;
+  transition:
+    border-color 0.12s ease,
+    background 0.12s ease;
 
   &:has(input:checked) {
     border-color: $outpost-orange;

--- a/app/assets/stylesheets/pages/_hardware_funding.scss
+++ b/app/assets/stylesheets/pages/_hardware_funding.scss
@@ -24,9 +24,15 @@ $outpost-teal: #34e0ba;
     color: #fff;
     font-weight: 800;
 
-    &:hover,
-    &:focus-visible {
+    &:hover:not(:disabled),
+    &:focus-visible:not(:disabled) {
       filter: brightness(1.05);
+    }
+
+    &:disabled {
+      background: rgba($outpost-ink, 0.15);
+      color: rgba($outpost-ink, 0.35);
+      cursor: not-allowed;
     }
   }
 
@@ -35,6 +41,67 @@ $outpost-teal: #34e0ba;
     border: 2px solid rgba($outpost-ink, 0.25);
     color: $outpost-ink;
   }
+}
+
+// "Do you need funding?" question step
+.funding-modal__question-heading {
+  margin: 0 0 1rem;
+  font-size: 1.1rem;
+  font-weight: 800;
+  text-align: center;
+  color: $outpost-ink;
+}
+
+.funding-modal__question-btns {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+}
+
+.funding-modal__question-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  font: inherit;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: filter 0.12s ease;
+
+  &:hover {
+    filter: brightness(1.06);
+  }
+
+  &--yes {
+    background: linear-gradient(180deg, $outpost-gold, $outpost-orange);
+    border: none;
+    color: #fff;
+  }
+
+  &--no {
+    background: rgba($outpost-ink, 0.08);
+    border: 2px solid rgba($outpost-ink, 0.2);
+    color: $outpost-ink;
+  }
+}
+
+.funding-modal__question-cancel {
+  display: flex;
+  justify-content: center;
+}
+
+.funding-modal__no-funding-note {
+  margin: 0 0 1rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: 10px;
+  background: color-mix(in srgb, $outpost-teal 22%, #fff);
+  border: 1px solid color-mix(in srgb, $outpost-teal 55%, #fff);
+  font-size: 0.95rem;
+  color: #0c6b58;
+  line-height: 1.45;
 }
 
 .funding-modal__header {
@@ -196,16 +263,39 @@ $outpost-teal: #34e0ba;
 
 .funding-modal__bom-check {
   display: flex;
-  align-items: center;
-  gap: 0.5rem;
+  align-items: flex-start;
+  gap: 0.6rem;
   margin-bottom: 1rem;
-  font-weight: 600;
+  padding: 0.65rem 0.75rem;
+  border: 2px solid rgba($outpost-ink, 0.2);
+  border-radius: 10px;
+  background: rgba($outpost-ink, 0.04);
   font-size: 0.9rem;
   color: $outpost-ink;
   cursor: pointer;
+  transition: border-color 0.12s ease, background 0.12s ease;
+
+  &:has(input:checked) {
+    border-color: $outpost-orange;
+    background: color-mix(in srgb, $outpost-orange 8%, #fff);
+  }
+
+  &--required {
+    border-color: rgba($outpost-orange, 0.6);
+    background: color-mix(in srgb, $outpost-orange 5%, #fff);
+  }
 
   input[type="checkbox"] {
+    flex: 0 0 auto;
+    margin-top: 2px;
+    width: 1.1rem;
+    height: 1.1rem;
     accent-color: $outpost-orange;
+    cursor: pointer;
+  }
+
+  strong {
+    color: $outpost-orange;
   }
 
   code {
@@ -214,6 +304,11 @@ $outpost-teal: #34e0ba;
     border-radius: 4px;
     font-size: 0.85em;
   }
+}
+
+// Hide the "up to $X" funding max when user selected the no-funding path
+.funding-modal__tiers--hide-max .funding-tier__max {
+  display: none;
 }
 
 // Inline tier-max validation error (shown on cream — red reads fine).

--- a/app/assets/stylesheets/pages/projects/_new.scss
+++ b/app/assets/stylesheets/pages/projects/_new.scss
@@ -467,12 +467,6 @@
   color: var(--color-space-text-muted);
 }
 
-.project-creation__stage-chooser--sub {
-  margin-top: var(--space-s);
-  padding-top: var(--space-s);
-  border-top: 1px solid rgba(255, 255, 255, 0.12);
-}
-
 // ── Mobile ───────────────────────────────────────────────────────────────────
 
 @media (max-width: 640px) {

--- a/app/assets/stylesheets/pages/projects/_new.scss
+++ b/app/assets/stylesheets/pages/projects/_new.scss
@@ -467,6 +467,12 @@
   color: var(--color-space-text-muted);
 }
 
+.project-creation__stage-chooser--sub {
+  margin-top: var(--space-s);
+  padding-top: var(--space-s);
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
 // ── Mobile ───────────────────────────────────────────────────────────────────
 
 @media (max-width: 640px) {

--- a/app/assets/stylesheets/pages/projects/_show.scss
+++ b/app/assets/stylesheets/pages/projects/_show.scss
@@ -206,6 +206,18 @@ turbo-frame#project_hero {
     background: var(--color-brand-orange-soft);
     color: var(--color-brand-orange);
   }
+
+  &--design {
+    background: rgba(#EBB7FF, 0.15);
+    color: #EBB7FF;
+    border: 1px solid rgba(#EBB7FF, 0.35);
+  }
+
+  &--build {
+    background: rgba(#81FFFF, 0.12);
+    color: #81FFFF;
+    border: 1px solid rgba(#81FFFF, 0.3);
+  }
 }
 
 .project-show__title-input {

--- a/app/assets/stylesheets/pages/projects/_show.scss
+++ b/app/assets/stylesheets/pages/projects/_show.scss
@@ -208,15 +208,15 @@ turbo-frame#project_hero {
   }
 
   &--design {
-    background: rgba(#EBB7FF, 0.15);
-    color: #EBB7FF;
-    border: 1px solid rgba(#EBB7FF, 0.35);
+    background: rgba(#ebb7ff, 0.15);
+    color: #ebb7ff;
+    border: 1px solid rgba(#ebb7ff, 0.35);
   }
 
   &--build {
-    background: rgba(#81FFFF, 0.12);
-    color: #81FFFF;
-    border: 1px solid rgba(#81FFFF, 0.3);
+    background: rgba(#81ffff, 0.12);
+    color: #81ffff;
+    border: 1px solid rgba(#81ffff, 0.3);
   }
 }
 

--- a/app/controllers/projects/funding_requests_controller.rb
+++ b/app/controllers/projects/funding_requests_controller.rb
@@ -16,9 +16,9 @@ class Projects::FundingRequestsController < ApplicationController
 
     track_event "funding_requested", { project_id: @project.id, complexity_tier: params[:complexity_tier] }
     redirect_to project_path(@project),
-                notice: "Funding request submitted! We'll review your design and get back to you."
+                notice: "Design submitted for review! We'll get back to you soon."
   rescue ActiveRecord::RecordNotUnique
-    redirect_to project_path(@project), alert: "You already have a funding request under review."
+    redirect_to project_path(@project), alert: "You already have a design review in progress."
   rescue ActiveRecord::RecordInvalid => e
     redirect_back fallback_location: project_path(@project),
                   alert: e.record.errors.full_messages.to_sentence

--- a/app/javascript/controllers/project_builder_controller.js
+++ b/app/javascript/controllers/project_builder_controller.js
@@ -1,10 +1,10 @@
 import { Controller } from "@hotwired/stimulus";
 
-// Reveals the hardware stage chooser on /projects/new.
-// Level 1: "I need Funding" (submits directly) | "I don't need Funding" (reveals level 2)
-// Level 2: "I'm still designing" | "I'm ready to build"
+// Reveals the Design/Build stage chooser on /projects/new when the user clicks
+// "New hardware project +". The collapsed chooser is marked inert so its
+// controls drop out of the tab order; a CSS grid-rows transition animates the reveal.
 export default class extends Controller {
-  static targets = ["chooser", "hardwareBtn", "subChooser", "noFundingBtn"];
+  static targets = ["chooser", "hardwareBtn"];
 
   toggle() {
     const open = !this.chooserTarget.classList.contains("is-open");
@@ -13,32 +13,6 @@ export default class extends Controller {
 
     if (this.hasHardwareBtnTarget) {
       this.hardwareBtnTarget.setAttribute("aria-expanded", String(open));
-    }
-
-    // Collapse sub-chooser when the top-level chooser is closed
-    if (!open && this.hasSubChooserTarget) {
-      this._closeSubChooser();
-    }
-  }
-
-  showNoFundingOptions(event) {
-    event.preventDefault();
-    if (!this.hasSubChooserTarget) return;
-
-    const open = !this.subChooserTarget.classList.contains("is-open");
-    this.subChooserTarget.classList.toggle("is-open", open);
-    this.subChooserTarget.inert = !open;
-
-    if (this.hasNoFundingBtnTarget) {
-      this.noFundingBtnTarget.setAttribute("aria-expanded", String(open));
-    }
-  }
-
-  _closeSubChooser() {
-    this.subChooserTarget.classList.remove("is-open");
-    this.subChooserTarget.inert = true;
-    if (this.hasNoFundingBtnTarget) {
-      this.noFundingBtnTarget.setAttribute("aria-expanded", "false");
     }
   }
 }

--- a/app/javascript/controllers/project_builder_controller.js
+++ b/app/javascript/controllers/project_builder_controller.js
@@ -1,12 +1,10 @@
 import { Controller } from "@hotwired/stimulus";
 
-// Reveals the Design/Build stage chooser on /projects/new when the user clicks
-// "Blank new hardware project +". Software projects submit immediately; hardware
-// projects pick a stage first. The collapsed chooser is marked inert so its
-// controls drop out of the tab order and the a11y tree; a CSS grid-rows
-// transition animates the visual reveal.
+// Reveals the hardware stage chooser on /projects/new.
+// Level 1: "I need Funding" (submits directly) | "I don't need Funding" (reveals level 2)
+// Level 2: "I'm still designing" | "I'm ready to build"
 export default class extends Controller {
-  static targets = ["chooser", "hardwareBtn"];
+  static targets = ["chooser", "hardwareBtn", "subChooser", "noFundingBtn"];
 
   toggle() {
     const open = !this.chooserTarget.classList.contains("is-open");
@@ -15,6 +13,32 @@ export default class extends Controller {
 
     if (this.hasHardwareBtnTarget) {
       this.hardwareBtnTarget.setAttribute("aria-expanded", String(open));
+    }
+
+    // Collapse sub-chooser when the top-level chooser is closed
+    if (!open && this.hasSubChooserTarget) {
+      this._closeSubChooser();
+    }
+  }
+
+  showNoFundingOptions(event) {
+    event.preventDefault();
+    if (!this.hasSubChooserTarget) return;
+
+    const open = !this.subChooserTarget.classList.contains("is-open");
+    this.subChooserTarget.classList.toggle("is-open", open);
+    this.subChooserTarget.inert = !open;
+
+    if (this.hasNoFundingBtnTarget) {
+      this.noFundingBtnTarget.setAttribute("aria-expanded", String(open));
+    }
+  }
+
+  _closeSubChooser() {
+    this.subChooserTarget.classList.remove("is-open");
+    this.subChooserTarget.inert = true;
+    if (this.hasNoFundingBtnTarget) {
+      this.noFundingBtnTarget.setAttribute("aria-expanded", "false");
     }
   }
 }

--- a/app/models/certification/funding_request.rb
+++ b/app/models/certification/funding_request.rb
@@ -92,7 +92,7 @@ module Certification
     end
 
     validates :complexity_tier, inclusion: { in: TIER_MAX_CENTS.keys }
-    validates :requested_amount_cents, numericality: { only_integer: true, greater_than: 0 }
+    validates :requested_amount_cents, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
     validates :approved_amount_cents,
               numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
     validates :feedback, length: { maximum: 10_000 }, allow_blank: true
@@ -296,6 +296,7 @@ module Certification
 
     def issue_hcb_grant!
       return if hcb_grant_hashid.present?
+      return if final_amount_cents.to_i == 0
 
       owner = project.memberships.owner.first&.user || user
       grant = HCBService.create_card_grant(

--- a/app/models/certification/funding_request.rb
+++ b/app/models/certification/funding_request.rb
@@ -318,9 +318,14 @@ module Certification
 
       case status.to_sym
       when :approved
-        owner.dm_user("Your hardware project '#{project.title}' was approved for $#{final_amount_dollars} in funding! It's switched to the build phase. Log your build hours with a timelapse and ship when you're ready.")
+        msg = if final_amount_cents.to_i > 0
+          "Your design review for '#{project.title}' was approved — you've been granted $#{final_amount_dollars} to buy your parts! Your project is now in the build phase. Log your build hours and ship when you're ready."
+        else
+          "Your design review for '#{project.title}' was approved! Your project is now in the build phase. Log your build hours and ship when you're ready."
+        end
+        owner.dm_user(msg)
       when :returned
-        msg = "Your funding request for '#{project.title}' needs changes before it can be approved."
+        msg = "Your design review for '#{project.title}' needs changes before it can be approved."
         msg += "\n\n#{feedback}" if feedback.present?
         owner.dm_user(msg)
       end

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -115,15 +115,45 @@
             </button>
           <% end %>
 
-          <%= form_with url: projects_path, method: :post, data: { turbo_frame: "_top" }, class: "project-creation__stage-form" do %>
-            <%= hidden_field_tag "project[title]", "Untitled" %>
-            <%= hidden_field_tag "project[hardware_stage]", "build" %>
-            <button type="submit" class="project-creation__stage-option">
+          <div class="project-creation__stage-form">
+            <button type="button"
+                    class="project-creation__stage-option"
+                    data-action="project-builder#showNoFundingOptions"
+                    data-project-builder-target="noFundingBtn"
+                    aria-expanded="false"
+                    aria-controls="project-creation-no-funding-chooser">
               <span class="project-creation__stage-label">I don't need Funding</span>
-              <span class="project-creation__stage-title">I don't need funding for my project</span>
-              <span class="project-creation__stage-subtext">I already have my parts and am ready to start building</span>
+              <span class="project-creation__stage-title">Hack Club provides a kit or I already have parts</span>
+              <span class="project-creation__stage-subtext">Tell us which phase you're in →</span>
             </button>
-          <% end %>
+          </div>
+        </div>
+
+        <div id="project-creation-no-funding-chooser"
+             class="project-creation__stage-chooser project-creation__stage-chooser--sub"
+             data-project-builder-target="subChooser"
+             inert>
+          <div class="project-creation__stage-chooser-inner">
+            <%= form_with url: projects_path, method: :post, data: { turbo_frame: "_top" }, class: "project-creation__stage-form" do %>
+              <%= hidden_field_tag "project[title]", "Untitled" %>
+              <%= hidden_field_tag "project[hardware_stage]", "design" %>
+              <button type="submit" class="project-creation__stage-option">
+                <span class="project-creation__stage-label">Still Designing</span>
+                <span class="project-creation__stage-title">I'm still working on my design</span>
+                <span class="project-creation__stage-subtext">Post devlogs and submit your design when it's ready</span>
+              </button>
+            <% end %>
+
+            <%= form_with url: projects_path, method: :post, data: { turbo_frame: "_top" }, class: "project-creation__stage-form" do %>
+              <%= hidden_field_tag "project[title]", "Untitled" %>
+              <%= hidden_field_tag "project[hardware_stage]", "build" %>
+              <button type="submit" class="project-creation__stage-option">
+                <span class="project-creation__stage-label">Ready to Build</span>
+                <span class="project-creation__stage-title">I have my parts and I'm ready to build</span>
+                <span class="project-creation__stage-subtext">Start logging build hours right away</span>
+              </button>
+            <% end %>
+          </div>
         </div>
       </div>
     </section>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -109,51 +109,21 @@
             <%= hidden_field_tag "project[title]", "Untitled" %>
             <%= hidden_field_tag "project[hardware_stage]", "design" %>
             <button type="submit" class="project-creation__stage-option">
-              <span class="project-creation__stage-label">I need Funding</span>
-              <span class="project-creation__stage-title">I need funding to buy parts for my project</span>
-              <span class="project-creation__stage-subtext">Submit your design and we'll fund your build</span>
+              <span class="project-creation__stage-label">Design Stage</span>
+              <span class="project-creation__stage-title">I'm still working on my design</span>
+              <span class="project-creation__stage-subtext">Post devlogs and submit your design for review when it's ready</span>
             </button>
           <% end %>
 
-          <div class="project-creation__stage-form">
-            <button type="button"
-                    class="project-creation__stage-option"
-                    data-action="project-builder#showNoFundingOptions"
-                    data-project-builder-target="noFundingBtn"
-                    aria-expanded="false"
-                    aria-controls="project-creation-no-funding-chooser">
-              <span class="project-creation__stage-label">I don't need Funding</span>
-              <span class="project-creation__stage-title">Hack Club provides a kit or I already have parts</span>
-              <span class="project-creation__stage-subtext">Tell us which phase you're in →</span>
+          <%= form_with url: projects_path, method: :post, data: { turbo_frame: "_top" }, class: "project-creation__stage-form" do %>
+            <%= hidden_field_tag "project[title]", "Untitled" %>
+            <%= hidden_field_tag "project[hardware_stage]", "build" %>
+            <button type="submit" class="project-creation__stage-option">
+              <span class="project-creation__stage-label">Build Stage</span>
+              <span class="project-creation__stage-title">I have my parts and I'm ready to build</span>
+              <span class="project-creation__stage-subtext">Start logging build hours right away</span>
             </button>
-          </div>
-        </div>
-
-        <div id="project-creation-no-funding-chooser"
-             class="project-creation__stage-chooser project-creation__stage-chooser--sub"
-             data-project-builder-target="subChooser"
-             inert>
-          <div class="project-creation__stage-chooser-inner">
-            <%= form_with url: projects_path, method: :post, data: { turbo_frame: "_top" }, class: "project-creation__stage-form" do %>
-              <%= hidden_field_tag "project[title]", "Untitled" %>
-              <%= hidden_field_tag "project[hardware_stage]", "design" %>
-              <button type="submit" class="project-creation__stage-option">
-                <span class="project-creation__stage-label">Still Designing</span>
-                <span class="project-creation__stage-title">I'm still working on my design</span>
-                <span class="project-creation__stage-subtext">Post devlogs and submit your design when it's ready</span>
-              </button>
-            <% end %>
-
-            <%= form_with url: projects_path, method: :post, data: { turbo_frame: "_top" }, class: "project-creation__stage-form" do %>
-              <%= hidden_field_tag "project[title]", "Untitled" %>
-              <%= hidden_field_tag "project[hardware_stage]", "build" %>
-              <button type="submit" class="project-creation__stage-option">
-                <span class="project-creation__stage-label">Ready to Build</span>
-                <span class="project-creation__stage-title">I have my parts and I'm ready to build</span>
-                <span class="project-creation__stage-subtext">Start logging build hours right away</span>
-              </button>
-            <% end %>
-          </div>
+          <% end %>
         </div>
       </div>
     </section>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -169,7 +169,7 @@
               <div class="project-show__field project-show__field--inline"
                    data-project-type-target="stageSection"
                    <%= "hidden" unless @project.hardware? %>>
-                <span>Project stage <%= render "projects/help_tooltip", text: "\"I need Funding\" means you're still designing and need a grant to buy parts. Submit your design for funding to move to building. \"I don't need Funding\" means you already have your parts and are building." %></span>
+                <span>Project stage <%= render "projects/help_tooltip", text: "\"Design Stage\" means you're working on your design. Submit your design to move to building. \"Build Stage\" means you have your parts and are actively building." %></span>
                 <% if @project.has_any_funding_request? %>
                   <% fr = @project.latest_funding_request %>
                   <div class="project-show__stage-toggle project-show__stage-toggle--locked" aria-label="Project stage (locked)">
@@ -192,11 +192,11 @@
                   <div class="project-show__stage-toggle" role="radiogroup" aria-label="Project stage">
                     <label class="project-show__stage-choice">
                       <%= form.radio_button :hardware_stage, "design", class: "project-show__stage-radio", disabled: !@project.hardware?, data: { "project-type-target": "stageRadio" } %>
-                      <span class="project-show__stage-choice-label">I need Funding</span>
+                      <span class="project-show__stage-choice-label">Design Stage</span>
                     </label>
                     <label class="project-show__stage-choice">
                       <%= form.radio_button :hardware_stage, "build", class: "project-show__stage-radio", disabled: !@project.hardware?, data: { "project-type-target": "stageRadio" } %>
-                      <span class="project-show__stage-choice-label">I don't need Funding</span>
+                      <span class="project-show__stage-choice-label">Build Stage</span>
                     </label>
                   </div>
                 <% end %>
@@ -386,6 +386,13 @@
                   <h1 class="project-show__title"><%= @project.title %></h1>
                   <% if @project.hardware? %>
                     <span class="project-show__tag project-show__tag--hardware">Hardware</span>
+                    <% if Flipper.enabled?(:hardware_flow, current_user) %>
+                      <% if @project.design_stage? %>
+                        <span class="project-show__tag project-show__tag--stage project-show__tag--design">Design Stage</span>
+                      <% elsif @project.build_stage? %>
+                        <span class="project-show__tag project-show__tag--stage project-show__tag--build">Build Stage</span>
+                      <% end %>
+                    <% end %>
                   <% end %>
                 </div>
                 <div class="project-show__byline">
@@ -575,7 +582,7 @@
                   ) %>
             <% elsif !@project.info_complete? %>
               <%= render ActionButtonComponent.new(
-                    text: "Submit Design to Get Project Funding",
+                    text: "Submit Design",
                     variant: :primary,
                     type: :button,
                     icon: "icons/rocket.png",
@@ -588,7 +595,7 @@
                   ) %>
             <% else %>
               <%= render ActionButtonComponent.new(
-                    text: "Submit Design to Get Project Funding",
+                    text: "Submit Design",
                     variant: :primary,
                     type: :button,
                     icon: "icons/rocket.png",
@@ -1096,21 +1103,52 @@
               class="ship-modal ship-modal--post funding-modal--outpost"
               data-controller="modal"
               aria-label="Request project funding">
+        <div class="ship-modal__panel funding-modal__panel" id="funding-modal-question-<%= @project.id %>">
+          <header class="funding-modal__header">
+            <%= image_tag "outpost.png", alt: "Outpost", class: "funding-modal__logo" %>
+            <p class="funding-modal__tagline">The greatest hardware adventure yet.</p>
+          </header>
+
+          <p class="funding-modal__question-heading">Do you need funding to buy parts?</p>
+
+          <div class="funding-modal__question-btns">
+            <button type="button"
+                    class="funding-modal__question-btn funding-modal__question-btn--yes"
+                    onclick="fundingShowForm(<%= @project.id.to_json %>, true)">
+              Yes, I need Hack Club to fund my parts
+            </button>
+            <button type="button"
+                    class="funding-modal__question-btn funding-modal__question-btn--no"
+                    onclick="fundingShowForm(<%= @project.id.to_json %>, false)">
+              No, I already have my parts or Hack Club is providing a kit
+            </button>
+          </div>
+
+          <div class="funding-modal__question-cancel">
+            <button type="button"
+                    class="ship-modal__btn ship-modal__btn--secondary"
+                    onclick="document.getElementById('funding-request-modal-' + <%= @project.id.to_json %>).close()">
+              Cancel
+            </button>
+          </div>
+        </div>
+
         <%= form_with url: project_funding_request_path(@project),
                       method: :post,
                       data: { turbo: false },
-                      html: { class: "ship-modal__form", data: { tier_maxes: Certification::FundingRequest::TIER_MAX_DOLLARS.to_json, tier_discounts: Certification::FundingRequest.tier_discount_summary.to_json } } do |form| %>
+                      html: { id: "funding-modal-form-#{@project.id}", class: "ship-modal__form", style: "display:none", data: { tier_maxes: Certification::FundingRequest::TIER_MAX_DOLLARS.to_json, tier_discounts: Certification::FundingRequest.tier_discount_summary.to_json } } do |form| %>
+          <%= form.hidden_field :requested_amount, value: "", id: "funding-modal-amount-#{@project.id}" %>
           <div class="ship-modal__panel funding-modal__panel">
             <header class="funding-modal__header">
               <%= image_tag "outpost.png", alt: "Outpost", class: "funding-modal__logo" %>
-              <p class="funding-modal__tagline">The greatest hardware adventure yet. Get your build funded.</p>
+              <p class="funding-modal__tagline" id="funding-modal-tagline-<%= @project.id %>"></p>
             </header>
 
-            <fieldset class="funding-modal__tiers">
+            <fieldset class="funding-modal__tiers" id="funding-modal-tiers-<%= @project.id %>">
               <legend>Pick your complexity tier</legend>
               <% Certification::FundingRequest::TIERS.each do |tier_id, t| %>
                 <label class="funding-tier">
-                  <%= form.radio_button :complexity_tier, tier_id, required: true, class: "funding-tier__input", onchange: "fundingValidate(this.form)" %>
+                  <%= form.radio_button :complexity_tier, tier_id, class: "funding-tier__input", required: true, onchange: "fundingValidate(this.form)" %>
                   <span class="funding-tier__badge funding-tier__badge--<%= t[:code].downcase %>"><%= t[:code] %></span>
                   <span class="funding-tier__info">
                     <span class="funding-tier__name"><%= t[:name] %></span>
@@ -1120,63 +1158,135 @@
                 </label>
               <% end %>
             </fieldset>
-
-            <label class="funding-modal__amount">
-              <span>Amount requested ($)</span>
-              <%= form.number_field :requested_amount, min: 1, step: 1, required: true, class: "funding-modal__amount-input", oninput: "fundingValidate(this.form)" %>
-            </label>
-            <p class="funding-request__error" role="alert" hidden></p>
             <p class="funding-modal__discount" role="status" hidden></p>
 
-            <p class="funding-modal__note">
-              Get your design approved to earn Stardust toward the Outpost Ticket — higher tiers cover more of it.
-              <%= link_to "How tiers work", guide_path("tiers"), class: "funding-modal__guide-link", target: "_blank", rel: "noopener" %>
-            </p>
+            <div id="funding-modal-funded-fields-<%= @project.id %>">
+              <label class="funding-modal__amount">
+                <span>Amount requested ($)</span>
+                <input type="number" name="requested_amount_display" min="0" step="1"
+                       class="funding-modal__amount-input"
+                       oninput="fundingValidate(this.form)">
+              </label>
+              <p class="funding-request__error" role="alert" hidden></p>
 
-            <label class="funding-modal__bom-check">
-              <input type="checkbox" required onchange="fundingValidate(this.form)">
-              <span>I have a <code>BOM.csv</code> in my repository</span>
-            </label>
+              <p class="funding-modal__note">
+                Get your design approved to earn Stardust toward the Outpost Ticket — higher tiers cover more of it.
+                <%= link_to "How tiers work", guide_path("tiers"), class: "funding-modal__guide-link", target: "_blank", rel: "noopener" %>
+              </p>
+
+              <label class="funding-modal__bom-check" id="funding-modal-bom-<%= @project.id %>">
+                <input type="checkbox" onchange="fundingValidate(this.form)">
+                <span>
+                  <strong>Required:</strong> I have a <code>BOM.csv</code> in my repository
+                </span>
+              </label>
+            </div>
+
+            <div id="funding-modal-no-funding-note-<%= @project.id %>" hidden>
+              <p class="funding-modal__no-funding-note">
+                We'll submit your design for review with <strong>$0 requested</strong>. Once approved, your project moves to the build stage and you'll earn the Outpost Ticket discount for your tier.
+              </p>
+            </div>
 
             <div class="ship-modal__actions">
               <button type="button"
                       class="ship-modal__btn ship-modal__btn--secondary"
-                      onclick="document.getElementById('funding-request-modal-' + <%= @project.id.to_json %>).close()">
-                Cancel
+                      onclick="fundingResetToQuestion(<%= @project.id.to_json %>)">
+                Back
               </button>
-              <%= form.submit "Submit for funding", class: "ship-modal__btn ship-modal__btn--primary funding-modal__submit", data: { disable_with: "Submitting…" } %>
+              <%= form.submit "Submit design", disabled: true, class: "ship-modal__btn ship-modal__btn--primary funding-modal__submit", data: { disable_with: "Submitting…" } %>
             </div>
           </div>
         <% end %>
       </dialog>
       <script>
+        function fundingShowForm(projectId, needsFunding) {
+          var question = document.getElementById("funding-modal-question-" + projectId);
+          var form = document.getElementById("funding-modal-form-" + projectId);
+          var amountInput = document.getElementById("funding-modal-amount-" + projectId);
+          var tagline = document.getElementById("funding-modal-tagline-" + projectId);
+          var fundedFields = document.getElementById("funding-modal-funded-fields-" + projectId);
+          var noFundingNote = document.getElementById("funding-modal-no-funding-note-" + projectId);
+          var submit = form ? form.querySelector('[type="submit"]') : null;
+
+          if (!question || !form) return;
+          question.style.display = "none";
+          form.style.display = "";
+          form.dataset.noFunding = needsFunding ? "" : "true";
+
+          var tiers = document.getElementById("funding-modal-tiers-" + projectId);
+          if (needsFunding) {
+            tagline.textContent = "Get your build funded.";
+            fundedFields.removeAttribute("hidden");
+            noFundingNote.setAttribute("hidden", "");
+            amountInput.value = "";
+            if (tiers) tiers.classList.remove("funding-modal__tiers--hide-max");
+            if (submit) submit.disabled = true;
+            fundingValidate(form);
+          } else {
+            tagline.textContent = "Submit your design for approval.";
+            fundedFields.setAttribute("hidden", "");
+            noFundingNote.removeAttribute("hidden");
+            amountInput.value = "0";
+            if (tiers) tiers.classList.add("funding-modal__tiers--hide-max");
+            var tier = form.querySelector('[name="complexity_tier"]:checked');
+            if (submit) submit.disabled = !tier;
+            fundingValidate(form);
+          }
+        }
+
+        function fundingResetToQuestion(projectId) {
+          var question = document.getElementById("funding-modal-question-" + projectId);
+          var form = document.getElementById("funding-modal-form-" + projectId);
+          if (!question || !form) return;
+          question.style.display = "";
+          form.style.display = "none";
+        }
+
         function fundingValidate(form) {
           if (!form) return;
+          var noFunding = form.dataset.noFunding === "true";
           var maxes = JSON.parse(form.dataset.tierMaxes || "{}");
           var discounts = JSON.parse(form.dataset.tierDiscounts || "{}");
           var tier = form.querySelector('[name="complexity_tier"]:checked');
-          var amountEl = form.querySelector('[name="requested_amount"]');
-          var err = form.querySelector(".funding-request__error");
+          var amountInput = form.querySelector('[name="requested_amount"]');
           var discountEl = form.querySelector(".funding-modal__discount");
           var submit = form.querySelector('[type="submit"]');
-          if (!amountEl || !err || !submit) return;
-          var amount = parseFloat(amountEl.value);
-          var max = tier ? maxes[tier.value] : null;
-          if (max != null) amountEl.max = max;
+          if (!submit || !amountInput) return;
 
-          var bomCheck = form.querySelector('.funding-modal__bom-check input[type="checkbox"]');
-          var bomMissing = bomCheck && !bomCheck.checked;
-          var over = max != null && !isNaN(amount) && amount > max;
-          err.textContent = over ? "This tier funds up to $" + max + ". Lower your request or pick a higher tier." : "";
-          err.hidden = !over;
-          submit.disabled = over || bomMissing;
+          if (noFunding) {
+            amountInput.value = "0";
+            submit.disabled = !tier;
+          } else {
+            var displayAmountEl = form.querySelector('[name="requested_amount_display"]');
+            var err = form.querySelector(".funding-request__error");
+            if (!displayAmountEl || !err) return;
+
+            var amount = parseFloat(displayAmountEl.value);
+            var max = tier ? maxes[tier.value] : null;
+            if (max != null) displayAmountEl.max = max;
+            amountInput.value = amountMissing ? "" : amount;
+
+            var bomLabel = form.querySelector('.funding-modal__bom-check');
+            var bomCheck = bomLabel ? bomLabel.querySelector('input[type="checkbox"]') : null;
+            var noTier = !tier;
+            var amountMissing = displayAmountEl.value === "" || isNaN(amount);
+            var over = max != null && !isNaN(amount) && amount > max;
+            var bomMissing = bomCheck && !bomCheck.checked;
+            err.textContent = over ? "This tier funds up to $" + max + ". Lower your request or pick a higher tier." : "";
+            err.hidden = !over;
+            submit.disabled = noTier || amountMissing || over || bomMissing;
+            if (bomLabel) {
+              bomLabel.classList.toggle("funding-modal__bom-check--required", !noTier && !amountMissing && !over && bomMissing);
+            }
+          }
 
           if (discountEl) {
             var d = tier ? discounts[tier.value] : null;
             if (d) {
               discountEl.textContent = d.pct >= 100
-                ? "Approved at " + d.code + " tier = a free Outpost Ticket (✦ " + d.sd + ", 100% off)."
-                : "Approved at " + d.code + " tier = " + d.pct + "% off the Outpost Ticket (✦ " + d.sd + ").";
+                ? d.code + " tier approval = free Outpost Ticket (✦" + d.sd + " stardust discount, 100% off)."
+                : d.code + " tier approval = " + d.pct + "% off the Outpost Ticket (✦" + d.sd + " stardust discount).";
               discountEl.hidden = false;
             } else {
               discountEl.hidden = true;

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -175,11 +175,11 @@
                   <div class="project-show__stage-toggle project-show__stage-toggle--locked" aria-label="Project stage (locked)">
                     <span class="project-show__stage-choice-label project-show__stage-choice-label--locked">
                       <% if fr.approved? %>
-                        Design Stage — $<%= fr.final_amount_dollars %> approved
+                        Design Stage — review approved<%= " ($#{fr.final_amount_dollars})" if fr.final_amount_cents.to_i > 0 %>
                       <% elsif fr.pending? %>
-                        Design Stage — $<%= fr.requested_amount_dollars %> under review
+                        Design Stage — review in progress
                       <% else %>
-                        Design Stage — funding returned
+                        Design Stage — review returned
                       <% end %>
                     </span>
                     <span class="project-show__stage-choice-label project-show__stage-choice-label--locked project-show__stage-choice-label--selected">
@@ -570,7 +570,7 @@
           <% if Flipper.enabled?(:hardware_flow, current_user) && is_member && @project.design_stage? %>
             <% if @project.has_pending_funding_request? %>
               <%= render ActionButtonComponent.new(
-                    text: "Funding request under review",
+                    text: "Design review in progress",
                     variant: :secondary,
                     type: :button,
                     disabled: :soft,

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1165,6 +1165,7 @@
                 <span>Amount requested ($)</span>
                 <input type="number" name="requested_amount_display" min="0" step="1"
                        class="funding-modal__amount-input"
+                       autocomplete="off"
                        oninput="fundingValidate(this.form)">
               </label>
               <p class="funding-request__error" role="alert" hidden></p>

--- a/test/models/certification/funding_request_test.rb
+++ b/test/models/certification/funding_request_test.rb
@@ -68,6 +68,25 @@ class Certification::FundingRequestTest < ActiveSupport::TestCase
     assert fr.errors[:requested_amount_cents].any?
   end
 
+  test "allows a $0 funding request for the no-grant (kit provided) path" do
+    fr = @project.certification_funding_requests.new(user: @owner, complexity_tier: 1, requested_amount_cents: 0)
+    assert fr.valid?, fr.errors.full_messages.to_sentence
+  end
+
+  test "approving a $0 request advances to build and accrues the discount without an HCB grant" do
+    fr = @project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 3, requested_amount_cents: 0, status: :pending
+    )
+    # No HCBService stub: a $0 request must NOT attempt to issue a card grant
+    # (issuing would hit the real service and raise).
+    fr.update!(reviewer: @reviewer, status: :approved)
+
+    assert_equal "build", @project.reload.hardware_stage
+    assert_nil fr.reload.hcb_grant_hashid
+    # tier 3 (S) flat discount still accrues toward the Outpost Ticket.
+    assert_equal 300, @owner.reload.outpost_discount_stardust
+  end
+
   test "approval switches the project to build and accrues the owner discount" do
     fr = @project.certification_funding_requests.create!(
       user: @owner, complexity_tier: 3, requested_amount_cents: 6_000, status: :pending


### PR DESCRIPTION
## what's this do?

The UX has been changed to show things in design/build stage, rather than needing funding or not needing funding. This is still asked, but it's part of the submission now. Previously, hackpad's just couldn't submit or were confusing to submit, this resolves both the submit issue and makes it more obvious how to do it.

## show it works

https://github.com/user-attachments/assets/69c576c1-7303-49d9-9f82-16549f3149cf
ignore the big Will, I had claude seed the db with an example project and it found this random picture in the repo.

## ai?

Claude Code w/ sonnet & honcho memory did most of it