### PR TITLE
Lookout: signal Stardance on stop + syncing-in-progress copy

### DIFF
--- a/app/javascript/controllers/lookout_capture_controller.js
+++ b/app/javascript/controllers/lookout_capture_controller.js
@@ -44,6 +44,8 @@ export default class extends Controller {
     deepLink: String,
     modeUrl: String,
     forwardUrl: String,
+    stopUrl: String,
+    syncUrl: String,
   };
 
   connect() {
@@ -228,11 +230,18 @@ export default class extends Controller {
     this.stopStream();
 
     this.showStage("done");
-    this.setText(this.doneStatusTarget, "Saving your recording…");
+    this.setText(
+      this.doneStatusTarget,
+      "Finishing up processing your timelapse. This can take a minute or two. Keep this tab open.",
+    );
     this.chooseDestination(); // enable the right destination field for the default
+    // Tell Lookout to stop, and tell Stardance too so it stamps stopped_at and
+    // starts syncing the recording immediately rather than waiting for the
+    // every-5-min poller to notice.
     await this.postJson(`/api/sessions/${this.tokenValue}/stop`, {}).catch(
       () => {},
     );
+    this.notifyStardanceStop();
     // No auto-forward: the user picks where the time goes (or not) on this stage,
     // then clicks Finish. Meanwhile, poll for the compiled video to preview it.
     this.pollStatus(this.doneStatusTarget, { showVideo: true });
@@ -250,6 +259,31 @@ export default class extends Controller {
       },
       body: JSON.stringify({ mode }),
     }).catch(() => {});
+  }
+
+  // Tell Stardance the recording stopped so it stamps stopped_at and syncs the
+  // latest state from Lookout right away, instead of waiting for the every-5-min
+  // poller. Same-origin, best-effort — the recorder still works against Lookout's
+  // API even if this fails.
+  notifyStardanceStop() {
+    if (!this.stopUrlValue) return;
+    fetch(this.stopUrlValue, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": this.csrfToken(),
+      },
+    }).catch(() => {});
+  }
+
+  // Ask Stardance to pull this session from Lookout (its `show` action runs
+  // sync_from_remote!), so the finished recording + duration land in Stardance's
+  // DB within seconds instead of on the next poll cycle. Best-effort.
+  syncStardance() {
+    if (!this.syncUrlValue) return;
+    fetch(this.syncUrlValue, { headers: { Accept: "application/json" } }).catch(
+      () => {},
+    );
   }
 
   // ── destination ("where should this time go?") ────────────────────────
@@ -389,6 +423,9 @@ export default class extends Controller {
     }
 
     if (data.status === "complete") {
+      // Stardance still shows this session in-progress until it syncs from
+      // Lookout — pull it now so the finished recording appears in the app.
+      this.syncStardance();
       if (doneOnComplete) {
         this.showStage("done");
         this.chooseDestination();
@@ -407,7 +444,12 @@ export default class extends Controller {
       return;
     }
 
-    this.setText(statusEl, "Processing your timelapse…");
+    this.setText(
+      statusEl,
+      doneOnComplete
+        ? "Waiting for your Lookout recording to finish…"
+        : "Finishing up processing your timelapse. This can take a minute or two. Keep this tab open.",
+    );
     if (!TERMINAL.includes(data.status)) {
       this.statusTimer = setTimeout(
         () => this.pollStatus(statusEl, { showVideo, doneOnComplete }),

--- a/app/views/projects/lookout_sessions/record.html.erb
+++ b/app/views/projects/lookout_sessions/record.html.erb
@@ -6,7 +6,9 @@
       data-lookout-capture-api-base-value="<%= @lookout_api_base %>"
       data-lookout-capture-deep-link-value="<%= @deep_link %>"
       data-lookout-capture-mode-url-value="<%= set_mode_project_lookout_session_path(@project, @lookout_session) %>"
-      data-lookout-capture-forward-url-value="<%= forward_heartbeats_project_lookout_session_path(@project, @lookout_session) %>">
+      data-lookout-capture-forward-url-value="<%= forward_heartbeats_project_lookout_session_path(@project, @lookout_session) %>"
+      data-lookout-capture-stop-url-value="<%= stop_project_lookout_session_path(@project, @lookout_session) %>"
+      data-lookout-capture-sync-url-value="<%= project_lookout_session_path(@project, @lookout_session) %>">
 
   <header class="lookout-rec__header">
     <h1 class="lookout-rec__title">Lookout Recording</h1>
@@ -86,7 +88,7 @@
 
   <%# ── Done: preview the timelapse, then choose where the time goes ────── %>
   <section class="lookout-rec__stage lookout-rec__stage--done" data-lookout-capture-target="doneStage" hidden>
-    <p class="lookout-rec__status" data-lookout-capture-target="doneStatus">Finishing up your timelapse…</p>
+    <p class="lookout-rec__status" data-lookout-capture-target="doneStatus">Finishing up processing your timelapse. This can take a minute or two. Keep this tab open.</p>
 
     <div class="lookout-rec__preview-wrap">
       <video class="lookout-rec__preview" data-lookout-capture-target="result" controls playsinline hidden></video>


### PR DESCRIPTION
## What

When a user ends a Lookout recording, Stardance now hears about it **immediately** instead of waiting up to 5 minutes for the poller.

Two small changes, reuse-only (no new endpoints, no migration, no new UI):

1. **Stop signal.** The recorder already tells Lookout's API to stop, but Stardance only learned about it via `SyncPendingLookoutSessionsJob` (recurring, every 5 min). Now, on stop, the recorder also POSTs Stardance's **existing** `stop` route (stamps `stopped_at`), and on compile-complete it GETs Stardance's **existing** `show` route (runs `sync_from_remote!`), so the finished recording + duration land in Stardance's DB within seconds.
   - Both calls are same-origin, best-effort — if either fails, the recorder keeps working against Lookout's API and the 5-min job still finalizes it as a backstop.
   - Wired via two new Stimulus `values` (`stopUrl`, `syncUrl`) on the recorder element, mirroring the existing `modeUrl` / `forwardUrl` plumbing.

2. **"Syncing your data" copy.** The done stage now sets expectations while the timelapse compiles: what's happening, roughly how long, and to **keep the tab open** (the user still picks where the time goes and clicks Finish — closing early skips that). The desktop-app flow keeps an honest "waiting for your recording" message instead, since there the tab is only a poller.

## Files

- `app/javascript/controllers/lookout_capture_controller.js` — `notifyStardanceStop()` + `syncStardance()` helpers; call them in `stop()` and on `pollStatus` complete; reframed processing copy.
- `app/views/projects/lookout_sessions/record.html.erb` — added `stop-url` + `sync-url` data values; updated the done-stage default status line.

## Testing

- JS parses clean (`esbuild` bundle + `node --check`).
- Manual: record → stop → confirm Stardance's session row flips to `stopped` / synced without waiting for the poller; confirm the done-stage copy shows the compile-wait guidance and desktop shows the waiting message.

Draft — leaving open for review before marking ready.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only changes reusing existing Stardance routes with best-effort fetches; no new APIs or schema. Stardance `stop` may duplicate Lookout stop calls but matches existing server behavior.
> 
> **Overview**
> The Lookout recorder now **pings Stardance on the same tab** when a session ends, so session state and the finished timelapse show up in the app within seconds instead of waiting on the ~5‑minute background poller.
> 
> After the existing Lookout API stop, the controller **POSTs** Stardance’s existing `stop` route (`notifyStardanceStop`) to stamp `stopped_at`. When status polling sees **complete**, it **GETs** the session `show` route (`syncStardance`) to trigger `sync_from_remote!`. Both calls are same-origin, CSRF-protected, and best-effort (`.catch` only)—Lookout capture and the poller remain the backstop. The record view wires **`stopUrl`** and **`syncUrl`** Stimulus values like the existing mode/forward URLs.
> 
> **Copy** on the done stage and while polling now explains that compile can take a minute or two and to **keep the tab open**; the desktop hand-off path still shows a “waiting for your Lookout recording” message when `doneOnComplete` is true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49c06d95fc81f05be298cdd47104586e8281d25a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->