### PR TITLE
Require idv for likes & feed event tracking

### DIFF
--- a/app/controllers/feed_events_controller.rb
+++ b/app/controllers/feed_events_controller.rb
@@ -15,7 +15,7 @@ class FeedEventsController < ApplicationController
   }.freeze
 
   def create
-    if current_user.present?
+    if current_user.present? && current_user.identity_verified?
       event_params.each { |event| record_event(event) }
     end
 

--- a/app/policies/like_policy.rb
+++ b/app/policies/like_policy.rb
@@ -1,6 +1,6 @@
 class LikePolicy < ApplicationPolicy
   def create?
-    logged_in?
+    logged_in? && verified?
   end
 
   def destroy?

--- a/test/controllers/feed_events_controller_test.rb
+++ b/test/controllers/feed_events_controller_test.rb
@@ -128,6 +128,24 @@ class FeedEventsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, @post.reload.views_count
   end
 
+  test "unverified user does not record a post view" do
+    @user.update!(verification_status: "needs_submission")
+
+    assert_no_difference -> { PostView.count }, -> { @post.reload.views_count } do
+      post feed_events_path, params: {
+        events: [
+          {
+            event_type: "impression",
+            item_type: "post",
+            post_id: @post.id
+          }
+        ]
+      }, as: :json
+    end
+
+    assert_response :accepted
+  end
+
   private
     def with_gorse_enabled
       original = Gorse.method(:enabled?)

--- a/test/policies/like_policy_test.rb
+++ b/test/policies/like_policy_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class LikePolicyTest < ActiveSupport::TestCase
+  setup do
+    @user = create_user(slack_id: "U_LIKE_POLICY_USER", display_name: "lpu")
+    @likeable = post_devlogs(:one)
+    @like = Like.new(user: @user, likeable: @likeable)
+  end
+
+  test "create? is false for nil user" do
+    refute LikePolicy.new(nil, @like).create?
+  end
+
+  test "create? is false for a logged-in but unverified user" do
+    @user.update!(verification_status: "needs_submission")
+    refute LikePolicy.new(@user, @like).create?
+  end
+
+  test "create? is true once the user is verified" do
+    @user.update!(verification_status: "verified")
+    assert LikePolicy.new(@user, @like).create?
+  end
+end


### PR DESCRIPTION
## what's this do?

The `LikePolicy` only checked `logged_in?`, not `verified?`. The FeedEventsController only checked `current_user_present`.
This lets unverified accounts farm likes and inflate view counts. This PR makes both require identity verification.

## show it works

<!-- screen recording, screenshots, test output— whatever makes sense for the change -->

<img width="1003" height="216" alt="image" src="https://github.com/user-attachments/assets/c32ee164-9c5a-40b1-b9ff-98105fa323c6" />
(The tests tests the new logic)

## ai?

Yes, used opencode for finding the exploit.
