### PR TITLE
feat: admin qol and fix first ship vote amount

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -610,7 +610,6 @@ dialog {
   border: 1px solid var(--color-space-border);
   border-radius: 0.5rem;
   padding: var(--space-m);
-  margin-top: var(--space-m);
 
   &--highlighted {
     border: 2px solid var(--color-brand-yellow);
@@ -707,7 +706,6 @@ dialog {
 
 /* ── Audit log component ─────────────────────────────────────────── */
 .audit-log {
-  margin-top: var(--space-l);
   border: 1px solid var(--color-space-border);
   border-radius: 8px;
   background: var(--color-space-surface-faint);

--- a/app/assets/stylesheets/pages/admin/_support.scss
+++ b/app/assets/stylesheets/pages/admin/_support.scss
@@ -34,6 +34,12 @@
     }
   }
 
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-l);
+  }
+
   &__section-title {
     margin: 0 0 var(--space-s);
     font-size: 16px;

--- a/app/assets/stylesheets/pages/shop/_admin_order_show.scss
+++ b/app/assets/stylesheets/pages/shop/_admin_order_show.scss
@@ -860,7 +860,6 @@
   border: 1px solid var(--color-space-border);
   border-radius: 12px;
   overflow: hidden;
-  margin-bottom: var(--space-l);
 
   &__header {
     display: flex;

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -399,10 +399,10 @@ class Project < ApplicationRecord
     state :rejected
 
     event :submit_for_review do
-      transitions from: [ :draft, :submitted, :under_review, :needs_changes, :approved, :rejected ], to: :submitted, guard: :shippable?
-      after do
-        self.shipped_at = Time.current # I moved this logic to the ships controller as there's differences in how we handle reships - @AVD
-      end
+      transitions from: [ :draft, :submitted, :under_review, :needs_changes, :approved, :rejected ],
+                  to: :submitted,
+                  guard: :shippable?,
+                  after: -> { self.shipped_at = Time.current }
     end
 
     event :start_review do

--- a/app/views/admin/projects/show.html.erb
+++ b/app/views/admin/projects/show.html.erb
@@ -90,7 +90,6 @@
     </div>
   </div>
 
-  
   <div class="mission-panel">
     <h2 class="admin-user-show__section-title">Actions</h2>
     <div class="admin-user-show__actions">

--- a/app/views/admin/projects/show.html.erb
+++ b/app/views/admin/projects/show.html.erb
@@ -31,8 +31,8 @@
         <% end %>
         <dt>Created</dt>      <dd><%= @project.created_at.strftime("%Y-%m-%d %H:%M") %></dd>
         <dt>Updated</dt>      <dd><%= @project.updated_at.strftime("%Y-%m-%d %H:%M") %></dd>
-        <dt>Shipped</dt>      <dd><%= @project.shipped_at&.strftime("%Y-%m-%d %H:%M") || content_tag(:span, "Not shipped", class: "admin-user-show__muted") %></dd>
-        <dt>Status</dt>       <dd><%= @project.deleted? ? "Deleted" : "Active" %></dd>
+        <dt>Last Shipped</dt> <dd><%= @project.shipped_at&.strftime("%Y-%m-%d %H:%M") || content_tag(:span, "Not shipped", class: "admin-user-show__muted") %></dd>
+        <dt>Active</dt>       <dd><%= @project.deleted? ? "Deleted" : "Yes" %></dd>
         <dt>Tutorial</dt>     <dd><%= @project.tutorial? ? "Yes" : "No" %></dd>
         <dt>Duration</dt>     <dd><%= @project.duration_seconds > 0 ? "#{(@project.duration_seconds / 3600.0).round(1)}h" : "0h" %></dd>
         <dt>Devlogs</dt>      <dd><%= @project.devlogs_count %></dd>
@@ -90,13 +90,14 @@
     </div>
   </div>
 
-  <% if policy(current_user).view_order_full_details? %>
-    <div class="mission-panel">
-      <h2 class="admin-user-show__section-title">Actions</h2>
-      <div class="admin-user-show__actions">
-        <%= render ActionButtonComponent.new(text: "← Back", href: admin_projects_path, size: :small, variant: :secondary) %>
-        <%= render ActionButtonComponent.new(text: "Public Page", href: project_path(@project), size: :small, variant: :secondary) %>
-        <%= render ActionButtonComponent.new(text: "Votes", href: votes_admin_project_path(@project), size: :small, variant: :secondary) %>
+  
+  <div class="mission-panel">
+    <h2 class="admin-user-show__section-title">Actions</h2>
+    <div class="admin-user-show__actions">
+      <%= render ActionButtonComponent.new(text: "← Back", href: admin_projects_path, size: :small, variant: :secondary) %>
+      <%= render ActionButtonComponent.new(text: "Public Page", href: project_path(@project), size: :small, variant: :secondary) %>
+      <%= render ActionButtonComponent.new(text: "Votes", href: votes_admin_project_path(@project), size: :small, variant: :secondary) %>
+      <% if policy(current_user).view_order_full_details? %>
         <% if @project.deleted? %>
           <%= button_to "Restore Project", restore_admin_project_path(@project), method: :post,
               data: { confirm: "Restore this project?" } %>
@@ -104,9 +105,11 @@
           <%= button_to "Delete Project", delete_admin_project_path(@project), method: :post,
               data: { confirm: "Delete this project?" } %>
         <% end %>
-      </div>
+      <% end %>
     </div>
+  </div>
 
+  <% if policy(current_user).view_order_full_details? %>
     <%= render layout: "shared/modal", locals: { id: "change-ship-status-modal", title: "Change Ship Status", description: "Bypasses AASM transitions and is logged to PaperTrail." } do %>
       <form action="<%= update_ship_status_admin_project_path(@project) %>" method="post">
         <%= hidden_field_tag :authenticity_token, form_authenticity_token %>

--- a/app/views/admin/projects/votes.html.erb
+++ b/app/views/admin/projects/votes.html.erb
@@ -7,6 +7,10 @@
     <input type="checkbox" id="toggle-reasons" checked>
     Show vote reasons
   </label>
+  <label>
+    <input type="checkbox" id="toggle-discarded" checked>
+    Show discarded votes
+  </label>
 </div>
 
 <div>
@@ -66,18 +70,36 @@
 
 <script>
   (function() {
-    const toggle = document.getElementById("toggle-reasons");
-    if (!toggle) return;
+    const toggleReasons = document.getElementById("toggle-reasons");
+    const toggleDiscarded = document.getElementById("toggle-discarded");
 
-    const setReasonsExpanded = (expanded) => {
-      document.querySelectorAll("td.vote-reasons details").forEach((details) => {
-        details.open = expanded;
+    if (toggleDiscarded) {
+      const setDiscardedVisibility = (visible) => {
+        document.querySelectorAll("tr").forEach((row) => {
+          const statusCell = row.querySelector("td:nth-child(7)");
+          if (statusCell && statusCell.textContent.trim() === "Discarded") {
+            row.style.display = visible ? "" : "none";
+          }
+        });
+      };
+
+      setDiscardedVisibility(toggleDiscarded.checked);
+      toggleDiscarded.addEventListener("change", function() {
+        setDiscardedVisibility(this.checked);
+      });
+    }
+
+    if (toggleReasons) {
+      const setReasonsExpanded = (expanded) => {
+        document.querySelectorAll("td.vote-reasons details").forEach((details) => {
+          details.open = expanded;
+        });
+      };
+
+      setReasonsExpanded(toggleReasons.checked);
+      toggleReasons.addEventListener("change", function() {
+        setReasonsExpanded(this.checked);
       });
     };
-
-    setReasonsExpanded(toggle.checked);
-    toggle.addEventListener("change", function() {
-      setReasonsExpanded(this.checked);
-    });
   })();
 </script>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -263,22 +263,24 @@
         </script>
       <% end %>
 
-      <% if @user.shop_orders.where(aasm_state: %w[pending awaiting_periodical_fulfillment]).any? %>
-        <button type="button" onclick="document.getElementById('reject-modal-orders').showModal()">
-          ✗ Reject Orders
-        </button>
-        <%= render layout: "shared/modal", locals: { id: "reject-modal-orders", title: "Reject All Orders", description: "This will reject all pending and awaiting fulfillment orders for #{@user.display_name}." } do %>
-          <form action="<%= admin_user_order_rejection_path(@user) %>" method="post">
-            <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
-            <div>
-              <%= label_tag :reason, "Rejection Reason (optional)" %>
-              <%= text_area_tag :reason, "", placeholder: "Enter reason..." %>
-            </div>
-            <div>
-              <button type="submit">Confirm Reject</button>
-              <button type="button" onclick="document.getElementById('reject-modal-orders').close()">Cancel</button>
-            </div>
-          </form>
+      <% if policy(current_user).view_order_full_details? %>
+        <% if @user.shop_orders.where(aasm_state: %w[pending awaiting_periodical_fulfillment]).any? %>
+          <button type="button" onclick="document.getElementById('reject-modal-orders').showModal()">
+            ✗ Reject Orders
+          </button>
+          <%= render layout: "shared/modal", locals: { id: "reject-modal-orders", title: "Reject All Orders", description: "This will reject all pending and awaiting fulfillment orders for #{@user.display_name}." } do %>
+            <form action="<%= admin_user_order_rejection_path(@user) %>" method="post">
+              <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+              <div>
+                <%= label_tag :reason, "Rejection Reason (optional)" %>
+                <%= text_area_tag :reason, "", placeholder: "Enter reason..." %>
+              </div>
+              <div>
+                <button type="submit">Confirm Reject</button>
+                <button type="button" onclick="document.getElementById('reject-modal-orders').close()">Cancel</button>
+              </div>
+            </form>
+          <% end %>
         <% end %>
       <% end %>
 

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -29,6 +29,8 @@
         <% end %>
         <dt>Balance</dt>
         <dd><%= @user.balance %> tickets</dd>
+        <dt>Vote Balance</dt>
+        <dd><%= @user.vote_balance %> votes</dd>
         <dt>Roles</dt>
         <dd><%= @user.roles.map { |r| r.to_s.titleize }.join(", ").presence || content_tag(:span, "None", class: "admin-user-show__muted") %></dd>
         <dt>Projects (<%= @all_projects.size %>)</dt>
@@ -154,12 +156,12 @@
   <% end %>
 </div>
 <br>
-<div>
+<div class="admin-user-show__list">
   <div>
     <h2>Actions</h2>
     <div>
       <% if policy(Message).create? %>
-        <%= link_to "✉️ Send Message", admin_messages_path(slack_id: @user.slack_id) %>
+       <%= render ActionButtonComponent.new(text: "Send Message", href: admin_messages_path(slack_id: @user.slack_id), size: :small, variant: :secondary) %>
       <% end %>
       <% if policy(@user).impersonate? && !impersonating? %>
         <%= button_to "Impersonate User",
@@ -169,15 +171,19 @@
                         confirm: "Are you sure you want to impersonate #{@user.display_name}? You will see the site as they do."
                       } %>
       <% end %>
+      <% if policy(@user).sync_hackatime? %>
       <%= button_to "🔄 Sync Hackatime Data",
                     admin_user_hackatime_sync_path(@user),
                     method: :post,
                     title: "Sync Hackatime Data" %>
+      <% end %>
+      <% if policy(@user).refresh_verification? %>
       <%= button_to "🔄 Refresh Verification",
                     admin_user_verification_path(@user),
                     method: :post,
                     title: "Refresh verification status from HCA",
                     data: { confirm: "Refresh verification status for #{@user.display_name}?" } %>
+      <% end %>
       <% if policy(@user).ban? %>
         <% if @user.banned? %>
           <%= button_to "🔓 Unban", admin_user_ban_path(@user), method: :delete,

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -684,7 +684,7 @@
         ship_tour_text = if is_fixed_payout
           "Your ship is now in review. Once it's approved, you'll earn the mission's prizes!"
         else
-          "Yay congrats on your first ship! To get your payout, you need to vote at least #{Post::ShipEvent::VOTES_REQUIRED_FOR_PAYOUT} times on other people's projects."
+          "Yay congrats on your first ship! To get your payout, you need to vote at least #{Post::ShipEvent::VOTE_COST_PER_SHIP} times on other people's projects."
         end
 
         ship_tour_steps = [


### PR DESCRIPTION
## what's this do?

- Fix shipped_at field by setting it in the transition after, not the event after which is post save
- Make it possible to hide discarded votes because there are too many disarded ✌🏻 
- Change 12 (`VOTES_REQUIRED_FOR_PAYOUT`) to 15 (`Post::ShipEvent::VOTE_COST_PER_SHIP`)<img width="504" height="240" alt="image" src="https://github.com/user-attachments/assets/7239b36d-3904-450f-a194-58aede6c84fb" />
- Show actions for all since they are generic, just hide delete/restore.
- Add vote balance to user info
- Change a send message to a button to align better
- other genuinely small thingies

## show it works

Admin view & ship test

https://github.com/user-attachments/assets/affbe3f3-014f-4738-acbd-299c6fc5e9b4

Helper view
<img width="2386" height="1333" alt="image" src="https://github.com/user-attachments/assets/e17efa0e-fc03-476b-9d4d-2aca65b840c0" />
<img width="2362" height="1180" alt="image" src="https://github.com/user-attachments/assets/36cb5fe8-ccd9-4f55-90d7-d3f0c29d6316" />

Hide discarded votes:
<img width="1058" height="808" alt="image" src="https://github.com/user-attachments/assets/8f29e370-c8e1-4cb7-b4d1-81470de1f1ad" />
<img width="1048" height="700" alt="image" src="https://github.com/user-attachments/assets/f04b8cfb-7e83-4729-ba0a-3d91583efb98" />



## ai?

Claude fable funf