### PR TITLE
Show composer Record button for software projects (under :lookout)

### DIFF
--- a/app/components/posts/composer_component.html.erb
+++ b/app/components/posts/composer_component.html.erb
@@ -13,6 +13,7 @@
       <div class="feed-composer__chips" aria-label="Posting project">
       <% projects.each do |project| %>
         <% selected = project == selected_project %>
+        <% chip_record_url = record_url_for(project) %>
         <%= link_to project.title,
               home_path(project_id: project.id),
               class: class_names("feed-composer__chip", "feed-composer__chip--active": selected, "feed-composer__chip--hardware": project.hardware?),
@@ -23,8 +24,8 @@
                       composer_preview_url_param: preview_time_project_devlogs_path(project),
                       composer_edit_url_param: project_path(project, editing: true),
                       composer_hackatime_linked_param: project.hackatime_keys.present? || (project == selected_project && test_time_granted),
-                      composer_hardware_param: project.hardware?,
-                      composer_record_url_param: (show_record? && project.hardware? ? project_lookout_sessions_path(project) : "") } %>
+                      composer_record_url_param: chip_record_url,
+                      composer_recordable_param: chip_record_url.present? } %>
       <% end %>
       </div>
     <% end %>
@@ -140,17 +141,19 @@
 
         <div class="feed-composer__submit-group">
           <% if show_record? %>
-            <%# Record a timelapse — /home composer only, shown while a hardware
-                project is the selected chip. selectProject() in the composer
-                controller toggles it and re-points its create URL on chip switch. %>
+            <%# Record a timelapse — /home composer only. Shown for recordable
+                projects (hardware, or any project once the :lookout flag is on).
+                selectProject() in the composer controller toggles it and
+                re-points its create URL on chip switch. %>
+            <% selected_record_url = record_url_for(selected_project) %>
             <button type="button"
                     class="feed-composer__record"
                     data-controller="lookout-recorder"
                     data-composer-target="recordBtn"
                     data-action="lookout-recorder#record"
-                    data-lookout-recorder-create-url-value="<%= selected_project&.hardware? ? project_lookout_sessions_path(selected_project) : "" %>"
+                    data-lookout-recorder-create-url-value="<%= selected_record_url %>"
                     aria-label="Record a timelapse"
-                    <%= "hidden" unless selected_project&.hardware? %>>
+                    <%= "hidden" if selected_record_url.blank? %>>
               <span class="feed-composer__record-dot" aria-hidden="true"></span>
               Record
             </button>

--- a/app/components/posts/composer_component.rb
+++ b/app/components/posts/composer_component.rb
@@ -67,10 +67,21 @@ module Posts
     end
 
     # Only the /home composer shows the "Record a timelapse" button (toggled per
-    # selected project's hardware status by the composer controller). The project
-    # page has its own dedicated record button, so its composer leaves this off.
+    # selected project by the composer controller). The project page has its own
+    # dedicated record button, so its composer leaves this off.
     def show_record?
       show_record
+    end
+
+    # Where the Record button points for a given project chip, or "" when the
+    # button shouldn't render. Lookout recording is offered for hardware projects,
+    # and for every project once the :lookout flag is on (Lookout becomes the
+    # default time path there). The view keys both the create-URL and the button's
+    # visibility off this one method, so they can never drift apart.
+    def record_url_for(project)
+      return "" unless show_record? && project
+      return "" unless project.hardware? || Flipper.enabled?(:lookout, current_user)
+      helpers.project_lookout_sessions_path(project)
     end
 
     def form_url

--- a/app/javascript/controllers/composer_controller.js
+++ b/app/javascript/controllers/composer_controller.js
@@ -198,7 +198,7 @@ export default class extends Controller {
       previewUrl,
       editUrl,
       hackatimeLinked,
-      hardware,
+      recordable,
       recordUrl,
     } = event.params;
     const linked = !!hackatimeLinked;
@@ -238,10 +238,11 @@ export default class extends Controller {
       if (editUrl) this.warnTarget.href = editUrl;
     }
 
-    // The Record button (home composer only) applies to hardware projects; show
-    // it and point it at the newly-selected project's create-session endpoint.
+    // The Record button (home composer only) shows for recordable projects
+    // (hardware, or any project once the :lookout flag is on); point it at the
+    // newly-selected project's create-session endpoint.
     if (this.hasRecordBtnTarget) {
-      this.recordBtnTarget.hidden = !hardware;
+      this.recordBtnTarget.hidden = !recordable;
       if (recordUrl) {
         this.recordBtnTarget.dataset.lookoutRecorderCreateUrlValue = recordUrl;
       }


### PR DESCRIPTION
## What

Let people with **software** projects record a Lookout timelapse from the home-feed devlog composer — the "Record" button now renders for them, not just hardware projects.

## Why it was blocked

The server already allows it: `Projects::LookoutSessionsController` gates on `hardware_flow || lookout` and authorizes `create_devlog?` — nothing project-type-specific. The only thing holding software projects back was the composer's **view/JS** gating (`project.hardware?`).

## Change (reuse-only, no new endpoints/migration/UI)

- Add `ComposerComponent#record_url_for(project)` — returns the create-session URL when the Record button should show (**hardware project, or any project once `:lookout` is on for the actor**), else `""`.
- The chip data params, the initial button render, and the Stimulus `selectProject` toggle all key off this one method, so the create-URL and the button's visibility can't drift apart.
- Renamed the composer `hardware` Stimulus param → `recordable` to match the new meaning (it only ever drove the Record button).

## Flag-gated / prod-safe

With `:lookout` **off** (prod default) behavior is unchanged — hardware only. With it **on**, software projects gain the Record button too. Consistent with the rest of the Lookout-default rollout.

## Testing

- `ruby -c` + ERB parse + `node --check` all clean.
- Manual (with `:lookout` enabled): pick a software project chip in the home composer → Record button shows and points at that project's `lookout_sessions` create URL; switching chips re-points it; with `:lookout` off, only hardware chips show it.

Draft — flip `:lookout` for your user and eyeball both project types, then mark ready.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and Flipper gating only; backend authorization was already flag-aware, and prod default leaves hardware-only behavior unchanged.
> 
> **Overview**
> The home-feed devlog composer **Record** control was tied to **hardware** projects only in the view and Stimulus layer, even though Lookout session creation already allows software when **`:lookout`** is enabled for the user.
> 
> **`ComposerComponent#record_url_for(project)`** centralizes when the button should appear and where it posts: it returns the project’s Lookout create-session path for hardware projects, or for any project type when **`Flipper.enabled?(:lookout, current_user)`**, otherwise an empty string. Project chips, the initial Record button render, and chip switching all use that helper so visibility and **`data-lookout-recorder-create-url-value`** stay in sync.
> 
> The composer Stimulus param **`hardware`** is renamed to **`recordable`**, set from whether the chip has a non-blank record URL, and **`selectProject`** toggles the Record button from **`recordable`** instead of hardware status.
> 
> With **`:lookout` off**, behavior is unchanged (hardware only). With it on, software project chips show Record and point at the correct session endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed1fc1f779b1f721a21c98944b44312892d9e180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->