### PR TITLE
Fix re-certification blocked by previous-ship payout check

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -730,9 +730,13 @@ class Project < ApplicationRecord
   def previous_ship_event_has_payout?
     return true if last_ship_event.nil?
     return true if last_ship_event.payout.present?
+    # Only an approved ship that is still awaiting its payout should block the
+    # next ship. A ship that's pending, returned for changes, or rejected isn't
+    # a "previous ship awaiting payout" — it's the one currently being
+    # (re-)certified, so it must not block re-certification.
+    return true unless last_ship_event.certification_status == "approved"
     sub = last_ship_event.mission_submission
     return true if sub&.payout_path == "static_prize"
-    return true if sub&.rejected?
     false
   end
 

--- a/test/models/project_payout_requirement_test.rb
+++ b/test/models/project_payout_requirement_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class ProjectPayoutRequirementTest < ActiveSupport::TestCase
+  setup do
+    @owner = create_user(slack_id: "U_PAYOUT_OWNER", display_name: "payoutowner")
+    @project = Project.create!(title: "payout project", description: "d")
+    @project.memberships.create!(user: @owner, role: :owner)
+  end
+
+  def payout_requirement
+    @project.shipping_requirements.find { |r| r[:key] == :payout }
+  end
+
+  def create_ship_event(status:, payout: nil)
+    ship_event = Post::ShipEvent.create!(
+      body: "Ship it",
+      uploading_attachments: true,
+      certification_status: status,
+      payout: payout,
+      hours_at_ship: 1
+    )
+    Post.create!(project: @project, user: @owner, postable: ship_event)
+    ship_event
+  end
+
+  test "payout requirement passes when there is no previous ship" do
+    assert payout_requirement[:passed]
+  end
+
+  test "payout requirement does not block re-certifying a returned ship" do
+    create_ship_event(status: "returned")
+
+    assert payout_requirement[:passed],
+      "a ship returned for changes must not be treated as a previous ship awaiting payout"
+  end
+
+  test "payout requirement does not block a pending ship" do
+    create_ship_event(status: "pending")
+
+    assert payout_requirement[:passed]
+  end
+
+  test "payout requirement blocks shipping again while an approved ship awaits payout" do
+    create_ship_event(status: "approved", payout: nil)
+
+    refute payout_requirement[:passed]
+  end
+
+  test "payout requirement passes once the approved ship has a payout" do
+    create_ship_event(status: "approved", payout: 12.5)
+
+    assert payout_requirement[:passed]
+  end
+end


### PR DESCRIPTION
## what's this do?

Fixes re-certification getting blocked with "Wait for your previous ship to get a payout before shipping again." A returned ship is its own `last_ship_event`, so `previous_ship_event_has_payout?` wrongly failed, made `shippable?` false, and tripped the `resubmit_for_review!` guard. Now the payout gate only blocks the next ship when the last ship is **approved** and still awaiting its payout — pending/returned/rejected ships pass.

## show it works

Added `test/models/project_payout_requirement_test.rb` covering no-previous-ship, returned ship (the recert case), pending ship, approved-awaiting-payout (still blocks), and approved-with-payout. Note: couldn't run the suite locally — Docker daemon wasn't running — so relying on CI.

## ai?

Yes — Claude Code (Opus) diagnosed the bug and wrote the fix + tests.
