### PR TITLE
fix: preserve platform access for stardances who turn 19

### DIFF
--- a/app/services/sessions/hca_login_service.rb
+++ b/app/services/sessions/hca_login_service.rb
@@ -215,7 +215,20 @@ module Sessions
         return nil if fields[:birthday].nil?
 
         age = age_from_birthday(fields[:birthday])
-        age >= 13 && age <= 18 ? :teen : :ineligible
+        return :teen if age >= 13 && age <= 18
+
+        if user.persisted? && user.age_attestation_teen_13_18?
+          signup_age = age_on_date(fields[:birthday], user.created_at.to_date)
+          return :teen if signup_age >= 13 && signup_age <= 18
+        end
+
+        :ineligible
+      end
+
+      def age_on_date(birthday, date)
+        age = date.year - birthday.year
+        age -= 1 if date < birthday + age.years
+        age
       end
 
       def age_ineligible_result(user, is_new_user, guest_collision)

--- a/test/services/sessions/hca_login_service_test.rb
+++ b/test/services/sessions/hca_login_service_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class Sessions::HCALoginServiceTest < ActiveSupport::TestCase
+  setup do
+    @service = Sessions::HCALoginService.new(auth: nil, current_user: nil)
+  end
+
+  test "hca_age_attestation returns teen for user who was 18 at signup and is now 19" do
+    user = users(:one)
+    signup_date = Date.current - 1.year
+    birthday = Date.current - 19.years
+
+    user.update_columns(age_attestation: "teen_13_18", created_at: signup_date.to_time)
+
+    result = @service.send(:hca_age_attestation, user, { ysws_eligible: false, birthday: birthday })
+
+    assert_equal :teen, result, "user who was 18 at signup should not be blocked after turning 19"
+  end
+
+  test "hca_age_attestation returns ineligible for user who was always over 18 at signup" do
+    user = users(:one)
+    birthday = Date.current - 26.years
+
+    user.update_columns(age_attestation: "teen_13_18", created_at: Time.current)
+
+    result = @service.send(:hca_age_attestation, user, { ysws_eligible: false, birthday: birthday })
+
+    assert_equal :ineligible, result
+  end
+
+  test "hca_age_attestation returns teen when ysws_eligible is true regardless of age" do
+    user = users(:one)
+    birthday = Date.current - 26.years
+
+    result = @service.send(:hca_age_attestation, user, { ysws_eligible: true, birthday: birthday })
+
+    assert_equal :teen, result
+  end
+
+  test "hca_age_attestation returns ineligible for new user with birthday over 18" do
+    user = User.new
+
+    birthday = Date.current - 26.years
+    result = @service.send(:hca_age_attestation, user, { ysws_eligible: false, birthday: birthday })
+
+    assert_equal :ineligible, result
+  end
+end


### PR DESCRIPTION
fixes an issue where stardancers who joined before they turn 19 can't participate anymore when they turn 19

### show it works?

I used rails console to mimic the situation

```
user = User.create!(
  email: "turns19demo@example.com",
  display_name: "demo_nineteen_#{rand(1000)}",
  age_attestation: "teen_13_18",
  experience_level: "some",
  interests: ["web_dev"],
  onboarded_at: 1.year.ago,
  verification_status: "verified",
  ysws_eligible: true
)
```
```
user.update_columns(created_at: 1.year.ago)
service = Sessions::HCALoginService.new(auth: nil, current_user: nil)
birthday = Date.current - 19.years
result = service.send(:hca_age_attestation, user, { ysws_eligible: false, birthday: birthday })
puts result # should be teen even tho they're 19 but created_at is 1 year ago
```
ai?
writing test file & rails console queries

closes #738