### PR TITLE
feat(missions): scope review queues to missions the user can review

### DIFF
--- a/app/controllers/admin/missions/submissions_controller.rb
+++ b/app/controllers/admin/missions/submissions_controller.rb
@@ -120,7 +120,12 @@ module Admin
         end
         skip_ids = parse_skip_ids
 
-        candidate = Mission::Submission.next_eligible(current_user, mission: @mission, skip_ids: skip_ids)
+        missions_filter = if @mission
+          @mission
+        elsif !global_reviewer?
+          current_user.mission_memberships.select(:mission_id)
+        end
+        candidate = Mission::Submission.next_eligible(current_user, missions: missions_filter, skip_ids: skip_ids)
         unless candidate
           redirect_to admin_mission_submissions_path(mission_slug),
                       notice: "No more submissions to review." and return
@@ -182,10 +187,10 @@ module Admin
         mission.memberships.exists?(user_id: current_user.id)
       end
 
-      # Admins, helpers, and global mission reviewers can review any mission;
-      # everyone else is scoped to missions they're a member of.
+      # Admins and global mission reviewers can review any mission; everyone
+      # else (helpers included) is scoped to missions they're a member of.
       def global_reviewer?
-        current_user.admin? || current_user.has_role?(:helper) || current_user.has_role?(:mission_reviewer)
+        current_user.admin? || current_user.has_role?(:mission_reviewer)
       end
 
       def set_submission

--- a/app/models/concerns/mission_reviewable.rb
+++ b/app/models/concerns/mission_reviewable.rb
@@ -8,12 +8,13 @@ module MissionReviewable
   SLA_DAYS = 3
 
   class_methods do
-    def available_for(user, mission: nil)
+    # missions: a Mission, a collection of mission ids, or nil for no filter.
+    def available_for(user, missions: nil)
       scope = where(status: "pending").where(
         "(reviewed_by_id IS NULL OR claim_expires_at IS NULL OR claim_expires_at < ?) OR reviewed_by_id = ?",
         Time.current, user.id
       )
-      scope = scope.where(mission_id: mission.id) if mission
+      scope = scope.where(mission_id: missions) if missions
       scope
     end
 
@@ -31,8 +32,8 @@ module MissionReviewable
         .update_all(reviewed_by_id: nil, claim_expires_at: nil, updated_at: Time.current)
     end
 
-    def next_eligible(user, mission: nil, skip_ids: [])
-      scope = available_for(user, mission: mission)
+    def next_eligible(user, missions: nil, skip_ids: [])
+      scope = available_for(user, missions: missions)
       scope = scope.where.not(id: skip_ids) if skip_ids.any?
       scope.order(
         Arel.sql(sanitize_sql_array([ "CASE WHEN reviewed_by_id = ? THEN 0 ELSE 1 END", user.id ])),

--- a/app/policies/mission/submission_policy.rb
+++ b/app/policies/mission/submission_policy.rb
@@ -2,7 +2,7 @@ class Mission::SubmissionPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
       return scope.none if user.blank?
-      return scope.all if user.admin? || user.has_role?(:helper) || user.has_role?(:mission_reviewer)
+      return scope.all if user.admin? || user.has_role?(:mission_reviewer)
 
       scope.where(mission_id: user.mission_memberships.select(:mission_id))
     end
@@ -10,8 +10,7 @@ class Mission::SubmissionPolicy < ApplicationPolicy
 
   def index?
     return false unless user.present?
-    user.admin? || user.has_role?(:helper) ||
-      user.has_role?(:mission_reviewer) ||
+    user.admin? || user.has_role?(:mission_reviewer) ||
       user.mission_memberships.exists?
   end
 

--- a/test/controllers/admin/missions/submissions_controller_test.rb
+++ b/test/controllers/admin/missions/submissions_controller_test.rb
@@ -74,9 +74,48 @@ class Admin::Missions::SubmissionsControllerTest < ActionDispatch::IntegrationTe
     assert_response :success
   end
 
+  test "overview only lists missions the user can review" do
+    member = create_member
+    other_mission = create_mission
+    other_mission.memberships.create!(user: member, role: :reviewer)
+
+    sign_in member
+    get admin_mission_reviews_path
+    assert_response :success
+    assert_includes response.body, other_mission.name
+    assert_not_includes response.body, @mission.name
+  end
+
+  test "helpers without memberships cannot browse the review queues" do
+    helper = create_member(granted_roles: [ "helper" ])
+    sign_in helper
+    get admin_mission_reviews_path
+    assert_not_equal 200, response.status
+  end
+
+  test "the all-missions queue never hands out inaccessible submissions" do
+    member = create_member
+    other_mission = create_mission
+    other_mission.memberships.create!(user: member, role: :reviewer)
+
+    sign_in member
+    get next_admin_mission_submissions_path("all")
+    assert_redirected_to admin_mission_submissions_path("all")
+    assert_nil @submission.reload.reviewed_by_id
+  end
+
   test "builders cannot reach the queue" do
     sign_in @builder
     get admin_mission_submissions_path(@mission.slug)
     assert_not_equal 200, response.status
+  end
+
+  private
+
+  def create_member(granted_roles: [])
+    User.create!(email: "member-#{SecureRandom.hex(4)}@example.test",
+                 display_name: "member-#{SecureRandom.hex(4)}",
+                 slack_id: "U#{SecureRandom.hex(8)}",
+                 granted_roles: granted_roles)
   end
 end


### PR DESCRIPTION
## what's this do?

previously for some reason helpers were included in the users able to view missions. This kinda makes sense for individual submissions, but it made them able to see the review dash. This removes that

## ai?

claude
