### PR TITLE
fix(ships): reships were stuck on submitted instead of approved

### DIFF
--- a/app/controllers/projects/ships_controller.rb
+++ b/app/controllers/projects/ships_controller.rb
@@ -47,6 +47,7 @@ class Projects::ShipsController < ApplicationController
         cert = @project.ship_reviews.create!(status: :pending, post_ship_event_id: ship_event.id)
         ExternalDashboard::ShipWebhookJob.perform_later(cert.id)
       elsif probe_result.ok?
+        @project.start_review! if @project.may_start_review?
         @project.approve! if @project.may_approve?
         @post.postable.update!(certification_status: "approved")
         create_ysws_review(ship_event)

--- a/lib/tasks/backfill_stuck_reship_approvals.rake
+++ b/lib/tasks/backfill_stuck_reship_approvals.rake
@@ -1,0 +1,45 @@
+# The reship auto-approve path called Project#approve! before the project had
+# gone through under_review, so the AASM guard silently no-op'd and the
+# project got stuck on "submitted" even though its ship event was already
+# marked "approved" (see Projects::ShipsController#create).
+#
+# dry run:  bin/rails backfill:stuck_reship_approvals
+# to apply: bin/rails backfill:stuck_reship_approvals DRY_RUN=false
+
+namespace :backfill do
+  desc "Move projects stuck on 'submitted' with an approved ship event into 'approved'"
+  task stuck_reship_approvals: :environment do
+    dry_run = ENV.fetch("DRY_RUN", "true") != "false"
+
+    puts dry_run ? "[DRY RUN] No changes will be written." : "Writing changes to the database."
+    puts
+
+    count = 0
+
+    Project.where(ship_status: "submitted").find_each do |project|
+      ship_event = project.last_ship_event
+
+      next unless ship_event&.certification_status == "approved"
+
+      unless project.may_start_review?
+        puts "  [SKIP] Project ##{project.id} \"#{project.title}\", can't start_review from #{project.ship_status}"
+        next
+      end
+
+      puts "  [FIX] Project ##{project.id} \"#{project.title}\", ship event ##{ship_event.id}: submitted → approved"
+
+      unless dry_run
+        project.with_lock do
+          project.start_review!
+          project.approve!
+        end
+      end
+
+      count += 1
+    end
+
+    puts
+    puts "#{dry_run ? 'Would fix' : 'Fixed'} #{count} project(s)."
+    puts "Run with DRY_RUN=false to apply." if dry_run
+  end
+end

--- a/lib/tasks/backfill_stuck_reship_approvals.rake
+++ b/lib/tasks/backfill_stuck_reship_approvals.rake
@@ -15,6 +15,7 @@ namespace :backfill do
     puts
 
     count = 0
+    failed = 0
 
     Project.where(ship_status: "submitted").find_each do |project|
       ship_event = project.last_ship_event
@@ -28,18 +29,30 @@ namespace :backfill do
 
       puts "  [FIX] Project ##{project.id} \"#{project.title}\", ship event ##{ship_event.id}: submitted → approved"
 
-      unless dry_run
-        project.with_lock do
-          project.start_review!
-          project.approve!
-        end
+      if dry_run
+        count += 1
+        next
       end
 
-      count += 1
+      begin
+        project.with_lock do
+          # State can shift between the may_start_review? check above and the
+          # lock, so re-check inside the transaction before transitioning.
+          raise ActiveRecord::Rollback unless project.may_start_review?
+
+          project.start_review!
+          project.approve!
+          count += 1
+        end
+      rescue => e
+        failed += 1
+        puts "  [FAIL] Project ##{project.id} \"#{project.title}\": #{e.class} #{e.message}"
+      end
     end
 
     puts
     puts "#{dry_run ? 'Would fix' : 'Fixed'} #{count} project(s)."
+    puts "Skipped #{failed} project(s) due to errors — see [FAIL] lines above." if failed.positive?
     puts "Run with DRY_RUN=false to apply." if dry_run
   end
 end


### PR DESCRIPTION
## what's this do?

Fixes reships getting stuck on "submitted" forever: the auto-approve path called `approve!` before the project had gone through `under_review`, so the AASM guard silently blocked it. Also added a backfill task to fix projects already stuck this way :)

## show it works

Seeded a project stuck exactly like the bug (submitted + an already-approved ship event), then ran the backfill task:

```
[DRY RUN] No changes will be written.
  [FIX] Project #980190967 "Demo Stuck Reship", ship event #980190964: submitted → approved
Would fix 1 project(s).

Writing changes to the database.
  [FIX] Project #980190967 "Demo Stuck Reship", ship event #980190964: submitted → approved
Fixed 1 project(s).

ship_status is now: approved
```

## ai?

Claude