### PR TITLE
fix(missions): make prize redemption override cost

### DIFF
--- a/app/javascript/controllers/order_form_controller.js
+++ b/app/javascript/controllers/order_form_controller.js
@@ -17,6 +17,7 @@ export default class extends Controller {
     hasAddresses: Boolean,
     baseTicketCost: Number,
     userBalance: Number,
+    free: Boolean,
     blockedCountries: Array,
     stardustIconUrl: String,
   };
@@ -211,8 +212,12 @@ export default class extends Controller {
     const modifiers = this.getSelectedModifiers();
     const accTotal = accessories.reduce((sum, acc) => sum + acc.price, 0);
     const modTotal = modifiers.reduce((sum, mod) => sum + mod.price, 0);
-    // Accessories are multiplied by quantity; modifiers are per-order (not per-unit)
-    const total = this.baseTicketCostValue * qty + accTotal * qty + modTotal;
+    // Accessories are multiplied by quantity; modifiers are per-order (not per-unit).
+    // Redeeming an approved mission prize is always free, so the balance check
+    // below must never gate the submit button on the item's normal price.
+    const total = this.freeValue
+      ? 0
+      : this.baseTicketCostValue * qty + accTotal * qty + modTotal;
 
     if (
       this.hasAccessoriesListContainerTarget &&

--- a/app/views/shop/items/show.html.erb
+++ b/app/views/shop/items/show.html.erb
@@ -97,7 +97,7 @@
             <div class="shop-order__customs-warning" data-customs-warning-target="warning" style="display: none;"></div>
         </div>
         <% if current_user %>
-        <div class="shop-order__details" data-controller="order-form" data-order-form-has-addresses-value="<%= @user_addresses.any? %>" data-order-form-base-ticket-cost-value="<%= @sale_price || @shop_item.ticket_cost || 0 %>" data-order-form-user-balance-value="<%= @user_balance %>" data-order-form-addresses-value="<%= @user_addresses.to_json %>" data-order-form-blocked-countries-value="<%= @shop_item.blocked_countries.to_json %>" data-order-form-stardust-icon-url-value="<%= image_path('icons/stardust.png') %>" data-action="address-select:change@document->order-form#addressChanged">
+        <div class="shop-order__details" data-controller="order-form" data-order-form-has-addresses-value="<%= @user_addresses.any? %>" data-order-form-base-ticket-cost-value="<%= @sale_price || @shop_item.ticket_cost || 0 %>" data-order-form-user-balance-value="<%= @user_balance %>" data-order-form-free-value="<%= @mission_submission.present? %>" data-order-form-addresses-value="<%= @user_addresses.to_json %>" data-order-form-blocked-countries-value="<%= @shop_item.blocked_countries.to_json %>" data-order-form-stardust-icon-url-value="<%= image_path('icons/stardust.png') %>" data-action="address-select:change@document->order-form#addressChanged">
             <h2>Complete your order:</h2>
             <%= form_with url: shop_orders_path(shop_item_id: @shop_item.id), method: :post, local: true, id: "order-form" do |form| %>
                 <% if @mission_submission %>


### PR DESCRIPTION
## what's this do?

previously it would block the user client-side if a mission prize redemption costed more stardust than they had. Now that is overridden.

## show it works

<img width="2042" height="1090" alt="image" src="https://github.com/user-attachments/assets/1e00800b-06b8-446e-b9cf-482c48e3b93b" />
(this costs 100 stardust in the shop)

## ai?

claude
