### PR TITLE
Harden payout Loops sync: only genuine positive payouts (never reversals)

### DIFF
--- a/app/jobs/airtable/user_sync_job.rb
+++ b/app/jobs/airtable/user_sync_job.rb
@@ -62,11 +62,16 @@ class Airtable::UserSyncJob < Airtable::BaseSyncJob
   # templated into the email. All of these `Loops - stardancePayout*` fields exist
   # on the `_users` table. Recommendations come from ShopItem.affordable_for (full
   # balance + region + wishlist + live catalog). Per-user latest payout only (one
-  # row per user); blank for users with no ship-event payout; fails closed to {}
-  # so it can never break the sync.
+  # row per user); blank for users with no genuine ship-event payout; fails closed
+  # to {} so it can never break the sync.
   def payout_loops_fields(user)
+    # Only genuine positive payouts drive the email. Ship-event ledger entries
+    # also include clawbacks (created_by "manual_ship_event_payout_reversal",
+    # negative amount); if a reversal were the user's latest entry the email
+    # would announce e.g. "-9 stardust", so scope to real payouts of amount > 0.
     entry = user.ledger_entries
-                .where(ledgerable_type: "Post::ShipEvent")
+                .where(ledgerable_type: "Post::ShipEvent", created_by: "ship_event_payout")
+                .where("amount > 0")
                 .order(created_at: :desc)
                 .first
     return {} unless entry


### PR DESCRIPTION
Follow-up to #747 (now merged + live).

## Problem
`Airtable::UserSyncJob#payout_loops_fields` picked each user's **latest `Post::ShipEvent` ledger entry with no filter**. But ship-event ledger entries also include **clawbacks** — `created_by = "manual_ship_event_payout_reversal"` with a **negative amount**. If a reversal were a user's most recent ship-event entry, the payout email would announce something like *"you earned −9 stardust"* and set the `stardancePayoutIssuedAt` trigger off a reversal.

## Fix
Scope the lookup to genuine positive payouts only:
```ruby
.where(ledgerable_type: "Post::ShipEvent", created_by: "ship_event_payout")
.where("amount > 0")
```

## Evidence (prod data)
- 404 genuine `ship_event_payout` entries across **339 distinct users**, amounts 1–1260.
- **1** `manual_ship_event_payout_reversal` at **−9**.
- No user's *latest* entry is currently a reversal, so this is **preventative** — it stops a future reversal (or any non-payout ship-event entry) from ever driving a wrong/negative payout email.

## Scope
One-line query hardening; no behavior change for the 339 real payouts. The blank-project case (~13% of payouts don't resolve a project title) is handled in the email copy (Loops side), not here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-query hardening in Airtable user sync with fail-closed error handling; no auth or payment path changes, and prod data shows no current users affected.
> 
> **Overview**
> **Hardens `Airtable::UserSyncJob#payout_loops_fields`** so Loops payout email triggers and templated stardust/project fields only reflect real payouts, not clawbacks.
> 
> The latest `Post::ShipEvent` ledger lookup now filters to **`created_by: "ship_event_payout"`** and **`amount > 0`**, excluding **`manual_ship_event_payout_reversal`** entries that could otherwise become the most recent row and produce negative or misleading payout copy. Comments clarify “genuine ship-event payout” vs any ship-event ledger row; behavior for users whose latest entry is already a real payout is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45c931d3a5d42f6ac014a1e1dec1f47518c31f43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->