### PR TITLE
feat: display project multipliers, payouts, and blessings publicly on…

### DIFF
--- a/app/views/projects/_ship_card.html.erb
+++ b/app/views/projects/_ship_card.html.erb
@@ -73,6 +73,11 @@
         <% end %>
       <% end %>
     <% end %>
+    <% if ship.payout_blessing == "blessed" %>
+      <span class="project-show__latest-ship-status project-show__latest-ship-status--approved" title="Blessed (+20% bonus)">✨ Blessed</span>
+    <% elsif ship.payout_blessing == "cursed" %>
+      <span class="project-show__latest-ship-status project-show__latest-ship-status--returned" title="Cursed (-50% reduction)">💀 Cursed</span>
+    <% end %>
   </div>
 
   <header class="feed-post-card__header">
@@ -123,6 +128,18 @@
       <%= inline_svg_tag "icons/time.svg", class: "profile-project-card__meta-icon profile-project-card__meta-icon--time" %>
       <span><%= ship_hours %>h<%= " build" if project.hardware? %></span>
     </li>
+    <% ship_multiplier = ship.multiplier || ship.payout_multiplier %>
+    <% if ship_multiplier.present? %>
+      <li class="profile-project-card__meta-item profile-project-card__meta-item--multiplier" title="Quality multiplier">
+        <%= inline_svg_tag "icons/star_fill.svg", class: "profile-project-card__meta-icon" %>
+        <span><%= number_with_precision(ship_multiplier, precision: 2) %>x multiplier</span>
+      </li>
+    <% end %>
+    <% if ship.payout.present? %>
+      <li class="profile-project-card__meta-item profile-project-card__meta-item--payout" title="Stardust payout">
+        <span><%= ship.payout.to_i %> Stardust</span>
+      </li>
+    <% end %>
     <% mission = ship.mission_submission&.mission %>
     <% if mission %>
       <li class="profile-project-card__meta-item profile-project-card__meta-item--mission">


### PR DESCRIPTION
## what's this do?
Implements #859 by showing the multiplier, and total stardust earned per ship
## show it works
<img width="1470" height="956" alt="Screenshot 2026-07-21 at 7 22 17 PM" src="https://github.com/user-attachments/assets/8b47ad15-7496-4de9-811e-6b38fefeeaca" />
<img width="1463" height="952" alt="Screenshot 2026-07-21 at 7 22 10 PM" src="https://github.com/user-attachments/assets/d2e7b86d-5fd2-4613-9fb4-dacc38b84688" />

## ai?
Used Claude to host the thing on localhost, i could not figure out a thing about that, but i needed screenshots as per the CONTRIBUTING.md. since i used claude, thats why the pictures show completely ai genrated devlogs. and it told me to use @kartikey username for testing cuz its there in the code as super admin so thats why the pics show him. 