### PR TITLE
feat(shop): add 'Made by a teen' banner to shop items

### DIFF
--- a/app/assets/stylesheets/components/_shop-item-card.scss
+++ b/app/assets/stylesheets/components/_shop-item-card.scss
@@ -300,9 +300,9 @@
 
   &--stacked-ribbons {
     .shop-item-card__ribbon--teen-creator {
-      top: 48px; 
+      top: 48px;
     }
-    
+
     .shop-item-card__sale-badge {
       top: 84px;
     }

--- a/app/assets/stylesheets/components/_shop-item-card.scss
+++ b/app/assets/stylesheets/components/_shop-item-card.scss
@@ -66,6 +66,24 @@
           var(--color-brand-highlight) transparent;
       }
     }
+
+    &--teen-creator {
+      background: var(--color-brand-orange);
+      color: var(--color-space-bg);
+      cursor: pointer;
+      transition: filter 0.2s ease;
+
+      &::after {
+        border-color: var(--color-brand-orange) transparent
+          var(--color-brand-orange) transparent;
+      }
+
+      &:hover,
+      &:focus-visible {
+        filter: brightness(1.05);
+        outline: none;
+      }
+    }
   }
 
   &__star {
@@ -277,6 +295,16 @@
   &--out-of-stock {
     .shop-item-card__order-cta {
       display: none;
+    }
+  }
+
+  &--stacked-ribbons {
+    .shop-item-card__ribbon--teen-creator {
+      top: 48px; 
+    }
+    
+    .shop-item-card__sale-badge {
+      top: 84px;
     }
   }
 }

--- a/app/components/shop_item_card_component.html.erb
+++ b/app/components/shop_item_card_component.html.erb
@@ -1,4 +1,4 @@
-<div class="shop-item-card<%= ' shop-item-card--achievement-locked' if locked_by_achievement %><%= ' shop-item-card--mission-locked' if mission_locked %><%= ' shop-item-card--out-of-stock' if out_of_stock? %><%= ' shop-item-card--on-sale' if on_sale %><%= ' shop-item-card--with-bow' if show_bow %><%= ' shop-item-card--spotlight' if tutorial_spotlight %><%= ' shop-item-card--wishlisted' if wishlisted %>"
+<div class="shop-item-card<%= ' shop-item-card--achievement-locked' if locked_by_achievement %><%= ' shop-item-card--mission-locked' if mission_locked %> <%= ' shop-item-card--out-of-stock' if out_of_stock? %> <%= ' shop-item-card--on-sale' if on_sale %> <%= ' shop-item-card--with-bow' if show_bow %> <%= ' shop-item-card--spotlight' if tutorial_spotlight %> <%= ' shop-item-card--wishlisted' if wishlisted %> <%= ' shop-item-card--stacked-ribbons' if (purchase_count || is_new) && teen_creator? %>"
      data-categories="<%= categories.join(',') %>"
      data-regions="<%= enabled_regions.join(',') %>"
      data-achievement-locked="<%= locked_by_achievement %>"
@@ -32,6 +32,12 @@
       <span class="shop-item-card__ribbon"><%= purchase_count %> given out</span>
     <% elsif is_new %>
       <span class="shop-item-card__ribbon shop-item-card__ribbon--new">New</span>
+    <% end %>
+
+    <% if teen_creator? %>
+      <%= link_to teen_creator_url, target: "_blank", rel: "noopener", class: "shop-item-card__ribbon shop-item-card__ribbon--teen-creator" do %>
+        Made by a teen!
+      <% end %>
     <% end %>
 
     <% if on_sale %>

--- a/app/components/shop_item_card_component.rb
+++ b/app/components/shop_item_card_component.rb
@@ -8,9 +8,9 @@ class ShopItemCardComponent < ViewComponent::Base
   # surface the popup in place instead of routing to a separate screen.
   OPEN_VERIFY_MODAL = "document.getElementById('idv-verify-modal')?.showModal()".freeze
 
-  attr_reader :item_id, :name, :description, :hours, :price, :image_url, :item_type, :balance, :enabled_regions, :regional_price, :logged_in, :tutorial_spotlight, :cta_mode, :remaining_stock, :limited, :on_sale, :sale_percentage, :original_price, :created_at, :show_bow, :show_time_ago, :purchase_count, :is_new, :enabled_until, :locked_by_achievement, :required_achievement_names, :required_achievement_hints, :mission_locked, :unlocking_mission_names, :wishlisted
+  attr_reader :item_id, :name, :description, :hours, :price, :image_url, :item_type, :balance, :enabled_regions, :regional_price, :logged_in, :tutorial_spotlight, :cta_mode, :remaining_stock, :limited, :on_sale, :sale_percentage, :original_price, :created_at, :show_bow, :show_time_ago, :purchase_count, :is_new, :enabled_until, :locked_by_achievement, :required_achievement_names, :required_achievement_hints, :mission_locked, :unlocking_mission_names, :wishlisted, :teen_creator_url
 
-  def initialize(item_id:, name:, description:, hours:, price:, image_url:, item_type: nil, balance: nil, enabled_regions: [], regional_price: nil, logged_in: true, interactive: true, tutorial_spotlight: false, cta_mode: :order, remaining_stock: nil, limited: false, on_sale: false, sale_percentage: nil, original_price: nil, created_at: nil, show_bow: false, show_time_ago: false, purchase_count: nil, is_new: false, enabled_until: nil, locked_by_achievement: false, required_achievement_names: [], required_achievement_hints: [], mission_locked: false, unlocking_mission_names: [], wishlisted: false)
+  def initialize(item_id:, name:, description:, hours:, price:, image_url:, item_type: nil, balance: nil, enabled_regions: [], regional_price: nil, logged_in: true, interactive: true, tutorial_spotlight: false, cta_mode: :order, remaining_stock: nil, limited: false, on_sale: false, sale_percentage: nil, original_price: nil, created_at: nil, show_bow: false, show_time_ago: false, purchase_count: nil, is_new: false, enabled_until: nil, locked_by_achievement: false, required_achievement_names: [], required_achievement_hints: [], mission_locked: false, unlocking_mission_names: [], wishlisted: false, teen_creator_url: nil)
     @item_id = item_id
     @name = name
     @description = description
@@ -41,6 +41,7 @@ class ShopItemCardComponent < ViewComponent::Base
     @mission_locked = mission_locked
     @unlocking_mission_names = unlocking_mission_names
     @wishlisted = wishlisted
+    @teen_creator_url = teen_creator_url
   end
 
   def lock_overlay_html
@@ -121,5 +122,9 @@ class ShopItemCardComponent < ViewComponent::Base
   def cta_price_icon
     return nil if display_price.to_i.zero?
     "icons/stardust.png"
+  end
+
+  def teen_creator?
+    teen_creator_url.present?
   end
 end

--- a/app/models/shop_item.rb
+++ b/app/models/shop_item.rb
@@ -53,6 +53,7 @@
 #  source_region                     :string
 #  special                           :boolean
 #  stock                             :integer
+#  teen_creator_url                  :string
 #  ticket_cost                       :integer
 #  type                              :string
 #  unlisted                          :boolean          default(FALSE)

--- a/app/views/shop/items/_item_card.html.erb
+++ b/app/views/shop/items/_item_card.html.erb
@@ -52,5 +52,6 @@
   required_achievement_hints: item_achievement_infos.map(&:description),
   mission_locked: item_mission_locked,
   unlocking_mission_names: item_unlocking_missions,
-  wishlisted: wishlisted_item_ids.include?(item.id)
+  wishlisted: wishlisted_item_ids.include?(item.id),
+  teen_creator_url: item.teen_creator_url
 ) %>

--- a/app/views/shop/items/_recently_added.html.erb
+++ b/app/views/shop/items/_recently_added.html.erb
@@ -35,7 +35,8 @@
           required_achievement_names: item_achievement_infos.map(&:name),
           required_achievement_hints: item_achievement_infos.map(&:description),
           mission_locked: item_mission_locked,
-          unlocking_mission_names: item_unlocking_missions
+          unlocking_mission_names: item_unlocking_missions,
+          teen_creator_url: item.teen_creator_url
         ) %>
       <% end %>
       </div>

--- a/db/migrate/20260701212214_add_teen_creator_url_to_shop_items.rb
+++ b/db/migrate/20260701212214_add_teen_creator_url_to_shop_items.rb
@@ -1,0 +1,5 @@
+class AddTeenCreatorUrlToShopItems < ActiveRecord::Migration[8.1]
+  def change
+    add_column :shop_items, :teen_creator_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_30_165531) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_01_212214) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
@@ -1066,6 +1066,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_30_165531) do
     t.string "source_region"
     t.boolean "special"
     t.integer "stock"
+    t.string "teen_creator_url"
     t.integer "ticket_cost"
     t.string "type"
     t.boolean "unlisted", default: false

--- a/test/fixtures/shop_items.yml
+++ b/test/fixtures/shop_items.yml
@@ -59,6 +59,7 @@
 #  source_region                     :string
 #  special                           :boolean
 #  stock                             :integer
+#  teen_creator_url                  :string
 #  ticket_cost                       :integer
 #  type                              :string
 #  unlisted                          :boolean          default(FALSE)

--- a/test/models/shop_item_test.rb
+++ b/test/models/shop_item_test.rb
@@ -53,6 +53,7 @@
 #  source_region                     :string
 #  special                           :boolean
 #  stock                             :integer
+#  teen_creator_url                  :string
 #  ticket_cost                       :integer
 #  type                              :string
 #  unlisted                          :boolean          default(FALSE)


### PR DESCRIPTION
- added teen_creator_url to ShopItems via migration
- updated ShopItemCardComponent to render the new banner and also handle overlap when mutliple ribbons exist
- added styling and positioning for the --teen-creator ribbon, 
- updated _item_card.html.erb and _recently_added.html.erb to pass the teen_creator_url attribute.

Closes #692

## what's this do?

This PR adds a "Made by a teen!" ribbon to shop items that have a teen_creator_url defined, to help spotlight items created by hackclubbers directly on the card.



## show it works

 #### BEFORE
<img width="1418" height="561" alt="before" src="https://github.com/user-attachments/assets/82164b13-0b05-4eec-8220-e95c9f1f7303" />

 #### AFTER along with other ribbons

<img width="1418" height="563" alt="after_with_existing" src="https://github.com/user-attachments/assets/8dabc2b1-7a41-443b-bea4-aa9814efe16a" />

 #### AFTER 
<img width="1418" height="649" alt="after_without_existing_banners" src="https://github.com/user-attachments/assets/1b98e1ba-6986-4d12-92ed-a839e9ea2ef1" />

## testing

HCA was not used, testing was done locally by creating a test user and applying a teen_creator_url to a ShopItem.

 Initializing a test user
```ruby
user = User.find_or_initialize_by(email: "xxx@xxxx.com")
user.update!(
  first_name: "Sreya",
  last_name: "Saju",
  display_name: "SreyaSaju",
  approx_balance: 500,
  verification_status: "needs_submission"
)
```
and applying a testing url and banner to existing shop item card (which was the Outpost ticket)
``` bash
docker compose exec web bin/rails runner 'item = ShopItem.find(4); item.update_columns(teen_creator_url: "https://github.com/hackclub/stardance");'
```


## ai?
Copilot assisted with the local testing process and formatting the data setup commands!