### PR TITLE
Show the hardware→Outpost notice after a timelapse, not before

### DIFF
--- a/app/controllers/projects/lookout_sessions_controller.rb
+++ b/app/controllers/projects/lookout_sessions_controller.rb
@@ -6,13 +6,6 @@ class Projects::LookoutSessionsController < ApplicationController
   def create
     authorize @project, :create_devlog?
 
-    # Hardware projects moved to Outpost — don't start a timelapse for one; tell
-    # the recorder to show the Outpost notice instead (see lookout_recorder JS).
-    if @project.hardware? && Flipper.enabled?(:hardware_to_outpost, current_user)
-      render json: { hardware_outpost_redirect: project_path(@project, hardware: "outpost") }, status: :forbidden
-      return
-    end
-
     # A session's tracked time is forwarded to Hackatime, so a linked Hackatime
     # account is required before one can be started.
     unless current_user.hackatime_identity.present?

--- a/app/javascript/controllers/lookout_capture_controller.js
+++ b/app/javascript/controllers/lookout_capture_controller.js
@@ -434,6 +434,7 @@ export default class extends Controller {
         this.setText(statusEl, "Your timelapse is ready!");
       }
       if (showVideo) await this.revealVideo();
+      this.showHardwareOutpostNotice();
       return;
     }
     if (data.status === "failed") {
@@ -477,6 +478,14 @@ export default class extends Controller {
       this.renderingTarget.textContent =
         "Your timelapse will be ready to watch in a moment.";
     }
+  }
+
+  // Hardware moved to Outpost — once the timelapse is done, let the builder know.
+  // The notice is only rendered on the page for hardware projects with the flag
+  // on, so this is a no-op everywhere else.
+  showHardwareOutpostNotice() {
+    const dialog = document.getElementById("hardware-outpost-modal");
+    if (dialog && !dialog.open) dialog.showModal();
   }
 
   close(event) {

--- a/app/javascript/controllers/lookout_recorder_controller.js
+++ b/app/javascript/controllers/lookout_recorder_controller.js
@@ -25,21 +25,6 @@ export default class extends Controller {
 
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
-        // Hardware projects moved to Outpost — show the notice instead of
-        // recording. Prefer the popup already on the page; otherwise send the
-        // just-opened tab to the project page, where it auto-opens.
-        if (body.hardware_outpost_redirect) {
-          const popup = document.getElementById("hardware-outpost-modal");
-          if (popup) {
-            recorderWindow?.close();
-            popup.showModal();
-          } else if (recorderWindow) {
-            recorderWindow.location = body.hardware_outpost_redirect;
-          } else {
-            window.location.assign(body.hardware_outpost_redirect);
-          }
-          return;
-        }
         throw new Error(body.error || `The server returned ${res.status}.`);
       }
 

--- a/app/views/projects/lookout_sessions/record.html.erb
+++ b/app/views/projects/lookout_sessions/record.html.erb
@@ -175,3 +175,9 @@
                 hidden: true %>
   </section>
 </main>
+
+<%# Hardware moved to Outpost — once this timelapse finishes, the capture
+    controller pops this notice (rendered only for hardware projects). %>
+<% if @project.hardware? && Flipper.enabled?(:hardware_to_outpost, current_user) %>
+  <%= render "projects/hardware_outpost_modal" %>
+<% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -910,10 +910,6 @@
     </dialog>
   <% end %>
 
-  <% if @project.hardware? && Flipper.enabled?(:hardware_to_outpost, current_user) %>
-    <%= render "projects/hardware_outpost_modal" %>
-  <% end %>
-
   <% if is_member && @hackatime_linked && @project.has_devlog_since_last_ship? %>
     <%
       ship_warn_seconds = [ @project.hackatime_keys.sum { |k| @hackatime_times[k].to_i } - @project.duration_seconds, 0 ].max


### PR DESCRIPTION
Follow-up to #764 (merged + enabled).

## Change
Recording a timelapse on a **hardware** project used to be **blocked up front** — `LookoutSessionsController#create` returned a redirect and the recorder popped the Outpost notice instead of ever recording. Per feedback, flip the timing: **let the timelapse record, and pop the notice once it finishes.**

- Removed the pre-create hardware block in `LookoutSessionsController#create` (hardware projects record normally again).
- Removed the `lookout_recorder` controller's handling of that block (restored its plain error path).
- Removed the project-page popup render (it only existed to serve that block).
- Render the Outpost popup on the **recorder page** for hardware projects (flag-gated); `lookout_capture_controller` opens it when the timelapse hits `complete` (the "Your timelapse is ready!" moment), for both the browser/camera and desktop flows.

## Unchanged
Project **creation** still shows the notice up front — creating a new hardware project or picking a hardware mission in the setup wizard is unaffected. This only moves the **timelapse** timing.

Behind the same `hardware_to_outpost` flag.

## Testing
- Ruby / both JS controllers / ERB all syntax-clean; no dangling `hardware_outpost_redirect` refs.
- Manual (flag on, hardware project): start a timelapse → it records normally → when it finishes and the video is ready, the Outpost notice pops.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX/timing change behind an existing Flipper flag with no auth or data-path changes; main risk is modal timing overlapping the destination step on the done stage.
> 
> **Overview**
> **Hardware timelapses record first; the Outpost notice appears when processing finishes** (still gated by `hardware_to_outpost`).
> 
> The create-session API no longer blocks hardware projects with `hardware_outpost_redirect` — **`LookoutSessionsController#create`** behaves like any other project again. **`lookout_recorder_controller`** drops the special-case redirect/popup/close-tab logic and only surfaces normal errors.
> 
> The Outpost modal moves from the **project show** page to the **recorder** page (`record.html.erb`, only for hardware + flag). When Lookout reports **`complete`**, **`lookout_capture_controller`** calls **`showHardwareOutpostNotice()`** at the “Your timelapse is ready!” moment (desktop and browser/camera flows).
> 
> Project **creation** / setup wizard behavior for the notice is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a36ddbbad8dc5dadeb2f429c5cf7cfd5e2d596a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->