### PR TITLE
feat(notifications): Loops-native email path + payout wiring (fixes email 450s)

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -7,13 +7,19 @@ class NotificationMailer < ApplicationMailer
     @recipient = @notification.recipient
     @actor     = @notification.actor
     @record    = @notification.record
-    @recommended_items = payout_recommendations
 
-    mail(
-      to:            @recipient.email,
-      subject:       @notification.email_subject,
-      template_name: @notification.template_key
-    )
+    if @notification.loops_transactional_id.present?
+      # Loops-native: the body is a JSON transactional payload and Loops owns the
+      # design + subject (see loops_transactional.text.erb).
+      mail(to: @recipient.email, template_name: "loops_transactional")
+    else
+      @recommended_items = payout_recommendations
+      mail(
+        to:            @recipient.email,
+        subject:       @notification.email_subject,
+        template_name: @notification.template_key
+      )
+    end
   end
 
   private

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -305,6 +305,19 @@ class Notification < ApplicationRecord
     "Stardance notification"
   end
 
+  # Loops transactional template id for this notification's email. When present,
+  # NotificationMailer sends the Loops JSON payload (email_data_variables) instead
+  # of rendering the legacy HTML/text template. nil = keep the legacy template.
+  def loops_transactional_id
+    nil
+  end
+
+  # Data variables handed to the Loops transactional template (see
+  # loops_transactional_id). Ignored unless loops_transactional_id is present.
+  def email_data_variables
+    {}
+  end
+
   def sanitize_slack_mentions(text)
     text.to_s.gsub(SLACK_MENTION_PATTERN, "")
   end

--- a/app/models/notifications/payouts/ship_event_issued.rb
+++ b/app/models/notifications/payouts/ship_event_issued.rb
@@ -17,6 +17,44 @@ module Notifications
         title = params["project_title"]
         title.present? ? "Payout issued for #{title}" : "Ship event payout issued"
       end
+
+      # Send via Loops once its transactional template exists. Inert (nil) until
+      # LOOPS_SHIP_EVENT_PAYOUT_TEMPLATE_ID is set, so merging changes nothing
+      # until Loops is ready; then this email flips to the Loops JSON payload.
+      def loops_transactional_id
+        ENV["LOOPS_SHIP_EVENT_PAYOUT_TEMPLATE_ID"].presence
+      end
+
+      # Payout details + (behind :payout_recommendations) up to 3 affordable-item
+      # recommendations, as flat variables the Loops payout template renders.
+      def email_data_variables
+        opts     = ActionMailer::Base.default_url_options
+        host     = opts[:host] || "stardance.hackclub.com"
+        protocol = opts[:protocol] || "https"
+        urls     = Rails.application.routes.url_helpers
+
+        vars = {
+          stardust:     params["stardust"],
+          projectTitle: params["project_title"],
+          hours:        params["hours"],
+          multiplier:   params["multiplier"],
+          shipDate:     params["ship_date"],
+          blessing:     params["blessing"],
+          balanceUrl:   urls.my_balance_url(host:, protocol:)
+        }
+
+        return vars unless Flipper.enabled?(:payout_recommendations, recipient)
+
+        ShopItem.affordable_for(recipient, limit: 3).each_with_index do |item, i|
+          n = i + 1
+          vars[:"rec#{n}Name"]     = item.name
+          vars[:"rec#{n}Price"]    = item.recommended_price
+          vars[:"rec#{n}Url"]      = urls.shop_item_url(item, host:, protocol:)
+          vars[:"rec#{n}Wishlist"] = item.recommended_from_wishlist?
+        end
+
+        vars
+      end
     end
   end
 end

--- a/app/views/notification_mailer/loops_transactional.text.erb
+++ b/app/views/notification_mailer/loops_transactional.text.erb
@@ -1,0 +1,5 @@
+<%# Loops transactional payload. Loops' SMTP relay reads this leading JSON object
+    (transactionalId + dataVariables) and renders the email from the matching
+    Loops template; it ignores the plain-text footer the mailer layout appends.
+    Used for any notification whose #loops_transactional_id is present. %>
+<%= { transactionalId: @notification.loops_transactional_id, email: @recipient.email, dataVariables: @notification.email_data_variables }.to_json %>


### PR DESCRIPTION
> Stacked on #733 (`feat/payout-recommendations`) because the payout data variables reuse `ShopItem.affordable_for`. Base will retarget to `main` once #733 merges.

## What

Notification emails are 100% broken in production: every one is rejected by Loops SMTP with `450 your request did not include a valid JSON payload`. The notification mailer renders normal HTML/text MIME, but Loops' relay only accepts a JSON transactional payload (`transactionalId` + `dataVariables`) — the same format the RSVP/onboarding mailers already use successfully.

This adds the Loops JSON path and wires the **payout email** as the first consumer (proof), leaving the other 12 types untouched for now.

## How

- `Notification#loops_transactional_id` (default `nil`) and `#email_data_variables` (default `{}`) — per-type overrides.
- `NotificationMailer`: when `loops_transactional_id` is present, send the Loops JSON payload (new `loops_transactional.text.erb`); otherwise render the legacy template exactly as before.
- `Notifications::Payouts::ShipEventIssued` implements both:
  - `loops_transactional_id` reads `ENV["LOOPS_SHIP_EVENT_PAYOUT_TEMPLATE_ID"]`, so it is **inert (nil) until that env var is set**. Merging this changes nothing until Loops is ready; then the payout email flips to the JSON path automatically.
  - `email_data_variables` carries the payout details plus, behind the `:payout_recommendations` flag, up to 3 affordable-item recs (`rec1Name/Price/Url/Wishlist` ...) built from `affordable_for`. The recs move from ERB rendering into Loops data variables.

Verified the JSON pattern works in prod: all recent `450`s are from `NotificationDeliveryJob` (the HTML mailer); zero from the onboarding/rsvp JSON mailers, which deliver fine even with the mailer footer appended (Loops parses the leading JSON object and ignores the footer).

## Needs from whoever owns Loops (cskartikey)

1. Create a **Loops transactional template** for the payout email, with data variables `stardust`, `projectTitle`, `hours`, `multiplier`, `shipDate`, `blessing`, `balanceUrl`, and `rec1Name/rec1Price/rec1Url/rec1Wishlist` ... `rec3*` (render up to 3 conditionally).
2. Set `LOOPS_SHIP_EVENT_PAYOUT_TEMPLATE_ID` to that template's id.

## Test

- Locally, render the payout mail and assert the body is a single JSON object with the right `transactionalId` + `dataVariables` (a Minitest mailer test).
- In prod, once the template + env var exist: trigger a payout notification to yourself, confirm no `450` in the worker logs, `email_delivered_at` gets stamped, and the email arrives.

## Follow-ups

- Roll the same pattern to the other 12 notification types (each needs a Loops template + its two methods). Once all are converted, the legacy per-type HTML/text templates can be deleted.
- Add the missing templates issue is moot after conversion (Loops owns the design).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production email delivery for high-priority payout notifications once the env var is set; misconfigured template or variables would break payout emails while other types stay on legacy templates until migrated.
> 
> **Overview**
> **Notification emails can send a Loops transactional JSON body** instead of legacy HTML/text when a notification type supplies a template id. The base `Notification` model adds **`loops_transactional_id`** (default nil) and **`email_data_variables`** (default `{}`); **`NotificationMailer`** branches on that id to use a new **`loops_transactional.text.erb`** view that emits `transactionalId`, recipient email, and `dataVariables`, otherwise behavior is unchanged (subject + per-type template, including payout recommendations in ERB).
> 
> **Ship event payout notifications** are the first wired type: **`loops_transactional_id`** comes from **`LOOPS_SHIP_EVENT_PAYOUT_TEMPLATE_ID`** (no env var → still legacy mail). **`email_data_variables`** maps payout fields and URLs for Loops, and when **`:payout_recommendations`** is on for the recipient, adds up to three shop rec fields (`rec1Name` …) built from **`ShopItem.affordable_for`**, moving that content from the mailer template into Loops data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84a2d46ae272589afa38000a4e4f7a4a9297abad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->