### PR TITLE
fix(projects): compute unposted devlog time from the Hackatime devlog window, not totals-minus-durations arithmetic

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -58,6 +58,8 @@ class ProjectsController < ApplicationController
         result = current_user.try_sync_hackatime_data!
         @hackatime_times = result&.dig(:projects) || {}
         @hackatime_token_stale = current_user.hackatime_token_stale?
+        identity = current_user.hackatime_identity
+        @unposted_seconds = @project.seconds_coded_in_devlog_window(identity.uid, access_token: identity.access_token).to_i
 
         linked_ids = @linked_hackatime_projects.map(&:id).to_set
         taken_project_ids = @all_hackatime_projects.map(&:project_id).compact.uniq - [ @project.id ]

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -478,8 +478,7 @@
       <% if @hackatime_linked || @test_time_granted %>
         <%
           no_hackatime_project = @project.hackatime_keys.blank? && !@test_time_granted
-          live_seconds = @project.hackatime_keys.sum { |k| @hackatime_times[k].to_i }
-          unposted_seconds = [ live_seconds - @project.duration_seconds, 0 ].max
+          unposted_seconds = @unposted_seconds.to_i
           enough_time = !no_hackatime_project && (unposted_seconds >= 15 * 60 || @test_time_granted)
           devlog_disabled_message = "Edit this project to add a Hackatime project" if no_hackatime_project
           # Only call it the primary action when devlogging is actually
@@ -912,7 +911,7 @@
 
   <% if is_member && @hackatime_linked && @project.has_devlog_since_last_ship? %>
     <%
-      ship_warn_seconds = [ @project.hackatime_keys.sum { |k| @hackatime_times[k].to_i } - @project.duration_seconds, 0 ].max
+      ship_warn_seconds = @unposted_seconds.to_i
       ship_warn_hours = ship_warn_seconds / 3600
       ship_warn_minutes = (ship_warn_seconds % 3600) / 60
       ship_warn_time = ship_warn_hours > 0 ? "#{ship_warn_hours}h #{ship_warn_minutes}m" : "#{ship_warn_minutes}m"


### PR DESCRIPTION
## what's this do?

it was computing the ship warning based on raw hackatime data which was bad. now it uses the actual time that a devlog would log if you logged it right at that moment.

## ai?

claude
