### PR TITLE
feat(artifacts): shareable purchase artifact page (flag: artifact_share)

### DIFF
--- a/app/controllers/artifacts_controller.rb
+++ b/app/controllers/artifacts_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Public, shareable "I earned this" page for a single shop purchase. The URL is
+# keyed by ShopOrder#signed_id (purpose: :artifact), not the sequential id, so
+# purchases can't be enumerated. The page is open to anyone with the link; the
+# link is only mintable from the buyer's own orders page (behind :artifact_share).
+class ArtifactsController < ApplicationController
+  def show
+    @order = ShopOrder.find_signed(params[:id], purpose: :artifact)
+    if @order.nil?
+      skip_authorization
+      return head :not_found
+    end
+
+    authorize @order, :show?, policy_class: ArtifactPolicy
+
+    @item             = @order.shop_item
+    @buyer            = @order.user
+    @stardust_spent   = @order.total_cost_with_modifiers
+    @featured_project = featured_project_for(@buyer)
+  end
+
+  private
+
+  # Stardust is a pooled balance, so a purchase isn't tied to a specific ship.
+  # Feature the buyer's most recent ship-event payout's project as the thing
+  # they "earned it by shipping". Best-effort: nil falls back to generic copy.
+  def featured_project_for(user)
+    LedgerEntry
+      .where(user: user, ledgerable_type: "Post::ShipEvent")
+      .order(created_at: :desc)
+      .first&.ledgerable&.post&.project
+  rescue StandardError
+    nil
+  end
+end

--- a/app/policies/artifact_policy.rb
+++ b/app/policies/artifact_policy.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# A purchase artifact is intentionally public: anyone with the signed link can
+# view it. Enumeration is prevented by the signed id (see ArtifactsController),
+# not by this policy.
+class ArtifactPolicy < ApplicationPolicy
+  def show? = true
+end

--- a/app/views/artifacts/show.html.erb
+++ b/app/views/artifacts/show.html.erb
@@ -1,0 +1,44 @@
+<% project = @featured_project %>
+<% content_for :title, "#{@buyer.display_name} earned #{@item.name} on Stardance" %>
+<% content_for :og_title, "I earned #{@item.name} on Stardance" %>
+<% content_for :og_description, project ? "Shipped #{project.title}, earned stardust, and redeemed it for #{@item.name} on Stardance." : "Earned stardust building on Stardance and redeemed it for #{@item.name}." %>
+<% content_for :og_image, project_og_image_url(project, format: :png) if project %>
+<% content_for :twitter_card, "summary_large_image" %>
+<% content_for :head do %>
+  <meta name="robots" content="noindex, nofollow">
+<% end %>
+
+<section class="idv-setup-card">
+  <p class="idv-setup-card__eyebrow">Stardance</p>
+  <h2 class="idv-setup-card__title"><%= @buyer.display_name %> earned this</h2>
+
+  <div class="idv-setup-card__body">
+    <% if project %>
+      <p class="idv-setup-card__lede">
+        Earned by shipping <strong><%= project.title %></strong> on Stardance, then redeemed
+        <strong><%= number_with_precision(@stardust_spent, precision: 0) %> stardust</strong>
+        for <strong><%= @item.name %></strong>.
+      </p>
+    <% else %>
+      <p class="idv-setup-card__lede">
+        Earned <strong><%= number_with_precision(@stardust_spent, precision: 0) %> stardust</strong>
+        building on Stardance and redeemed it for <strong><%= @item.name %></strong>.
+      </p>
+    <% end %>
+  </div>
+
+  <%= link_to "Start building on Stardance →", root_url,
+              class: "action-btn action-btn--large action-btn--primary idv-setup-card__cta" %>
+
+  <footer class="idv-setup-card__footer">
+    <p class="idv-setup-card__footer-links">
+      <button type="button" class="idv-setup-card__footer-link"
+              data-controller="copy tooltip"
+              data-copy-text-value="<%= artifact_url(@order.signed_id(purpose: :artifact)) %>"
+              data-tooltip-message-value="Click to copy"
+              data-action="copy#copy">
+        Copy link to share →
+      </button>
+    </p>
+  </footer>
+</section>

--- a/app/views/shop/orders/index.html.erb
+++ b/app/views/shop/orders/index.html.erb
@@ -39,6 +39,20 @@
                   <% if (order.pending? || order.aasm_state == "awaiting_periodical_fulfillment") && !order.shop_item.is_a?(ShopItem::FreeStickers) %>
                     <%= button_to "Cancel Order", cancel_shop_order_path(order), method: :delete, class: "my-orders__cancel-link", form: { onsubmit: "return confirm('Are you sure you want to cancel this order?')"   } %>
                   <% end %>
+                  <% if Flipper.enabled?(:artifact_share, current_user) %>
+                    <%= render ActionButtonComponent.new(
+                          text: "Share your win →",
+                          type: :button,
+                          size: :small,
+                          variant: :secondary,
+                          data: {
+                            controller: "copy tooltip",
+                            "copy-text-value": artifact_url(order.signed_id(purpose: :artifact)),
+                            "tooltip-message-value": "Click to copy",
+                            action: "copy#copy"
+                          }
+                        ) %>
+                  <% end %>
                 </div>
             </div>
           </div>

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -40,6 +40,7 @@ Rails.application.config.after_initialize do
         week_1_release
         hardware_flow
         ship_event_payouts
+        artifact_share
       ].each { |flag| Flipper.add(flag) }
     end
   rescue StandardError => e

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -434,6 +434,10 @@ Rails.application.routes.draw do
 
   # Static OG images
   get "og/:page", to: "og_images#show", as: :og_image, defaults: { format: :png }
+
+  # Shareable purchase artifact (public, keyed by a signed id — see ArtifactsController)
+  get "artifacts/:id", to: "artifacts#show", as: :artifact
+
   # Landing
   root "landing#index"
   get "landing/signup_count", to: "landing#signup_count", as: :landing_signup_count


### PR DESCRIPTION
## What

A shop purchase gets a public, shareable "I earned this" page, designed for posting on LinkedIn / Slack: "earned by shipping **[project]** on Stardance, then redeemed **[X] stardust** for **[item]**." Behind a new `artifact_share` Flipper flag (off by default).

## Why

Payouts are going out and people are spending stardust. Turning a purchase into a shareable artifact gives builders social proof to post off-platform, which is free, organic marketing for Stardance.

## How (least code, reuse-heavy)

No new model, no migration, no bespoke image generator.

- **Public page** `ArtifactsController#show` + `ArtifactPolicy#show? => true`, modeled on the public project page.
- **Security (fail-closed):** the URL is keyed by `ShopOrder#signed_id(purpose: :artifact)`, not the sequential order id, so purchases cannot be enumerated (no IDOR). `noindex, nofollow` by default. Tampered/invalid ids 404.
- **Social preview:** reuses the existing `content_for :og_*` system and the featured project's existing OG image via `project_og_image_url` — no new OG-image service/controller.
- **Provenance:** stardust is a pooled balance, so a purchase is not tied to a specific ship. We feature the buyer's most recent ship-event payout's project; generic copy when they have no ships. Item + stardust-spent are exact off the order.
- **UI:** reuses `.idv-setup-card` styling + `copy_controller.js` for the share button. No new SCSS or components.
- **Entry point:** a "Share your win →" button on the buyer's own orders page, gated behind `:artifact_share`. The public page itself is not flag-gated (it is open-by-signed-link), so logged-out recipients can always view a shared link once the owner has the flag and mints it.

Diff: 3 small new files (controller, policy, view) + ~19 lines across routes, the flag list, and the orders page.

## Test

```
bin/rails runner 'Flipper.enable_actor(:artifact_share, User.find_by(email: "you@example.com"))'
```

Place a shop order as that user, open the orders page, click "Share your win →", paste the link in a **logged-out** browser. Confirm: the page renders, OG meta + image are present (view-source or the OG preview tooling), `noindex` is set, and a bare sequential id at `/artifacts/123` does NOT resolve (signed id only).

Note: rubocop/erb_lint were not run locally (the sandbox only had Ruby 2.6, not the project's 3.4.3); ERB + controller syntax were validated and CI will run the full lint.

## Follow-ups

- Bespoke `OgImage::Artifact` branded share image ("bought [item] for [X] stardust").
- Let the buyer pick which ship to feature.
- Optionally show the item image on the page (kept text-only here to avoid new SCSS).
