### PR TITLE
Link a finished timelapse to a devlog (reassure + attach)

### DIFF
--- a/app/assets/stylesheets/components/_feed.scss
+++ b/app/assets/stylesheets/components/_feed.scss
@@ -299,6 +299,19 @@
     background: var(--color-brand-salmon);
   }
 
+  // Reassurance banner shown when a just-finished timelapse is being carried
+  // into this devlog (Lookout recording → "Add it to a devlog").
+  &__timelapse-note {
+    margin: 0 0 var(--space-xs);
+    padding: var(--space-xs);
+    border: 1px solid var(--color-brand-mint);
+    border-radius: var(--border-radius);
+    background: var(--color-space-accent-soft);
+    color: var(--color-space-text);
+    font-size: calc(var(--font-size-s) * 1.1);
+    line-height: 1.4;
+  }
+
   &__form {
     display: flex;
     flex-direction: column;
@@ -839,6 +852,23 @@
   &__duration {
     margin: var(--space-xxs) 0 0;
     font-size: calc(var(--font-size-s) * 1.2);
+  }
+
+  &__timelapse {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xxs);
+    margin: var(--space-xxs) 0 0;
+    font-size: calc(var(--font-size-s) * 1.1);
+    color: var(--color-brand-mint);
+  }
+
+  &__timelapse-dot {
+    flex: 0 0 auto;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--color-brand-mint);
   }
 
   &__body {

--- a/app/components/posts/card_component.html.erb
+++ b/app/components/posts/card_component.html.erb
@@ -57,6 +57,12 @@
         <p class="feed-post-card__duration"><%= helpers.format_seconds(display_postable.duration_seconds) %> logged</p>
       <% end %>
 
+      <% if devlog? && current_user && Flipper.enabled?(:timelapse_devlog, current_user) && display_postable.lookout_sessions.exists? %>
+        <p class="feed-post-card__timelapse">
+          <span class="feed-post-card__timelapse-dot" aria-hidden="true"></span>Timelapse attached
+        </p>
+      <% end %>
+
       <% if quote_repost? && body.present? %>
         <div class="feed-post-card__body feed-post-card__body--inline markdown-content">
           <%= helpers.md(body, allow_images: false) %>

--- a/app/components/posts/composer_component.html.erb
+++ b/app/components/posts/composer_component.html.erb
@@ -42,7 +42,7 @@
             session to this devlog, and reassure the user we kept their lapse. %>
         <%= hidden_field_tag "post_devlog[lookout_session_ids][]", pending_lookout_session.id %>
         <div class="feed-composer__timelapse-note" role="status">
-          Your timelapse (<%= helpers.format_seconds(pending_lookout_session.duration_seconds) %>) is saved and will be attached to this devlog.
+          Your timelapse<% if pending_lookout_session.duration_seconds.to_i > 0 %> (<%= helpers.format_seconds(pending_lookout_session.duration_seconds) %>)<% end %> is saved and will be attached to this devlog.
         </div>
       <% end %>
       <div class="feed-composer__scroll">

--- a/app/components/posts/composer_component.html.erb
+++ b/app/components/posts/composer_component.html.erb
@@ -37,6 +37,14 @@
                           action: class_names("submit->composer#guardSubmit", "paste->composer#paste": show_attachments?) } },
           class: "feed-composer__form",
           local: true do |f| %>
+      <% if pending_lookout_session.present? %>
+        <%# Carried over from a just-finished Lookout recording: link that
+            session to this devlog, and reassure the user we kept their lapse. %>
+        <%= hidden_field_tag "post_devlog[lookout_session_ids][]", pending_lookout_session.id %>
+        <div class="feed-composer__timelapse-note" role="status">
+          Your timelapse (<%= helpers.format_seconds(pending_lookout_session.duration_seconds) %>) is saved and will be attached to this devlog.
+        </div>
+      <% end %>
       <div class="feed-composer__scroll">
         <div class="feed-composer__main" data-markdown-preview-target="writePanel">
           <%= image_tag current_user.avatar, alt: "", class: "feed-composer__avatar" %>

--- a/app/components/posts/composer_component.rb
+++ b/app/components/posts/composer_component.rb
@@ -7,13 +7,13 @@ module Posts
     attr_reader :post, :current_user, :projects, :selected_project, :test_time_granted,
                 :url, :scope, :aria_label, :body_label, :placeholder, :submit_text,
                 :disable_with, :simple_mode, :show_project_chips, :show_attachments,
-                :show_time_preview, :show_record, :quote_preview_post
+                :show_time_preview, :show_record, :quote_preview_post, :pending_lookout_session
 
     def initialize(post:, current_user:, projects:, selected_project:, test_time_granted: false,
       url: nil, scope: nil, aria_label: "Create a devlog", body_label: "What are you working on?",
       placeholder: "What are you working on?", submit_text: "Post", disable_with: "Posting...",
       simple_mode: false, show_project_chips: true, show_attachments: true, show_time_preview: true,
-      show_record: false, quote_preview_post: nil)
+      show_record: false, quote_preview_post: nil, pending_lookout_session: nil)
       @post = post
       @current_user = current_user
       @projects = projects
@@ -32,6 +32,7 @@ module Posts
       @show_time_preview = show_time_preview
       @show_record = show_record
       @quote_preview_post = quote_preview_post
+      @pending_lookout_session = pending_lookout_session
     end
 
     # When a post to quote is supplied, the composer shows it below the text box

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -49,6 +49,14 @@ class ProjectsController < ApplicationController
       @composer_devlog = Post::Devlog.new
       @composer_projects = current_user.projects.order(updated_at: :desc)
 
+      # Coming back from a just-finished Lookout recording: pre-link that
+      # session to the devlog the user is about to write, so their timelapse
+      # attaches to the post instead of feeling lost.
+      if Flipper.enabled?(:timelapse_devlog, current_user) && params[:lookout_session_id].present?
+        @pending_lookout_session = @project.lookout_sessions.attachable
+          .find_by(id: params[:lookout_session_id], user: current_user, devlog_id: nil)
+      end
+
       @hackatime_linked = current_user.hackatime_identity.present?
 
       if @hackatime_linked

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -53,7 +53,7 @@ class ProjectsController < ApplicationController
       # session to the devlog the user is about to write, so their timelapse
       # attaches to the post instead of feeling lost.
       if Flipper.enabled?(:timelapse_devlog, current_user) && params[:lookout_session_id].present?
-        @pending_lookout_session = @project.lookout_sessions.attachable
+        @pending_lookout_session = @project.lookout_sessions.linkable
           .find_by(id: params[:lookout_session_id], user: current_user, devlog_id: nil)
       end
 

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -134,7 +134,9 @@ export default class extends Controller {
 
   // Landing on the project page straight from a finished Lookout recording
   // (?just_recorded=1): pop the devlog composer open so the timelapse can be
-  // attached, then strip the params so a refresh doesn't reopen it.
+  // attached, then strip just_recorded so a refresh doesn't reopen it.
+  // Keep lookout_session_id: it's what the server reads to render the hidden
+  // attach field, so dropping it would lose the link on a pre-submit refresh.
   openComposerModalFromQueryParam() {
     if (!this.element.id.startsWith("composer-modal-")) return;
 
@@ -146,7 +148,6 @@ export default class extends Controller {
     }
 
     params.delete("just_recorded");
-    params.delete("lookout_session_id");
     const query = params.toString();
     const nextUrl = `${window.location.pathname}${query ? `?${query}` : ""}${
       window.location.hash

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -30,6 +30,7 @@ export default class extends Controller {
 
     this.openSettingsModalFromQueryParam();
     this.openIdvModalFromQueryParam();
+    this.openComposerModalFromQueryParam();
   }
 
   disconnect() {
@@ -124,6 +125,28 @@ export default class extends Controller {
     }
 
     params.delete("idv_check");
+    const query = params.toString();
+    const nextUrl = `${window.location.pathname}${query ? `?${query}` : ""}${
+      window.location.hash
+    }`;
+    window.history.replaceState(window.history.state, "", nextUrl);
+  }
+
+  // Landing on the project page straight from a finished Lookout recording
+  // (?just_recorded=1): pop the devlog composer open so the timelapse can be
+  // attached, then strip the params so a refresh doesn't reopen it.
+  openComposerModalFromQueryParam() {
+    if (!this.element.id.startsWith("composer-modal-")) return;
+
+    const params = new URLSearchParams(window.location.search);
+    if (!params.has("just_recorded")) return;
+
+    if (!this.element.open) {
+      this.element.showModal();
+    }
+
+    params.delete("just_recorded");
+    params.delete("lookout_session_id");
     const query = params.toString();
     const nextUrl = `${window.location.pathname}${query ? `?${query}` : ""}${
       window.location.hash

--- a/app/models/lookout_session.rb
+++ b/app/models/lookout_session.rb
@@ -45,6 +45,13 @@ class LookoutSession < ApplicationRecord
 
   scope :for_project, ->(project) { where(project: project) }
   scope :attachable, -> { where(status: %w[stopped complete]) }
+  # Sessions that can be linked to a devlog from the recorder → composer flow.
+  # Broader than `attachable` (which requires a finished video): a session still
+  # `compiling` will finalize shortly, and the submit-side attach accepts any
+  # status, so the composer must surface the attach field for it too. Otherwise
+  # a background sync flipping stopped → compiling mid-flow silently drops the
+  # link. Excludes `failed` and the still-recording states.
+  scope :linkable, -> { where(status: %w[stopped compiling complete]) }
   # Sessions that might still advance — everything not yet in a terminal state.
   # SyncPendingLookoutSessionsJob re-polls these so a recording can finalize even
   # when the builder closed the recorder tab before Lookout finished compiling.

--- a/app/views/projects/lookout_sessions/record.html.erb
+++ b/app/views/projects/lookout_sessions/record.html.erb
@@ -165,8 +165,15 @@
 
     <%# Shown after the time is sent — nudge to actually log it in a devlog. %>
     <div class="lookout-rec__post-prompt" data-lookout-capture-target="postPrompt" hidden>
-      <%= link_to "Post a Devlog", project_path(@project), class: "lookout-rec__post-btn" %>
-      <p class="lookout-rec__post-sub">Your time only counts once you do a devlog.</p>
+      <% if Flipper.enabled?(:timelapse_devlog, current_user) %>
+        <%= link_to "Add it to a devlog",
+                    project_path(@project, lookout_session_id: @lookout_session.id, just_recorded: 1),
+                    class: "lookout-rec__post-btn" %>
+        <p class="lookout-rec__post-sub">Saved! We've got your timelapse. Add it to a devlog so your time counts.</p>
+      <% else %>
+        <%= link_to "Post a Devlog", project_path(@project), class: "lookout-rec__post-btn" %>
+        <p class="lookout-rec__post-sub">Your time only counts once you do a devlog.</p>
+      <% end %>
     </div>
 
     <%= link_to "Back to project →", project_path(@project),

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -905,7 +905,8 @@
             current_user: current_user,
             projects: @composer_projects,
             selected_project: @project,
-            test_time_granted: @test_time_granted
+            test_time_granted: @test_time_granted,
+            pending_lookout_session: @pending_lookout_session
           ) %>
     </dialog>
   <% end %>

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -42,6 +42,7 @@ Rails.application.config.after_initialize do
         ship_event_payouts
         lookout
         payout_recommendations
+        timelapse_devlog
       ].each { |flag| Flipper.add(flag) }
     end
   rescue StandardError => e


### PR DESCRIPTION
## The problem

People think their Lookout recording vanished. After recording, the timelapse **is** saved on Stardance's side — but it never surfaces again and isn't tied to anything, so it feels lost.

Digging in: the backend *already* supports linking a session to a devlog (`DevlogsController#attach_lookout_sessions` reads `params[:post_devlog][:lookout_session_ids]`), but **nothing in the UI ever sends it**, and **devlogs never display a timelapse**. So the wiring exists — it's just not connected.

## This PR — "reassure + link first" (flag: `timelapse_devlog`, off by default)

1. **Recorder done screen**: says it plainly — *"Saved! We've got your timelapse"* — and turns "Post a Devlog" into **"Add it to a devlog"**, carrying the session id + `just_recorded=1` back to the project page.
2. **Project page** (`ProjectsController#show`): reads `lookout_session_id`, sets `@pending_lookout_session` (must be attachable, owned by the user, not already linked).
3. **Composer**: renders a hidden `post_devlog[lookout_session_ids][]` for that session + a reassurance banner (*"Your timelapse (Xm) is saved and will be attached to this devlog"*). The `modal` controller auto-opens the composer on `?just_recorded=1` and strips the params.
4. **Devlog card**: a small **"Timelapse attached"** chip when the devlog has a linked session — so the connection is visible on the post.

Backend link + the destination flow are unchanged; on submit the existing `attach_lookout_sessions` sets `devlog_id`.

## Turning it on (and rolling back)

The whole feature is gated on the `timelapse_devlog` Flipper flag, registered in `config/initializers/flipper.rb`. It's a **per-actor** flag (`Flipper.enabled?(:timelapse_devlog, current_user)`), so you can enable it for yourself first, then a percentage, then everyone. Enable it the same way as `lookout`.

**Heads up:** the flag gates *both* sides — the author flow (recorder → "Add it to a devlog") **and** the viewer's "Timelapse attached" chip. So test with the flag enabled for the user who records *and* views.

**Option A — Flipper UI (`/admin/flipper`, admin-gated):**
- Go to `https://stardance.hackclub.com/admin/flipper`, open `timelapse_devlog`.
- Just you: under **Actors**, add your user's `flipper_id` and register it.
- Gradual: set **Percentage of Actors** (e.g. 10 → 50 → 100).
- Everyone at once: flip the **Boolean** gate to fully on.
- Roll back: clear the gate(s) / toggle Boolean off.

**Option B — Rails console** (Coolify `web` or `worker`, `bin/rails console`):
```ruby
# just one user (recommend starting here — enable it for yourself)
Flipper.enable_actor(:timelapse_devlog, User.find(<your_user_id>))

# gradual rollout to a % of users
Flipper.enable_percentage_of_actors(:timelapse_devlog, 25)

# everyone
Flipper.enable(:timelapse_devlog)

# roll back / turn fully off
Flipper.disable(:timelapse_devlog)
```

Prod is byte-for-byte unchanged until you enable it for an actor.

## Deliberately deferred (fast follow)

The actual **timelapse frame as the devlog's image** (auto-attaching a screenshot). Lookout exposes a `thumbnailUrl`; the plan is a same-origin thumbnail proxy + pre-attach into the composer so the screenshot shows in the draft.

## Notes / tradeoffs

- Reuse-only: no new endpoints, models, or migrations. Uses the existing `attachable` scope, `format_seconds` helper, the modal query-param opener pattern, and BEM classes in `_feed.scss`.
- The card chip does a per-card `lookout_sessions.exists?`; gated behind the flag to bound cost during rollout. **Preload `lookout_sessions` on the timeline query before this goes wide** (follow-up).

## Testing

- `ruby -c` / ERB parse / `node --check` all clean.
- Manual (with `:timelapse_devlog` on): record a timelapse → "Add it to a devlog" → project page opens the composer with the reassurance banner + hidden session field → post → devlog shows the "Timelapse attached" chip and the session's `devlog_id` is set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches devlog create params and session linking with Flipper gating; card `exists?` queries may need preload before wide rollout, but behavior is unchanged until the flag is enabled.
> 
> **Overview**
> Under the **`timelapse_devlog`** Flipper flag (off by default), this connects the **existing** devlog attach path (`post_devlog[lookout_session_ids][]` → `attach_lookout_sessions`) to the UI so finished Lookout sessions don’t feel lost.
> 
> **Author flow:** After recording, the done screen becomes **“Add it to a devlog”** with copy that the timelapse is saved, linking to the project with `lookout_session_id` and `just_recorded=1`. **`ProjectsController#show`** loads a **`linkable`** session (new scope: `stopped` / `compiling` / `complete`, broader than `attachable`) owned by the user and not yet linked. The devlog **composer** shows a reassurance banner plus a hidden session id field; **`modal_controller`** opens the composer on `?just_recorded=1` and strips only that param (keeps `lookout_session_id` for refresh-before-submit).
> 
> **Feed:** Devlog **cards** show a mint **“Timelapse attached”** indicator when the post has linked lookout sessions (flag-gated; uses `lookout_sessions.exists?` per card).
> 
> Styling adds composer note and card timelapse chip classes in **`_feed.scss`**. No new endpoints or migrations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb3dd94a47d8df7a978306f35bfaa98744dd05f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->