### PR TITLE
fix: let devlog time warning wrap in composer modal (#776)

### DIFF
--- a/app/assets/stylesheets/pages/projects/_show.scss
+++ b/app/assets/stylesheets/pages/projects/_show.scss
@@ -1787,7 +1787,6 @@ turbo-frame#project_hero {
   .feed-composer__chips,
   .feed-composer__grid,
   .feed-composer__attach-wrap,
-  .feed-composer__info-wrap,
   .feed-composer__toolbar {
     flex-shrink: 0;
   }


### PR DESCRIPTION
Fixes #776

## what's this do?

Deletes one line of CSS so the "Code for at least 15m before devlogging" message wraps instead of running under the Post button. A `flex-shrink: 0` rule meant to protect the modal's vertical layout was accidentally hitting the message's container too, which stopped it from shrinking and wrapping. The main page composer doesn't have that rule, which is why it was already fine there.

## show it works

Rendered the modal with the compiled CSS before and after, at desktop and mobile widths, plus every other message that slot can show.

**Desktop**

<img width="2584" height="402" alt="776-desktop-before-after" src="https://github.com/user-attachments/assets/da9f6402-3f54-4470-bb95-901bd44547b6" />

**Mobile**

<img width="1544" height="634" alt="776-mobile-before-after" src="https://github.com/user-attachments/assets/ee1b0df3-97c7-4793-ad34-9bb44e6cafe1" />

## ai?

Claude Code. I looked over the styles and spotted this line as the likely culprit when comparing it with the homepage (since the homepage doesn't have this bug), then had Opus run some tests to make sure I didn't explode everything (before/after renders at both widths, all the message states, and the squashed-modal case). Should be fine.