### PR TITLE
fix(missions): make mission review queue based on last review date

### DIFF
--- a/app/controllers/admin/missions/submissions_controller.rb
+++ b/app/controllers/admin/missions/submissions_controller.rb
@@ -24,7 +24,7 @@ module Admin
         oldest_pending = Mission::Submission
                            .where(status: "pending", deleted_at: nil)
                            .group(:mission_id)
-                           .minimum(:created_at)
+                           .minimum(Arel.sql("COALESCE(pending_at, created_at)"))
 
         @mission_stats = @missions.map do |m|
           {
@@ -54,7 +54,7 @@ module Admin
         scope = scope.where(mission_id: @mission.id) if @mission
 
         scope = apply_filters(scope)
-        @submissions = scope.order(created_at: :asc).limit(100)
+        @submissions = scope.order(Arel.sql("COALESCE(pending_at, created_at) ASC")).limit(100)
       end
 
       def show

--- a/app/models/concerns/mission_reviewable.rb
+++ b/app/models/concerns/mission_reviewable.rb
@@ -37,7 +37,7 @@ module MissionReviewable
       scope = scope.where.not(id: skip_ids) if skip_ids.any?
       scope.order(
         Arel.sql(sanitize_sql_array([ "CASE WHEN reviewed_by_id = ? THEN 0 ELSE 1 END", user.id ])),
-        :created_at
+        Arel.sql("COALESCE(pending_at, created_at)")
       ).first
     end
 
@@ -62,10 +62,10 @@ module MissionReviewable
         new_today: scoped.where(created_at: today..).count,
         decisions_this_week: decided.where(reviewed_at: week..).count,
         new_this_week: scoped.where(created_at: week..).count,
-        oldest_pending: scoped.pending.order(created_at: :asc).first,
+        oldest_pending: scoped.pending.order(Arel.sql("COALESCE(pending_at, created_at)")).first,
         queue_target: QUEUE_TARGET,
         sla_days: SLA_DAYS,
-        overdue_pending: scoped.pending.where("created_at < ?", now - SLA_DAYS.days).count
+        overdue_pending: scoped.pending.where("COALESCE(pending_at, created_at) < ?", now - SLA_DAYS.days).count
       }
     end
 

--- a/app/models/mission/submission.rb
+++ b/app/models/mission/submission.rb
@@ -64,7 +64,9 @@ class Mission::Submission < ApplicationRecord
 
   aasm column: :status, no_direct_assignment: true do
     state :awaiting_certification, initial: true
-    state :pending
+    # Queue age counts from the last review, so entering the queue (ship cert
+    # approved, or a decision undone/resubmitted) restamps pending_at.
+    state :pending, before_enter: :stamp_pending_at
     state :approved
     state :rejected
 
@@ -101,8 +103,14 @@ class Mission::Submission < ApplicationRecord
   scope :reviewable,  -> { pending }
   scope :unredeemed,  -> { approved.where(shop_order_id: nil) }
   scope :stale_pending, ->(days: 7) {
-    pending.where("created_at < ?", days.days.ago)
+    pending.where("pending_at < ?", days.days.ago)
   }
+
+  # When the submission last entered the review queue; created_at covers rows
+  # that predate pending_at (or never reached the queue).
+  def queue_entered_at
+    pending_at || created_at
+  end
 
   # Per-mission reviewers/owners, minus teammates (no self-review). Global
   # mission_reviewers manage every mission but are deliberately left out here —
@@ -137,6 +145,10 @@ class Mission::Submission < ApplicationRecord
   end
 
   private
+
+  def stamp_pending_at
+    self.pending_at = Time.current
+  end
 
   def notify_reviewers
     builder = ship_event&.post&.user

--- a/app/models/mission/submission.rb
+++ b/app/models/mission/submission.rb
@@ -7,6 +7,7 @@
 #  claimed_at                       :datetime
 #  deleted_at                       :datetime
 #  payout_path                      :string           not null
+#  pending_at                       :datetime
 #  rejection_message                :text
 #  reviewed_at                      :datetime
 #  status                           :string           not null
@@ -31,6 +32,7 @@
 #  index_mission_submissions_on_ship_event_id          (ship_event_id)
 #  index_mission_submissions_on_shop_order_id          (shop_order_id)
 #  index_mission_submissions_on_status_and_created_at  (status,created_at)
+#  index_mission_submissions_on_status_and_pending_at  (status,pending_at)
 #  index_mission_submissions_with_shop_order           (shop_order_id) WHERE (shop_order_id IS NOT NULL)
 #
 # Foreign Keys

--- a/app/views/admin/missions/submissions/index.html.erb
+++ b/app/views/admin/missions/submissions/index.html.erb
@@ -76,7 +76,7 @@
             <span class="mission-queue__label">Oldest waiting</span>
             <% if @stats[:oldest_pending] %>
               <span class="mission-queue__metric-value is-negative">
-                <%= time_ago_in_words(@stats[:oldest_pending].created_at) %>
+                <%= time_ago_in_words(@stats[:oldest_pending].queue_entered_at) %>
               </span>
               <span class="mission-queue__metric-hint">in the queue</span>
             <% else %>
@@ -203,7 +203,7 @@
                         class: "mission-queue__project-title") %>
                 </div>
                 <div class="mission-queue__project-meta">
-                  <span><%= time_ago_in_words(s.created_at) %> old</span>
+                  <span><%= time_ago_in_words(s.queue_entered_at) %> old</span>
                   <% if s.pending? %>
                     <span class="mission-queue__dot" aria-hidden="true">·</span>
                     <%= render "admin/missions/submissions/claim_flag", submission: s %>

--- a/app/views/admin/missions/submissions/show.html.erb
+++ b/app/views/admin/missions/submissions/show.html.erb
@@ -74,6 +74,10 @@
             <dd><%= builder&.display_name || "—" %></dd>
             <dt>Submitted</dt>
             <dd><%= time_ago_in_words(@submission.created_at) %> ago</dd>
+            <% if @submission.pending_at.present? %>
+              <dt>In queue</dt>
+              <dd><%= time_ago_in_words(@submission.pending_at) %> ago</dd>
+            <% end %>
             <dt>Payout path</dt>
             <dd><%= @submission.payout_path.titleize %></dd>
             <% if @submission.reviewed_by.present? %>

--- a/db/migrate/20260714143837_add_pending_at_to_mission_submissions.rb
+++ b/db/migrate/20260714143837_add_pending_at_to_mission_submissions.rb
@@ -1,0 +1,36 @@
+class AddPendingAtToMissionSubmissions < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :mission_submissions, :pending_at, :datetime
+
+    add_index :mission_submissions, [ :status, :pending_at ], algorithm: :concurrently
+
+    reversible do |dir|
+      dir.up do
+        safety_assured do
+          # Queue age counts from the last review (the ship certification, or a
+          # mission review that was undone or resubmitted), not from ship time.
+          # Backfill from the ship cert verdict; submissions that never reached
+          # the queue stay NULL.
+          execute <<~SQL
+            UPDATE mission_submissions SET pending_at = certs.decided_at
+            FROM (
+              SELECT post_ship_event_id, MAX(COALESCE(decided_at, updated_at)) AS decided_at
+              FROM certification_ship_reviews
+              WHERE status = 1 AND post_ship_event_id IS NOT NULL
+              GROUP BY post_ship_event_id
+            ) certs
+            WHERE mission_submissions.ship_event_id = certs.post_ship_event_id
+              AND mission_submissions.status <> 'awaiting_certification'
+          SQL
+
+          execute <<~SQL
+            UPDATE mission_submissions SET pending_at = created_at
+            WHERE pending_at IS NULL AND status = 'pending'
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_08_183407) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_14_143837) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
@@ -564,6 +564,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_08_183407) do
     t.datetime "deleted_at"
     t.bigint "mission_id", null: false
     t.string "payout_path", null: false
+    t.datetime "pending_at"
     t.text "rejection_message"
     t.datetime "reviewed_at"
     t.bigint "reviewed_by_id"
@@ -583,6 +584,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_08_183407) do
     t.index ["shop_order_id"], name: "index_mission_submissions_with_shop_order", where: "(shop_order_id IS NOT NULL)"
     t.index ["status", "claim_expires_at"], name: "idx_mission_submissions_on_status_claim_expires"
     t.index ["status", "created_at"], name: "index_mission_submissions_on_status_and_created_at"
+    t.index ["status", "pending_at"], name: "index_mission_submissions_on_status_and_pending_at"
   end
 
   create_table "missions", force: :cascade do |t|
@@ -1213,13 +1215,29 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_08_183407) do
     t.index ["slug"], name: "index_shop_sources_on_slug", unique: true
   end
 
-  create_table "shop_suggestions", force: :cascade do |t|
+  create_table "shop_suggestion_votes", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.text "explanation"
-    t.text "item"
-    t.string "link"
+    t.bigint "shop_suggestion_id", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.index ["shop_suggestion_id"], name: "index_shop_suggestion_votes_on_shop_suggestion_id"
+    t.index ["user_id"], name: "index_shop_suggestion_votes_on_user_id"
+  end
+
+  create_table "shop_suggestions", force: :cascade do |t|
+    t.string "aasm_state", default: "pending", null: false
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.datetime "discarded_at"
+    t.text "name"
+    t.string "rejection_reason"
+    t.bigint "shop_item_id"
+    t.datetime "updated_at", null: false
+    t.string "url"
+    t.decimal "usd_cost", precision: 8, scale: 2
+    t.bigint "user_id", null: false
+    t.index ["aasm_state"], name: "index_shop_suggestions_on_aasm_state"
+    t.index ["shop_item_id"], name: "index_shop_suggestions_on_shop_item_id"
     t.index ["user_id"], name: "index_shop_suggestions_on_user_id"
   end
 
@@ -1642,6 +1660,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_08_183407) do
   add_foreign_key "shop_orders", "shop_warehouse_packages", column: "warehouse_package_id"
   add_foreign_key "shop_orders", "users"
   add_foreign_key "shop_orders", "users", column: "assigned_to_user_id", on_delete: :nullify
+  add_foreign_key "shop_suggestion_votes", "shop_suggestions"
+  add_foreign_key "shop_suggestion_votes", "users"
   add_foreign_key "shop_suggestions", "users"
   add_foreign_key "shop_warehouse_packages", "users"
   add_foreign_key "shop_wishlists", "shop_items"

--- a/test/models/mission/submission_test.rb
+++ b/test/models/mission/submission_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class Mission::SubmissionTest < ActiveSupport::TestCase
+  setup do
+    @builder = User.create!(email: "builder-#{SecureRandom.hex(4)}@example.test",
+                            display_name: "builder-#{SecureRandom.hex(4)}",
+                            slack_id: "U#{SecureRandom.hex(8)}")
+    @project = Project.create!(title: "Queue Age Project")
+    @project.memberships.create!(user: @builder, role: :owner)
+    @mission = create_mission
+    @project.mission_attachments.create!(mission: @mission)
+  end
+
+  test "certifying stamps pending_at with the queue entry time" do
+    submission = ship_to_mission!(@project, @builder, @mission)
+    assert_nil submission.pending_at
+
+    travel 2.days do
+      submission.certify!
+      assert_in_delta Time.current, submission.reload.pending_at, 1.second
+    end
+  end
+
+  test "undo restamps pending_at so queue age counts from the last review" do
+    submission = ship_to_mission!(@project, @builder, @mission)
+    submission.certify!
+    first_entry = submission.reload.pending_at
+
+    travel 3.days do
+      submission.approve!
+      submission.undo!
+      assert_operator submission.reload.pending_at, :>, first_entry
+      assert_in_delta Time.current, submission.pending_at, 1.second
+    end
+  end
+
+  test "queue_entered_at falls back to created_at when pending_at is unset" do
+    submission = ship_to_mission!(@project, @builder, @mission, status: "pending")
+    assert_nil submission.pending_at
+    assert_equal submission.created_at, submission.queue_entered_at
+
+    submission.update_column(:pending_at, 1.hour.ago)
+    assert_equal submission.pending_at, submission.reload.queue_entered_at
+  end
+end

--- a/test/models/mission/submission_test.rb
+++ b/test/models/mission/submission_test.rb
@@ -1,5 +1,50 @@
 require "test_helper"
 
+# == Schema Information
+#
+# Table name: mission_submissions
+#
+#  id                               :bigint           not null, primary key
+#  claim_expires_at                 :datetime
+#  claimed_at                       :datetime
+#  deleted_at                       :datetime
+#  payout_path                      :string           not null
+#  pending_at                       :datetime
+#  rejection_message                :text
+#  reviewed_at                      :datetime
+#  status                           :string           not null
+#  submission_guide_acknowledged_at :datetime
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#  chosen_prize_id                  :bigint
+#  mission_id                       :bigint           not null
+#  reviewed_by_id                   :bigint
+#  ship_event_id                    :bigint           not null
+#  shop_order_id                    :bigint
+#
+# Indexes
+#
+#  idx_mission_submissions_on_status_claim_expires     (status,claim_expires_at)
+#  index_mission_submissions_active_per_ship_event     (ship_event_id) UNIQUE WHERE (deleted_at IS NULL)
+#  index_mission_submissions_on_chosen_prize_id        (chosen_prize_id)
+#  index_mission_submissions_on_deleted_at             (deleted_at)
+#  index_mission_submissions_on_mission_id             (mission_id)
+#  index_mission_submissions_on_mission_id_and_status  (mission_id,status)
+#  index_mission_submissions_on_reviewed_by_id         (reviewed_by_id)
+#  index_mission_submissions_on_ship_event_id          (ship_event_id)
+#  index_mission_submissions_on_shop_order_id          (shop_order_id)
+#  index_mission_submissions_on_status_and_created_at  (status,created_at)
+#  index_mission_submissions_on_status_and_pending_at  (status,pending_at)
+#  index_mission_submissions_with_shop_order           (shop_order_id) WHERE (shop_order_id IS NOT NULL)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (chosen_prize_id => mission_prizes.id)
+#  fk_rails_...  (mission_id => missions.id)
+#  fk_rails_...  (reviewed_by_id => users.id)
+#  fk_rails_...  (ship_event_id => post_ship_events.id)
+#  fk_rails_...  (shop_order_id => shop_orders.id)
+#
 class Mission::SubmissionTest < ActiveSupport::TestCase
   setup do
     @builder = User.create!(email: "builder-#{SecureRandom.hex(4)}@example.test",


### PR DESCRIPTION
## what's this do?

previously, things like mission review queue, oldest project, and 3d late were all based on the ship date rather than last review time. Now it's based on last review time! (so if things get returned and re-submitted, it doesn't mess up the stats)

## show it works

<img width="2161" height="1191" alt="image" src="https://github.com/user-attachments/assets/1bf3d79e-8bbe-4097-91c9-41c13c6d2dfe" />

## ai?

claude
