### PR TITLE
Fix devlog composer toolbar: time-warning overlapping the Post button

### DIFF
--- a/app/assets/stylesheets/components/_feed.scss
+++ b/app/assets/stylesheets/components/_feed.scss
@@ -451,6 +451,9 @@
     display: flex;
     align-items: center;
     gap: var(--space-xxs);
+    // Let the tools side (which holds the time-status text) shrink and wrap
+    // instead of overrunning the submit group in a narrow composer/modal.
+    min-width: 0;
   }
 
   // Unverified `!` warning sits just left of the Post button.
@@ -458,6 +461,8 @@
     display: flex;
     align-items: center;
     gap: var(--space-xs);
+    // Keep the Post button + IDV badge at full size; the tools side gives first.
+    flex-shrink: 0;
   }
 
   &__tool-btn {
@@ -576,6 +581,9 @@
     display: flex;
     align-items: center;
     gap: var(--space-xs);
+    // Allow the status/warning line to wrap within the shrunk tools side
+    // rather than pushing the toolbar wider than its container.
+    min-width: 0;
 
     &[hidden] {
       display: none;
@@ -585,6 +593,7 @@
   &__info-text {
     font-size: calc(var(--font-size-s) * 1.2);
     color: var(--color-space-text-muted);
+    overflow-wrap: anywhere;
 
     &--warn {
       color: var(--color-brand-salmon);


### PR DESCRIPTION
## The bug

In a narrow composer (e.g. the devlog composer opened from a project page), the time-tracking status line — *"Timelapse for at least 15m before devlogging (currently 0m logged)"* — overran and **overlapped the Post button**, making it hard to read and click.

## Cause

`.feed-composer__toolbar` is `justify-content: space-between` with two children:
- `.feed-composer__tools` — holds the tabs + the status line (nested `info-wrap > info > turbo-frame > span`)
- `.feed-composer__submit-group` — the IDV badge + Post button

Neither side could give: the submit group had no `flex-shrink` guard, and the `info` nesting broke the `min-width: 0` shrink chain, so a long/wrapped status line pushed the tools side wide enough to sit *under* the submit group.

## Fix (CSS only, `_feed.scss`)

- `.feed-composer__tools { min-width: 0 }` — let the status side shrink
- `.feed-composer__submit-group { flex-shrink: 0 }` — Post + badge keep full size
- `.feed-composer__info { min-width: 0 }` — status line wraps instead of forcing width
- `.feed-composer__info-text { overflow-wrap: anywhere }` — hard-break as a last resort

## Verification

Reproduced the exact DOM structure + real CSS and rendered before/after across modal widths (720 / 780 / 840px). Before: Post overlaps the wrapped warning. After: Post stays cleanly separated at every width.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped presentation-only changes to feed composer toolbar flex/wrapping; no logic, auth, or data impact.
> 
> **Overview**
> Fixes a **narrow-composer layout bug** where the timelapse status line could sit on top of the **Post** button in the devlog toolbar (e.g. project-page modal).
> 
> The toolbar is a `space-between` flex row: tools (tabs + status) vs submit group (IDV badge + Post). The change **restores a proper shrink chain** on the tools side and **protects** the submit group: `min-width: 0` on `.feed-composer__tools` and `.feed-composer__info`, `flex-shrink: 0` on `.feed-composer__submit-group`, and `overflow-wrap: anywhere` on `.feed-composer__info-text` so long warnings wrap instead of forcing width. **CSS only** in `_feed.scss`; no markup or JS changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b929998eda2dcf40384497e154f4290f0fdb8fff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->