### PR TITLE
feat(loops): sync payout data to Airtable as Loops contact properties (sanctioned email path)

### DIFF
--- a/app/jobs/airtable/user_sync_job.rb
+++ b/app/jobs/airtable/user_sync_job.rb
@@ -49,6 +49,46 @@ class Airtable::UserSyncJob < Airtable::BaseSyncJob
       )
     end
 
+    fields.merge!(payout_loops_fields(user))
     fields
+  end
+
+  private
+
+  # Payout notification data as Loops contact properties, synced through the
+  # `_users` Airtable table (the only sanctioned path to Loops — no direct API).
+  # `Loops - stardancePayoutIssuedAt` is the timestamp property a Loops workflow
+  # (or a filtered campaign) fires on; the rest are the values the email templates
+  # in. Per-user latest payout only (one row per user). Blank for users with no
+  # ship-event payout. Fails closed to {} so it can never break the sync.
+  def payout_loops_fields(user)
+    entry = user.ledger_entries
+                .where(ledgerable_type: "Post::ShipEvent")
+                .order(created_at: :desc)
+                .first
+    return {} unless entry
+
+    urls     = Rails.application.routes.url_helpers
+    opts     = ActionMailer::Base.default_url_options
+    host     = opts[:host] || "stardance.hackclub.com"
+    protocol = opts[:protocol] || "https"
+
+    fields = {
+      "Loops - stardancePayoutIssuedAt" => entry.created_at&.iso8601,
+      "Loops - stardancePayoutStardust" => entry.amount&.to_i,
+      "Loops - stardancePayoutProject"  => entry.ledgerable&.project&.title
+    }
+
+    ShopItem.affordable_for(user, limit: 3).each_with_index do |item, i|
+      n = i + 1
+      fields["Loops - stardancePayoutRec#{n}Name"]  = item.name
+      fields["Loops - stardancePayoutRec#{n}Price"] = item.recommended_price
+      fields["Loops - stardancePayoutRec#{n}Url"]   = urls.shop_item_url(item, host:, protocol:)
+    end
+
+    fields
+  rescue => e
+    Rails.logger.warn("UserSyncJob payout_loops_fields failed for user #{user.id}: #{e.message}")
+    {}
   end
 end

--- a/app/jobs/airtable/user_sync_job.rb
+++ b/app/jobs/airtable/user_sync_job.rb
@@ -58,9 +58,11 @@ class Airtable::UserSyncJob < Airtable::BaseSyncJob
   # Payout notification data as Loops contact properties, synced through the
   # `_users` Airtable table (the only sanctioned path to Loops — no direct API).
   # `Loops - stardancePayoutIssuedAt` is the timestamp property a Loops workflow
-  # (or a filtered campaign) fires on; the rest are the values the email templates
-  # in. Per-user latest payout only (one row per user). Blank for users with no
-  # ship-event payout. Fails closed to {} so it can never break the sync.
+  # (or a filtered campaign) fires on; Stardust/Project are templated into the
+  # email. These three fields already exist on the `_users` table. Per-user latest
+  # payout only (one row per user); blank for users with no ship-event payout;
+  # fails closed to {} so it can never break the sync. (Item recommendations are a
+  # follow-up — they need more `Loops - stardancePayoutRec*` columns created first.)
   def payout_loops_fields(user)
     entry = user.ledger_entries
                 .where(ledgerable_type: "Post::ShipEvent")
@@ -68,25 +70,11 @@ class Airtable::UserSyncJob < Airtable::BaseSyncJob
                 .first
     return {} unless entry
 
-    urls     = Rails.application.routes.url_helpers
-    opts     = ActionMailer::Base.default_url_options
-    host     = opts[:host] || "stardance.hackclub.com"
-    protocol = opts[:protocol] || "https"
-
-    fields = {
+    {
       "Loops - stardancePayoutIssuedAt" => entry.created_at&.iso8601,
       "Loops - stardancePayoutStardust" => entry.amount&.to_i,
       "Loops - stardancePayoutProject"  => entry.ledgerable&.project&.title
     }
-
-    ShopItem.affordable_for(user, limit: 3).each_with_index do |item, i|
-      n = i + 1
-      fields["Loops - stardancePayoutRec#{n}Name"]  = item.name
-      fields["Loops - stardancePayoutRec#{n}Price"] = item.recommended_price
-      fields["Loops - stardancePayoutRec#{n}Url"]   = urls.shop_item_url(item, host:, protocol:)
-    end
-
-    fields
   rescue => e
     Rails.logger.warn("UserSyncJob payout_loops_fields failed for user #{user.id}: #{e.message}")
     {}

--- a/app/jobs/airtable/user_sync_job.rb
+++ b/app/jobs/airtable/user_sync_job.rb
@@ -58,11 +58,12 @@ class Airtable::UserSyncJob < Airtable::BaseSyncJob
   # Payout notification data as Loops contact properties, synced through the
   # `_users` Airtable table (the only sanctioned path to Loops — no direct API).
   # `Loops - stardancePayoutIssuedAt` is the timestamp property a Loops workflow
-  # (or a filtered campaign) fires on; Stardust/Project are templated into the
-  # email. These three fields already exist on the `_users` table. Per-user latest
-  # payout only (one row per user); blank for users with no ship-event payout;
-  # fails closed to {} so it can never break the sync. (Item recommendations are a
-  # follow-up — they need more `Loops - stardancePayoutRec*` columns created first.)
+  # (or a filtered campaign) fires on; Stardust/Project + the Rec1-3 items are
+  # templated into the email. All of these `Loops - stardancePayout*` fields exist
+  # on the `_users` table. Recommendations come from ShopItem.affordable_for (full
+  # balance + region + wishlist + live catalog). Per-user latest payout only (one
+  # row per user); blank for users with no ship-event payout; fails closed to {}
+  # so it can never break the sync.
   def payout_loops_fields(user)
     entry = user.ledger_entries
                 .where(ledgerable_type: "Post::ShipEvent")
@@ -70,11 +71,25 @@ class Airtable::UserSyncJob < Airtable::BaseSyncJob
                 .first
     return {} unless entry
 
-    {
+    fields = {
       "Loops - stardancePayoutIssuedAt" => entry.created_at&.iso8601,
       "Loops - stardancePayoutStardust" => entry.amount&.to_i,
       "Loops - stardancePayoutProject"  => entry.ledgerable&.project&.title
     }
+
+    urls     = Rails.application.routes.url_helpers
+    opts     = ActionMailer::Base.default_url_options
+    host     = opts[:host] || "stardance.hackclub.com"
+    protocol = opts[:protocol] || "https"
+
+    ShopItem.affordable_for(user, limit: 3).each_with_index do |item, i|
+      n = i + 1
+      fields["Loops - stardancePayoutRec#{n}Name"]  = item.name
+      fields["Loops - stardancePayoutRec#{n}Price"] = item.recommended_price
+      fields["Loops - stardancePayoutRec#{n}Url"]   = urls.shop_item_url(item, host:, protocol:)
+    end
+
+    fields
   rescue => e
     Rails.logger.warn("UserSyncJob payout_loops_fields failed for user #{user.id}: #{e.message}")
     {}

--- a/app/jobs/airtable/user_sync_job.rb
+++ b/app/jobs/airtable/user_sync_job.rb
@@ -91,7 +91,12 @@ class Airtable::UserSyncJob < Airtable::BaseSyncJob
 
     fields
   rescue => e
-    Rails.logger.warn("UserSyncJob payout_loops_fields failed for user #{user.id}: #{e.message}")
+    # Fail closed so a bad lookup never breaks the whole sync, but make it loud:
+    # a systemic break here (renamed Airtable field, changed route, bad data)
+    # silently drops the payout-email trigger for everyone, so surface it via
+    # Sentry rather than a warn line no one reads.
+    Rails.logger.error("UserSyncJob payout_loops_fields failed for user #{user.id}: #{e.message}")
+    Sentry.capture_exception(e) if defined?(Sentry)
     {}
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -56,6 +56,12 @@ class Notification < ApplicationRecord
   class_attribute :category_description, default: nil
   class_attribute :category_group,       default: "General"
   class_attribute :inbox_record_preloads, default: nil
+  # Whether this type may deliver over email. Default true preserves the
+  # priority-based email defaults; set false to keep a type in-app/Slack only —
+  # used when a type's email is delivered out-of-band (e.g. through the Airtable
+  # -> Loops user sync) rather than the app's SMTP mailer. Overrides preference
+  # and even the critical bypass, so a false here is a hard off for email.
+  class_attribute :email_deliverable, default: true
   # Delay for slack/email delivery so aggregated rows fire one DM/email with
   # the final group_count instead of one per event. nil = immediate.
   class_attribute :digest_delay,         default: nil
@@ -223,7 +229,7 @@ class Notification < ApplicationRecord
     pref = preference_row
 
     slack_on = critical? || channel_enabled?(:slack, pref, defaults)
-    email_on = critical? || channel_enabled?(:email, pref, defaults)
+    email_on = email_deliverable && (critical? || channel_enabled?(:email, pref, defaults))
 
     channels = []
     channels << :slack if slack_on

--- a/app/models/notifications/payouts/ship_event_issued.rb
+++ b/app/models/notifications/payouts/ship_event_issued.rb
@@ -3,6 +3,11 @@ module Notifications
     class ShipEventIssued < ::Notification
       self.default_priority     = :high
       self.aggregatable         = false
+      # The payout email is delivered through the Airtable -> Loops user sync,
+      # not the app's SMTP mailer, which Loops' relay rejects (450, not a valid
+      # JSON payload). Keep this notification in-app + Slack only so we don't
+      # fire a second, broken SMTP email on every payout.
+      self.email_deliverable    = false
       self.slack_template_path  = "notifications/payouts/ship_event_issued"
       self.category_key         = :ship_event_payout_issued
       self.category_label       = "Ship event payouts"

--- a/app/models/post/ship_event/payouts.rb
+++ b/app/models/post/ship_event/payouts.rb
@@ -174,6 +174,9 @@ module Post::ShipEvent::Payouts
     if issued
       notify_payout_issued
       broadcast_payout
+      # Jump the recipient to the front of the Airtable sync so their
+      # `Loops - stardancePayout*` contact properties refresh within ~1 min.
+      payout_recipient&.flag_for_resync!
     end
 
     issued

--- a/test/jobs/airtable/user_sync_job_test.rb
+++ b/test/jobs/airtable/user_sync_job_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class Airtable::UserSyncJobTest < ActiveSupport::TestCase
+  setup do
+    @user = create_user(slack_id: "U#{SecureRandom.hex(8)}", display_name: "star#{SecureRandom.hex(4)}")
+  end
+
+  test "field_mapping surfaces the latest ship-event payout as Loops properties" do
+    # An older payout that should be superseded by the newer one below.
+    older = create_ship_event_payout(title: "Nebula Sampler", amount: 10)
+    older.update_column(:created_at, 3.days.ago)
+
+    newer = create_ship_event_payout(title: "Aurora Probe", amount: 42)
+
+    fields = Airtable::UserSyncJob.new.field_mapping(@user)
+
+    assert_equal newer.created_at.iso8601, fields["Loops - stardancePayoutIssuedAt"]
+    assert_equal 42, fields["Loops - stardancePayoutStardust"]
+    assert_equal "Aurora Probe", fields["Loops - stardancePayoutProject"]
+  end
+
+  test "field_mapping omits payout properties when the user has no ship-event payout" do
+    # A non-ship-event ledger entry must not trigger the payout fields.
+    @user.ledger_entries.create!(ledgerable: @user, amount: 5, reason: "Some other credit", created_by: "test")
+
+    fields = Airtable::UserSyncJob.new.field_mapping(@user)
+
+    assert_not fields.key?("Loops - stardancePayoutIssuedAt")
+    assert_not fields.key?("Loops - stardancePayoutStardust")
+    assert_not fields.key?("Loops - stardancePayoutProject")
+  end
+
+  private
+
+  def create_ship_event_payout(title:, amount:)
+    project = Project.create!(title: title, created_at: 3.days.ago)
+    ship_event = Post::ShipEvent.create!(body: "Ship it", uploading_attachments: true)
+    Post.create!(project: project, user: @user, postable: ship_event)
+    @user.ledger_entries.create!(
+      ledgerable: ship_event,
+      amount: amount,
+      reason: "Ship event payout: #{title}",
+      created_by: "ship_event_payout"
+    )
+  end
+end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -99,6 +99,19 @@ class NotificationTest < ActiveSupport::TestCase
     end
   end
 
+  test "email_deliverable defaults true so a high-priority type still emails" do
+    notification = Notifications::NewFollower.new(priority: :high)
+    assert_includes notification.effective_channels, :email
+  end
+
+  test "email_deliverable false drops the email channel but keeps slack" do
+    notification = Notifications::Payouts::ShipEventIssued.new(priority: :high)
+    channels = notification.effective_channels
+
+    assert_includes channels, :slack
+    assert_not_includes channels, :email
+  end
+
   test "orphaned? returns true when the polymorphic record is missing" do
     orphan = notifications(:orphaned_notification)
     assert orphan.orphaned?


### PR DESCRIPTION
> Stacked on #733 (reuses `ShopItem.affordable_for`). Supersedes #744 (the direct-Loops-SMTP approach) — please close #744.

## Why

Transactional notification emails are 100% broken in prod: the app sends normal HTML emails through Loops' SMTP relay, which only accepts a JSON transactional payload, so Loops rejects every one (`450 ... not a valid JSON payload`). Per Hack Club's Loops policy, **direct Loops (API/SMTP/events) is forbidden** — the only sanctioned path is **Postgres → Airtable → the internal tool → Loops**. So the fix isn't "send the right format," it's "stop going through SMTP and drive the email off Airtable contact properties."

## What this PR does (the code half)

Stardance already syncs every user into the `_users` Airtable table each minute. This piggybacks on that:

- **`Airtable::UserSyncJob#field_mapping`** now also writes, from the user's latest ship-event payout ledger entry + `ShopItem.affordable_for`:
  - `Loops - stardancePayoutIssuedAt` (timestamp — the property a Loops workflow/campaign fires on)
  - `Loops - stardancePayoutStardust`, `Loops - stardancePayoutProject`
  - `Loops - stardancePayoutRec1Name/Rec1Price/Rec1Url` … `Rec3*` (the recommendations)
  - Blank for users with no payout; per-user *latest* payout only (one row per user); fails closed to `{}` so it can never break the sync.
- **`issue_payout`** calls `payout_recipient.flag_for_resync!` (the existing mechanism), so the recipient jumps to the front of the sync and their properties update **within ~1 minute** of a payout.

No direct Loops calls, no SMTP, no new email templates.

## What still has to happen (Loops/Airtable side — not code)

1. On the `_users` Airtable table, add the matching fields: `Loops - stardancePayoutIssuedAt` as a **Date/Time** field, the rest as text/number (Airtable rejects writes to fields that don't exist yet).
2. In Loops, a **workflow** triggered by `stardancePayoutIssuedAt` that sends the payout email (or a **campaign** filtered on that property). Workflows weren't covered in the Loops training, so this likely goes through Zach. Email copy must be hand-written, from a person, with the emailtools.hackclub.com unsubscribe footer.

## Caveats

- **Per-user latest**: `_users` is one row per user, so this represents the user's most recent payout, not one email per ship.
- Payouts also haven't been issued yet (the `ship_event_payouts` flag is still limited to 8 staff), so nothing fires until payouts roll out.

## Test

- Unit: for a user with a ship-event ledger entry, `field_mapping` includes `Loops - stardancePayoutIssuedAt` + the values; for a user without one, it doesn't.
- End-to-end (after the Airtable fields + workflow exist): issue a payout to yourself, confirm the `_users` row gets the properties within ~1 min and the workflow/campaign email arrives.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payout notification delivery and Airtable sync payload for all users with payouts; mitigated by fail-closed sync helpers and disabling duplicate SMTP, but a Loops/Airtable field mismatch would silently drop payout email triggers until fixed.
> 
> **Overview**
> Ship-event payout emails move off the app’s broken Loops SMTP path onto the sanctioned **Postgres → Airtable → Loops** flow by enriching **`Airtable::UserSyncJob`** with **`Loops - stardancePayout*`** contact fields from the user’s latest ship-event ledger entry (timestamp, stardust, project) plus up to three **`ShopItem.affordable_for`** recommendations (name, price, URL). That lookup **fails closed** to `{}` and reports to Sentry so a bad field or route cannot break the whole user sync.
> 
> When a payout is issued, **`issue_payout`** now calls **`payout_recipient.flag_for_resync!`** so the recipient’s Airtable row (and Loops properties) refresh within about a minute instead of waiting on the normal sync round-robin.
> 
> **`Notification`** gains an **`email_deliverable`** switch (default true) that hard-disables the email channel in **`effective_channels`**, even for critical priority. **`Notifications::Payouts::ShipEventIssued`** sets it to **false** so payout notices stay in-app and Slack only while Loops sends the email from the synced properties.
> 
> Tests cover **`field_mapping`** payout fields (latest payout wins; omitted when none) and **`email_deliverable`** channel behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87ecc919a9dcfdabca4a63811a91589613db0714. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->