### PR TITLE
Source discover rail expeditions from the Ambassador app

### DIFF
--- a/app/components/discover_rail/upcoming_events_widget.html.erb
+++ b/app/components/discover_rail/upcoming_events_widget.html.erb
@@ -1,5 +1,5 @@
-<section class="rail-widget events-widget" aria-label="Upcoming events">
-  <h3 class="rail-widget__title">Upcoming events</h3>
+<section class="rail-widget events-widget" aria-label="Stardance expeditions">
+  <h3 class="rail-widget__title">Stardance expeditions</h3>
   <ul class="events-widget__list">
     <% events.each do |event| %>
       <li class="events-widget__item">
@@ -20,7 +20,7 @@
             <% end %>
           </span>
           <span class="events-widget__meta">
-            <%= event[:leader] %> ·
+            <%= event[:location].presence || event[:leader] %> ·
             <time class="events-widget__time"
                   datetime="<%= event[:start].iso8601 %>"
                   data-controller="event-time"
@@ -31,5 +31,7 @@
       </li>
     <% end %>
   </ul>
-  <%= link_to "See all events →", "https://events.hackclub.com", target: "_blank", rel: "noopener", class: "rail-widget__link" %>
+  <% if can_post_expeditions? %>
+    <%= link_to "Post an expedition →", "https://ambassador.hackclub.com/dashboard", target: "_blank", rel: "noopener", class: "rail-widget__link" %>
+  <% end %>
 </section>

--- a/app/components/discover_rail/upcoming_events_widget.rb
+++ b/app/components/discover_rail/upcoming_events_widget.rb
@@ -4,27 +4,13 @@ module DiscoverRail
   class UpcomingEventsWidget < BaseWidget
     register_as :upcoming_events
 
-    API_URL = "https://events.hackclub.com/api/events/upcoming/"
-    # The API returns every Hack Club event; we only surface Stardance's own.
-    STARDANCE_TAG = "stardance"
+    DEFAULT_API_URL = "https://ambassador.hackclub.com/api/stardance/expeditions"
+    DEFAULT_STATUS_API_URL = "https://ambassador.hackclub.com/api/stardance/ambassadors"
+    API_URL = ENV.fetch("AMBASSADOR_EXPEDITIONS_API_URL", DEFAULT_API_URL)
+    STATUS_API_URL = ENV.fetch("AMBASSADOR_STATUS_API_URL", DEFAULT_STATUS_API_URL)
+    API_KEY = ENV["AMBASSADOR_EXPEDITIONS_API_KEY"].presence
     LIMIT = 3
     CACHE_TTL = 15.minutes
-
-    # Hand-curated events the API doesn't carry (or doesn't tag as Stardance).
-    # Past entries drop out of the rail automatically — prune them here once
-    # they're stale.
-    PINNED_EVENTS = [
-      {
-        title: "AMA: Artemis I Flight Director Elias Myrmo",
-        leader: "Elias Myrmo",
-        start: "2026-06-12T21:00:00Z", # Fri June 12, 5pm EDT
-        end: "2026-06-12T22:00:00Z", # announcement gives no end; assume an hour
-        slug: "eliasmyrmo",
-        ama: true,
-        avatar: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR44FWKqT-m6yTSq_GX1VsFf5HN-KTP5sZTSA&s",
-        url: "https://lu.ma/eliasmyrmo"
-      }
-    ].freeze
     HTTP_TIMEOUT = 3 # seconds; the rail must never stall a pageload
 
     def events
@@ -58,12 +44,26 @@ module DiscoverRail
       end
     end
 
+    def can_post_expeditions?
+      return false if user&.slack_id.blank?
+      return false if API_KEY.blank?
+
+      Rails.cache.fetch(
+        [ "discover_rail", "ambassador_status", STATUS_API_URL, user.slack_id ],
+        expires_in: CACHE_TTL
+      ) do
+        request_ambassador_status(user.slack_id)
+      end
+    end
+
     private
 
     def fetch_events
+      return [] if API_KEY.blank?
+
       # Failures cache as "[]" so a broken API costs one request per TTL, not
       # one per pageload.
-      raw = Rails.cache.fetch("discover_rail/upcoming_events", expires_in: CACHE_TTL) do
+      raw = Rails.cache.fetch([ "discover_rail", "ambassador_expeditions", API_URL ], expires_in: CACHE_TTL) do
         request_events || "[]"
       end
       return [] if raw.blank?
@@ -71,54 +71,71 @@ module DiscoverRail
       parsed = JSON.parse(raw)
       now = Time.current
 
-      api_events = parsed
-        .select { |e| Array(e["tags"]).include?(STARDANCE_TAG) }
+      Array(parsed["expeditions"])
         .filter_map { |e| build_event(e) }
-
-      (pinned_events + api_events)
         .uniq { |e| e[:slug] }
-        .select { |e| (e[:end] || e[:start]) >= now } # stays up while running
+        .select { |e| e[:start] >= now }
         .sort_by { |e| e[:start] }
         .first(LIMIT)
     rescue JSON::ParserError, StandardError
       []
     end
 
-    def pinned_events
-      PINNED_EVENTS.map do |e|
-        e.merge(start: Time.zone.parse(e[:start]), end: e[:end] && Time.zone.parse(e[:end]))
-      end
-    end
-
-    # Returns the response body on success, nil otherwise. The URL must keep
-    # its trailing slash — the API 308s the slashless form and Net::HTTP
-    # doesn't follow redirects.
+    # Returns the response body on success, nil otherwise.
     def request_events
       uri = URI(API_URL)
       response = Net::HTTP.start(uri.host, uri.port,
                                  use_ssl: uri.scheme == "https",
                                  open_timeout: HTTP_TIMEOUT,
                                  read_timeout: HTTP_TIMEOUT) do |http|
-        http.request(Net::HTTP::Get.new(uri))
+        request = Net::HTTP::Get.new(uri)
+        request["Accept"] = "application/json"
+        request["X-Stardance-Data-Access-Key"] = API_KEY
+        http.request(request)
       end
       response.is_a?(Net::HTTPSuccess) ? response.body : nil
     rescue StandardError
       nil
     end
 
+    def request_ambassador_status(slack_id)
+      uri = URI("#{STATUS_API_URL.chomp("/")}/#{ERB::Util.url_encode(slack_id)}")
+      response = Net::HTTP.start(uri.host, uri.port,
+                                 use_ssl: uri.scheme == "https",
+                                 open_timeout: HTTP_TIMEOUT,
+                                 read_timeout: HTTP_TIMEOUT) do |http|
+        request = Net::HTTP::Get.new(uri)
+        request["Accept"] = "application/json"
+        request["X-Stardance-Data-Access-Key"] = API_KEY
+        http.request(request)
+      end
+      return false unless response.is_a?(Net::HTTPSuccess)
+
+      JSON.parse(response.body)["ambassador"] == true
+    rescue JSON::ParserError, StandardError
+      false
+    end
+
     def build_event(data)
-      start_time = Time.zone.parse(data["start"])
+      start_time = Time.zone.parse(data["date"].to_s)
       return nil unless start_time
 
+      venue = data["venue"].is_a?(Hash) ? data["venue"] : {}
+      city = venue["city"].presence
+      state = venue["state"].presence
+      country = venue["country"].presence
+      location = [ city, state || country ].compact.join(", ").presence
+
       {
-        title: data["title"],
-        leader: data["leader"],
+        title: data["prettyName"].presence || data["name"].presence || "Stardance expedition",
+        leader: data["ambassadorName"].presence || "Hack Club Ambassador",
+        location: location,
         start: start_time,
-        end: data["end"].present? ? Time.zone.parse(data["end"]) : nil,
-        slug: data["slug"],
-        ama: data["ama"] == true,
-        avatar: data["avatar"],
-        url: data["cal"].presence
+        end: nil,
+        slug: data["slug"].presence || data["id"],
+        ama: false,
+        avatar: nil,
+        url: data["googleMapsUrl"].presence || data["appleMapsUrl"].presence
       }
     rescue ArgumentError
       nil

--- a/config/initializers/mjml.rb
+++ b/config/initializers/mjml.rb
@@ -1,8 +1,10 @@
+require "shellwords"
+
 mjml_path = Rails.root.join("node_modules/.bin/mjml")
 
 if mjml_path.exist?
   Mjml.setup do |config|
-    config.mjml_binary = mjml_path.to_s
+    config.mjml_binary = mjml_path.to_s.shellescape
   end
 else
   Rails.logger.warn "[MJML] Binary not found at #{mjml_path} — email template rendering will be unavailable. Run `npm install` to fix this."

--- a/example.env
+++ b/example.env
@@ -25,6 +25,12 @@ OUTPOST_SLACK_IN_DEV=
 
 SWAI_KEY=replaceme
 
+# Stardance expeditions shown in the discover rail. The key must match
+# STARDANCE_DATA_ACCESS_KEY in the Ambassador app.
+AMBASSADOR_EXPEDITIONS_API_URL=https://ambassador.hackclub.com/api/stardance/expeditions
+AMBASSADOR_STATUS_API_URL=https://ambassador.hackclub.com/api/stardance/ambassadors
+AMBASSADOR_EXPEDITIONS_API_KEY=replaceme
+
 # Lookout screen-recording time tracker (hardware projects). Without a valid key
 # the "Record a timelapse" / "Record your screen" buttons can't start a session
 # (the API returns 503). Get a key from the Lookout team. Point LOOKOUT_BASE_URL


### PR DESCRIPTION
## Summary
- Replaces the hand-curated events.hackclub.com feed in the discover rail's "Upcoming events" widget with live Stardance expedition data pulled from the Ambassador app's API
- Shows a "Post an expedition" link only to users the Ambassador app confirms are approved ambassadors
- Fixes the MJML binary path not being shell-escaped, which broke email rendering on checkouts under a directory containing a space (e.g. `Hack Club/stardance`)

## Test plan
- [x] `rubocop` clean on changed files
- [x] `erb_lint` clean on the changed template
- [x] App boots via `rails runner`, widget class loads, resolved `API_URL` matches expected default
- [x] `build_event` exercised against a sample Ambassador API payload — title/location/url fields map correctly
- [x] Confirmed `Mjml.mjml_binary` now resolves to a properly escaped path

🤖 Generated with [Claude Code](https://claude.com/claude-code)