### PR TITLE
feat(feed): add length clamping and show more button

### DIFF
--- a/app/assets/stylesheets/components/_feed.scss
+++ b/app/assets/stylesheets/components/_feed.scss
@@ -881,6 +881,47 @@
     padding-left: 0;
   }
 
+  &__body-clamp {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xxs);
+  }
+
+  &__body--clamped {
+    // Roughly five lines of body text; the JS controller unhides the
+    // "Read more" toggle only when the content actually overflows this.
+    max-height: calc(1.4em * 5);
+    overflow: hidden;
+    -webkit-mask-image: linear-gradient(
+      to bottom,
+      #000 calc(100% - 2em),
+      transparent
+    );
+    mask-image: linear-gradient(to bottom, #000 calc(100% - 2em), transparent);
+  }
+
+  &__read-more {
+    margin-left: var(--feed-content-offset);
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--color-brand-cream);
+    font: inherit;
+    font-size: calc(var(--font-size-s) * 1.2);
+    line-height: 1.4;
+    cursor: pointer;
+    align-self: flex-start;
+
+    &:hover,
+    &:focus-visible {
+      text-decoration: underline;
+    }
+
+    @media (max-width: 640px) {
+      margin-left: 0;
+    }
+  }
+
   &__media {
     padding-left: var(--feed-content-offset);
 

--- a/app/components/posts/card_component.html.erb
+++ b/app/components/posts/card_component.html.erb
@@ -91,9 +91,24 @@
       <%= helpers.md("As a prize for your great work, look out for a bonus prize in the mail :)", allow_images: false) %>
     </div>
   <% elsif body.present? && !quote_repost? %>
-    <div class="feed-post-card__body markdown-content">
-      <%= helpers.md(body, allow_images: false) %>
-    </div>
+    <% if clamp_body? %>
+      <div class="feed-post-card__body-clamp"
+           data-controller="read-more"
+           data-read-more-clamped-class="feed-post-card__body--clamped">
+        <div class="feed-post-card__body feed-post-card__body--clamped markdown-content" data-read-more-target="body">
+          <%= helpers.md(body, allow_images: false) %>
+        </div>
+        <button type="button"
+                class="feed-post-card__read-more"
+                data-read-more-target="toggle"
+                data-action="read-more#toggle"
+                hidden>Read more</button>
+      </div>
+    <% else %>
+      <div class="feed-post-card__body markdown-content">
+        <%= helpers.md(body, allow_images: false) %>
+      </div>
+    <% end %>
   <% end %>
 
   <%= render "shared/post_media",

--- a/app/components/posts/card_component.rb
+++ b/app/components/posts/card_component.rb
@@ -126,6 +126,12 @@ module Posts
       display_postable.respond_to?(:body) ? display_postable.body : nil
     end
 
+    # Clamp long bodies everywhere except on the post's own page, where the
+    # full text should always be visible.
+    def clamp_body?
+      card_link_url.present? && request.path != card_link_url
+    end
+
     def original_post
       postable.original_post if repost? && postable.respond_to?(:original_post)
     end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -304,6 +304,9 @@ application.register("project-thumbs-scroll", ProjectThumbsScrollController);
 import ProjectTypeController from "./project_type_controller";
 application.register("project-type", ProjectTypeController);
 
+import ReadMoreController from "./read_more_controller";
+application.register("read-more", ReadMoreController);
+
 import ReadmeImageController from "./readme_image_controller";
 application.register("readme-image", ReadmeImageController);
 

--- a/app/javascript/controllers/read_more_controller.js
+++ b/app/javascript/controllers/read_more_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Collapses long feed post bodies to a few lines. The toggle only appears
+// when the body actually overflows its clamped height.
+export default class extends Controller {
+  static targets = ["body", "toggle"];
+  static classes = ["clamped"];
+
+  connect() {
+    if (this.overflowing()) {
+      this.toggleTarget.hidden = false;
+    } else {
+      this.bodyTarget.classList.remove(this.clampedClass);
+    }
+  }
+
+  toggle() {
+    const clamped = this.bodyTarget.classList.toggle(this.clampedClass);
+    this.toggleTarget.textContent = clamped ? "Read more" : "Show less";
+  }
+
+  overflowing() {
+    return this.bodyTarget.scrollHeight > this.bodyTarget.clientHeight + 1;
+  }
+}


### PR DESCRIPTION
## what's this do?

adds a show more button and clamping for increased scroll

## show it works

<img width="1251" height="882" alt="image" src="https://github.com/user-attachments/assets/e5a3c447-f992-4417-9d52-e891a7ca3abb" />

## ai?

claude
