### PR TITLE
feat(lookout): make Lookout the default time-tracking path (behind :lookout flag)

### DIFF
--- a/app/controllers/projects/lookout_sessions_controller.rb
+++ b/app/controllers/projects/lookout_sessions_controller.rb
@@ -1,5 +1,5 @@
 class Projects::LookoutSessionsController < ApplicationController
-  before_action -> { head :not_found unless Flipper.enabled?(:hardware_flow, current_user) }
+  before_action -> { head :not_found unless Flipper.enabled?(:hardware_flow, current_user) || Flipper.enabled?(:lookout, current_user) }
   before_action :set_project
   before_action :set_lookout_session, only: %i[show record stop set_mode forward_heartbeats]
 

--- a/app/views/projects/_record_timelapse_button.html.erb
+++ b/app/views/projects/_record_timelapse_button.html.erb
@@ -1,12 +1,15 @@
-<%# Launches a Lookout screen-recording session straight from the project page
-    (hardware projects). Sessions forward their time to Hackatime, so recording
-    is locked until the user links their Hackatime account.
-    Locals: project (required), disabled_message (optional — when present the
-    button is shown disabled with that tooltip instead of being actionable). %>
+<%# Launches a Lookout screen-recording session straight from the project page.
+    Sessions forward their time to Hackatime, so recording is locked until the
+    user links their Hackatime account.
+    Locals: project (required); disabled_message (optional — when present the
+    button is shown disabled with that tooltip instead of being actionable);
+    button_text / variant (optional — override the default label and variant). %>
+<% button_text = local_assigns.fetch(:button_text, "Record a timelapse") %>
+<% variant = local_assigns.fetch(:variant, :secondary) %>
 <% if local_assigns[:disabled_message].present? %>
   <%= render ActionButtonComponent.new(
-        text: "Record a timelapse",
-        variant: :secondary,
+        text: button_text,
+        variant: variant,
         type: :button,
         disabled: :soft,
         data: {
@@ -17,8 +20,8 @@
       ) %>
 <% else %>
   <%= render ActionButtonComponent.new(
-        text: "Record a timelapse",
-        variant: :secondary,
+        text: button_text,
+        variant: variant,
         type: :button,
         data: {
           controller: "lookout-recorder",

--- a/app/views/projects/_track_time_card.html.erb
+++ b/app/views/projects/_track_time_card.html.erb
@@ -1,0 +1,31 @@
+<%# "Track your time" card — shown during project onboarding when the :lookout
+    flag is on. Presents Lookout (record in your browser) as the recommended
+    default and the Hackatime editor extension as an advanced option. Reuses the
+    existing .idv-setup-card styling — no new CSS.
+    Locals: project (required), hackatime_linked (required). %>
+<section class="idv-setup-card">
+  <p class="idv-setup-card__eyebrow">Recommended</p>
+  <h2 class="idv-setup-card__title">Record in your browser with Lookout</h2>
+
+  <div class="idv-setup-card__body">
+    <p class="idv-setup-card__lede">No install — share your screen and Lookout logs your time automatically. The first time, you'll link your Hackatime account in one click so your time counts.</p>
+  </div>
+
+  <% if hackatime_linked %>
+    <%= render "projects/record_timelapse_button", project: project, button_text: "Record in your browser", variant: :primary %>
+  <% else %>
+    <%= button_to "/auth/hackatime",
+                  method: :post,
+                  params: { origin: request.fullpath },
+                  class: "action-btn action-btn--large action-btn--primary idv-setup-card__cta",
+                  form: { class: "idv-setup-card__cta-form" } do %>
+      Link Hackatime &amp; record<%= inline_svg_tag "icons/right-arrow.svg", class: "action-btn__icon action-btn__icon--trailing", aria: { hidden: true } %>
+    <% end %>
+  <% end %>
+
+  <footer class="idv-setup-card__footer">
+    <p class="idv-setup-card__footer-links">
+      <%= link_to "Prefer the Hackatime editor extension? Set it up (advanced) →", guide_path("hackatime"), class: "idv-setup-card__footer-link" %>
+    </p>
+  </footer>
+</section>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -489,7 +489,7 @@
           devlog_modifier_class = devlog_primary ? "project-show__action--primary" : "project-show__action--secondary"
         %>
         <nav class="project-show__actions" aria-label="Project actions">
-          <% if Flipper.enabled?(:hardware_flow, current_user) && @project.hardware? %>
+          <% if Flipper.enabled?(:hardware_flow, current_user) && @project.hardware? && !Flipper.enabled?(:lookout, current_user) %>
             <%= render "projects/record_timelapse_button",
                        project: @project,
                        disabled_message: (@hackatime_linked ? nil : "Link your Hackatime account to start recording") %>
@@ -650,7 +650,7 @@
         </nav>
       <% else %>
         <nav class="project-show__actions" aria-label="Project actions">
-          <% if Flipper.enabled?(:hardware_flow, current_user) && @project.hardware? %>
+          <% if Flipper.enabled?(:hardware_flow, current_user) && @project.hardware? && !Flipper.enabled?(:lookout, current_user) %>
             <%= render "projects/record_timelapse_button",
                        project: @project,
                        disabled_message: "Link your Hackatime account to start recording" %>
@@ -755,7 +755,9 @@
             <%= onboarding_mission ? onboarding_mission.name : (@hackatime_linked ? "You're all set — go #{verb}!" : "Welcome to your new project!") %>
           </h2>
 
-          <%# Time-tracking nudge — shown for every new project, mission or not. %>
+          <%# Time-tracking nudge — shown for every new project, mission or not.
+              Suppressed under :lookout; the Track-your-time card owns this message. %>
+          <% unless Flipper.enabled?(:lookout, current_user) %>
           <% if !@hackatime_linked %>
             <p class="project-show__onboarding-header-body">
               <% if onboarding_mission&.has_guide? %>
@@ -777,6 +779,7 @@
               Start coding with Hackatime running. Once you have 15 minutes, <%= link_to "edit your project", project_path(@project, editing: true), class: "project-show__onboarding-header-link", data: { turbo_frame: "project_hero" } %> to link your Hackatime project, then write your first devlog!
             </p>
           <% end %>
+          <% end %>
         </header>
 
         <%# Prominent guide CTA: the mission's own guide when on a mission,
@@ -797,6 +800,10 @@
                       data: { turbo: false } do %>
             Read on how to start your hardware project!<%= inline_svg_tag "icons/right-arrow.svg", class: "action-btn__icon action-btn__icon--trailing", aria: { hidden: true } %>
           <% end %>
+        <% end %>
+
+        <% if Flipper.enabled?(:lookout, current_user) %>
+          <%= render "projects/track_time_card", project: @project, hackatime_linked: @hackatime_linked %>
         <% end %>
       </section>
     <% end %>

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -40,6 +40,7 @@ Rails.application.config.after_initialize do
         week_1_release
         hardware_flow
         ship_event_payouts
+        lookout
       ].each { |flag| Flipper.add(flag) }
     end
   rescue StandardError => e


### PR DESCRIPTION
## What

Makes **Lookout** (record in your browser) the recommended default way to log time on the project page, with the **Hackatime editor extension demoted to an "advanced" option**. All behind a new `lookout` Flipper flag that is **off by default**, so production is unchanged until it is enabled per-actor.

## How (reuse-only, minimal diff)

No new SCSS, no new components, no migration. The one new file is a glue partial that composes existing pieces.

- Register `lookout` Flipper flag (off by default) in `config/initializers/flipper.rb`
- Widen the Lookout controller gate to `hardware_flow OR lookout` (hardware access unchanged); keep the Hackatime-identity requirement
- Parameterize `_record_timelapse_button` (`button_text` / `variant`, backward-compatible)
- New `_track_time_card` partial, reusing `.idv-setup-card` styling, the record-button partial, and the `/auth/hackatime` button
- Render the card in the onboarding section under `:lookout`; suppress the contradictory "link Hackatime first" nudge; guard the hardware-only record button against double-render

Diff: +55 / -13 across 5 files (one new ~31-line partial).

## Flag-off safety

With `lookout` disabled, every touched conditional collapses to today's behavior, so the page is byte-for-byte unchanged. The flag is off by default.

## Test

```
bin/rails runner 'Flipper.enable_actor(:lookout, User.find_by(email: "you@example.com"))'
```

Open a fresh project (no devlogs, so onboarding shows) as both a software and a hardware project. The "Track your time" card appears with Lookout recommended and the extension as an advanced link. `Flipper.disable(:lookout)` returns the page to today's flow.

erb_lint and rubocop pass clean on the changed files.

## Follow-ups (not in this PR)

- Pass 2: render the same `_track_time_card` at project creation / setup wizard (the real in-flow 44% fix)
- Pass 3: re-engagement banner reusing the partial for users who stalled after onboarding
- Optional: controller tests (software project records under `:lookout`; `:not_found` when neither flag set)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are gated behind a new Flipper flag defaulting off; only UI composition and a controller feature gate widen, with no new auth or data paths.
> 
> **Overview**
> Introduces a **`lookout` Flipper flag** (off by default) that, when enabled for a user, reframes project onboarding around **browser recording via Lookout** instead of leading with the Hackatime editor extension.
> 
> **Access:** `LookoutSessionsController` now allows requests when either **`hardware_flow` or `lookout`** is enabled; the Hackatime link requirement is unchanged.
> 
> **UI:** A new **`_track_time_card`** partial (reusing existing `idv-setup-card` styling) appears in the project onboarding section with Lookout as “Recommended,” primary **Record in your browser** / **Link Hackatime & record** CTAs, and Hackatime extension setup as an advanced footer link. **`_record_timelapse_button`** gains optional **`button_text`** and **`variant`** locals for reuse in that card.
> 
> **Project show:** When `:lookout` is on, the onboarding Hackatime nudge copy is hidden (the card owns that messaging), the hardware-only timelapse button in the action nav is **not** shown (avoids duplicate CTAs), and the track-time card is rendered. With the flag off, behavior matches the previous page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 646a87f1be01474e90237e5a002d74f7f3b3cb6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->