### PR TITLE
fix: out of frame attachments & infinite hrefs

### DIFF
--- a/app/assets/stylesheets/components/_feed.scss
+++ b/app/assets/stylesheets/components/_feed.scss
@@ -894,7 +894,6 @@
     min-width: 0;
     min-height: 0;
     aspect-ratio: 1 / 1;
-    place-items: center;
     margin: 0;
     border: 1px solid var(--color-space-surface-faint);
     border-radius: calc(var(--border-radius) * 0.45);

--- a/app/assets/stylesheets/components/_feed.scss
+++ b/app/assets/stylesheets/components/_feed.scss
@@ -894,7 +894,6 @@
     min-width: 0;
     min-height: 0;
     aspect-ratio: 1 / 1;
-    display: grid;
     place-items: center;
     margin: 0;
     border: 1px solid var(--color-space-surface-faint);

--- a/app/components/posts/card_component.html.erb
+++ b/app/components/posts/card_component.html.erb
@@ -1,5 +1,10 @@
-<article id="<%= dom_id(post) %>" class="<%= card_classes %>" <%= tag.attributes(data: card_data) %>>
-  <% if card_link_url.present? %>
+<% if card_link_url.present? && request.original_fullpath.include?(card_link_url) %>
+<article id="<%= dom_id(post) %>" class="<%= card_classes %>">
+<% else %>
+<article id="<%= dom_id(post) %>" class="<%= card_classes %>"
+  <%= tag.attributes(data: card_data) %>>
+<% end %>
+  <% if card_link_url.present? && !request.original_fullpath.include?(card_link_url) %>
     <%= link_to card_link_url,
           class: "feed-post-card__overlay-link",
           aria: { label: "Open comments for this post" } do %>

--- a/app/components/posts/card_component.html.erb
+++ b/app/components/posts/card_component.html.erb
@@ -1,10 +1,11 @@
-<% if card_link_url.present? && request.original_fullpath.include?(card_link_url) %>
+<% on_card_link_target = card_link_url.present? && request.path == card_link_url %>
+<% if on_card_link_target %>
 <article id="<%= dom_id(post) %>" class="<%= card_classes %>">
 <% else %>
 <article id="<%= dom_id(post) %>" class="<%= card_classes %>"
   <%= tag.attributes(data: card_data) %>>
 <% end %>
-  <% if card_link_url.present? && !request.original_fullpath.include?(card_link_url) %>
+  <% if card_link_url.present? && !on_card_link_target %>
     <%= link_to card_link_url,
           class: "feed-post-card__overlay-link",
           aria: { label: "Open comments for this post" } do %>

--- a/app/components/posts/card_component.rb
+++ b/app/components/posts/card_component.rb
@@ -49,7 +49,7 @@ module Posts
     def card_classes
       class_names(
         "feed-post-card",
-        "feed-post-card--linked": card_link_url.present?,
+        "feed-post-card--linked": card_link_url.present? && request.path != card_link_url,
         "feed-post-card--compact": compact,
         "feed-post-card--quote-repost": quote_repost?,
         "feed-post-card--#{theme}": theme.present?


### PR DESCRIPTION
## what's this do?

attachments are now always in frame and you can distinguish videos from images, also you can only press the post to open it if you havent already opened it

## show it works
before:

https://github.com/user-attachments/assets/856ba287-8f56-47bf-b831-c345b67527c1

after:

https://github.com/user-attachments/assets/6f9f3880-c974-4a06-8a7d-6aa3707c4d9c

## ai?

claude
