### PR TITLE
fix: ship attachments not being uploaded

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -165,6 +165,15 @@ module ApplicationHelper
     end
   end
 
+  def attachment_available?(attachment)
+    blob = attachment&.blob
+    return false unless blob
+
+    blob.service.exist?(blob.key)
+  rescue ActiveStorage::FileNotFoundError, ActiveStorage::IntegrityError, Errno::ENOENT
+    false
+  end
+
 
   def cache_stats
     hits = Thread.current[:cache_hits] || 0

--- a/app/models/post/ship_event.rb
+++ b/app/models/post/ship_event.rb
@@ -103,7 +103,9 @@ class Post::ShipEvent < ApplicationRecord
   end
 
   def capture_hours_at_ship
-    reload.recalculate_hours_at_ship
+    association(:post).reset
+    association(:project).reset
+    recalculate_hours_at_ship
   end
 
   def recalculate_hours_at_ship

--- a/app/views/shared/_post_media.html.erb
+++ b/app/views/shared/_post_media.html.erb
@@ -8,7 +8,9 @@
       <div class="feed-post-card__media-track">
         <% attachments.each do |attachment| %>
           <figure class="feed-post-card__media-slide <%= 'ai-detected' if current_user&.admin? && attachment.blob.metadata["ai_generated"] %>">
-            <% if attachment.variable? %>
+            <% if !attachment_available?(attachment) %>
+              <span class="feed-post-card__file">Attachment unavailable</span>
+            <% elsif attachment.variable? %>
               <%= image_tag attachment.variant(media_variant),
                             alt: "",
                             class: "feed-post-card__image",


### PR DESCRIPTION
## what's this do?

as a side effect of cb34de66, the website would reload which discarded the uploading to active storage which lead to the attachment going missing and hence the 500 on all ship attachments. This fixes that as well as adds a check to see if the attachment is available.

## show it works

https://github.com/user-attachments/assets/564c884e-503f-478b-990d-1d244e633ffb

## ai?

claude fable 5 🤯 
