### PR TITLE
add request re-certification button to ship decision feed card

### DIFF
--- a/app/views/projects/_ship_decision_card.html.erb
+++ b/app/views/projects/_ship_decision_card.html.erb
@@ -8,6 +8,8 @@
   decided_on = decision.decided_on
   reviewer = decision.reviewer
   reviewer_name = reviewer&.display_name.presence
+  returned = decision.returned? && project.needs_changes? &&
+    decision == project.ship_reviews.order(created_at: :desc, id: :desc).first
 %>
 
 <article id="<%= dom_id(decision) %>"
@@ -68,5 +70,16 @@
                       class: "ship-decision-card__video" %>
       </div>
     </section>
+  <% end %>
+
+  <% if returned %>
+    <% if is_member || current_user&.can_review? %>
+      <% confirm_msg = is_member ? "Have you addressed the feedback? This will re-enter the review queue." : "This will request re-certification on behalf of the user. Continue?" %>
+      <%= button_to "Request re-certification",
+            project_recertification_path(project),
+            method: :post,
+            class: "recert-modal__btn recert-modal__btn--primary",
+            form: { data: { turbo_confirm: confirm_msg } } %>
+    <% end %>
   <% end %>
 </article>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -829,7 +829,7 @@
         <% ship_index = 0 %>
         <% @timeline_entries.each do |entry| %>
           <% if entry.is_a?(Certification::Ship) %>
-            <%= render "projects/ship_decision_card", decision: entry %>
+            <%= render "projects/ship_decision_card", decision: entry, is_member: is_member, project: @project %>
           <% elsif entry.postable_type == "Post::ShipEvent" %>
             <% ship_index += 1 %>
             <% recert_id = ((is_member || current_user&.can_review?) && @project.needs_changes? && ship_index == 1) ? "recert-modal-#{@project.id}" : nil %>


### PR DESCRIPTION
## what's this do?

adds the request re-certification button to ship decision feed card as people seem to not be able to find it

## show it works

<img width="1136" height="541" alt="image" src="https://github.com/user-attachments/assets/7ff8b18b-9ed1-43f2-8309-a2cdcde8a2da" />

<img width="1136" height="1181" alt="image" src="https://github.com/user-attachments/assets/a82242ae-20b6-4ab1-8552-37c6254767f9" />

## ai?

little bit of claude