### PR TITLE
recalc modifier prices inside the lock so theyre fresh, also include …

### DIFF
--- a/app/controllers/shop/orders_controller.rb
+++ b/app/controllers/shop/orders_controller.rb
@@ -97,6 +97,10 @@ class Shop::OrdersController < Shop::BaseController
         current_user.lock!
         @shop_item.lock! if @shop_item.limited?
 
+        # recalc mod prices after lock so theyre fresh
+        modifiers_total = @modifiers.sum { |m| m.price_for_region(region) }
+        total_cost = item_total + accessories_total + modifiers_total
+
         if @mission_submission.nil?
           user_balance = current_user.balance
           if total_cost > user_balance

--- a/app/models/shop_order.rb
+++ b/app/models/shop_order.rb
@@ -377,7 +377,9 @@ class ShopOrder < ApplicationRecord
     return if redeeming_mission_submission.present?
     return unless frozen_item_price&.positive? && quantity.present?
 
-    total_cost_for_validation = frozen_item_price * quantity
+    # include modifier costs in the balance check
+    modifier_cost = frozen_modifiers_price || 0
+    total_cost_for_validation = (frozen_item_price * quantity) + modifier_cost
     if user&.balance&.< total_cost_for_validation
       shortage = total_cost_for_validation - (user.balance || 0)
       errors.add(:base, "Insufficient balance. You need #{shortage} more tickets.")


### PR DESCRIPTION
## fix: include modifier costs in balance check + recalc prices inside lock

Two related bugs in the shop order flow where modifier costs weren't being handled correctly.

### Bug 1: Stale modifier prices outside the lock

Modifier prices were being summed **before** `current_user.lock!` was acquired. If another request modified a modifier's price between the sum and the lock, the order would use a stale total.

**Before:**
```ruby
modifiers_total = @modifiers.sum { |m| m.price_for_region(region) }
total_cost = item_total + accessories_total + modifiers_total

current_user.lock!
@shop_item.lock! if @shop_item.limited?
```

**After:**
```ruby
current_user.lock!
@shop_item.lock! if @shop_item.limited?

# recalc mod prices after lock so theyre fresh
modifiers_total = @modifiers.sum { |m| m.price_for_region(region) }
total_cost = item_total + accessories_total + modifiers_total
```

### Bug 2: Balance check ignored modifier costs

`check_user_balance` only validated `frozen_item_price * quantity`, but `create_negative_payout` deducted the full cost including modifiers. This meant a user could pass the balance check but still end up with a negative balance after the payout.

**Before:**
```ruby
total_cost_for_validation = frozen_item_price * quantity
```

**After:**
```ruby
modifier_cost = frozen_modifiers_price || 0
total_cost_for_validation = (frozen_item_price * quantity) + modifier_cost
```

### Files changed
- `app/controllers/shop/orders_controller.rb` - move modifier price calc inside the lock
- `app/models/shop_order.rb` - include modifier costs in balance validation