### PR TITLE
feat(github): issue templtes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: bug report
+description: something's broken? tell us about it!
+title: "[bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        thanks for taking the time to report this! the more detail you give us, the faster we can fix it :)
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: what happened?
+      description: a sentence or two about what went wrong
+      placeholder: i clicked the launch button and my pc took off
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: what did you expect to happen?
+      placeholder: my pc not to have thrusters
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: how do we make it happen?
+      description: step-by-step so we can see it break too
+      placeholder: |
+        1. go to '...'
+        2. click on '...'
+        3. takeoff
+    validations:
+      required: true
+  - type: textarea
+    id: proof
+    attributes:
+      label: show us!
+      description: screenshots, screen recordings, error messages — whatever makes sense
+    validations:
+      required: false
+  - type: input
+    id: environment
+    attributes:
+      label: where were you?
+      description: browser + device, and the page/url if it matters
+      placeholder: arc on macos, on /projects
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Stardance Help
+    url: https://hackclub.enterprise.slack.com/archives/C0AP0NMSP3P
+    about: Having issues with the platform, ask the support scouts on slack!

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: feature request
+description: got an idea? we wanna hear it!
+title: "[feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        thanks for the idea! tell us about it below :)
+  - type: textarea
+    id: problem
+    attributes:
+      label: what's the problem?
+      description: what's annoying, missing, or could be better?
+      placeholder: it bugs me when...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: what do you want to happen?
+      description: describe the thing you'd like to see
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: any other ways to solve it?
+      description: other approaches you thought about, if any
+    validations:
+      required: false
+  - type: textarea
+    id: extra
+    attributes:
+      label: anything else?
+      description: sketches, links, context — anything that helps
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -23,13 +23,6 @@ body:
     validations:
       required: true
   - type: textarea
-    id: alternatives
-    attributes:
-      label: any other ways to solve it?
-      description: other approaches you thought about, if any
-    validations:
-      required: false
-  - type: textarea
     id: extra
     attributes:
       label: anything else?


### PR DESCRIPTION
## what's this do?

adds templates for github issues aswell as a link to #stardance-help

## show it works

<img width="898" height="409" alt="image" src="https://github.com/user-attachments/assets/3046fc88-9fcb-42aa-93fc-22e370c5f0e0" />

## ai?

claude fable 5