### PR TITLE
feat(shop): add customs modal

### DIFF
--- a/app/assets/stylesheets/pages/shop/_order.scss
+++ b/app/assets/stylesheets/pages/shop/_order.scss
@@ -720,3 +720,99 @@
     }
   }
 }
+
+.customs-modal {
+  border: 2px solid var(--color-brand-salmon);
+  border-radius: var(--border-radius);
+  padding: var(--space-xl);
+  max-width: 440px;
+  width: 90%;
+  background: var(--color-set-2-bg);
+  color: var(--color-space-text);
+  font-family: var(--font-family-text);
+
+  &::backdrop {
+    background: var(--color-backdrop);
+  }
+
+  &__close {
+    position: absolute;
+    top: var(--space-s);
+    right: var(--space-s);
+    background: none;
+    border: none;
+    color: var(--color-space-text-muted);
+    font-size: 1.5rem;
+    cursor: pointer;
+    line-height: 1;
+    padding: var(--space-xxs);
+
+    &:hover {
+      color: var(--color-space-text);
+    }
+  }
+
+  &__title {
+    margin: 0 0 var(--space-m) 0;
+    font-size: var(--font-size-xxl);
+    color: var(--color-brand-salmon);
+    font-family: var(--font-family-text);
+  }
+
+  &__body {
+    margin: 0 0 var(--space-m) 0;
+    line-height: var(--line-height-body);
+    color: var(--color-space-text);
+
+    &--detail {
+      color: var(--color-space-text-muted);
+      font-size: var(--font-size-s);
+    }
+
+    &--eu {
+      color: var(--color-brand-peach);
+      font-size: var(--font-size-s);
+      font-style: italic;
+    }
+  }
+
+  &__actions {
+    display: flex;
+    gap: var(--space-s);
+    margin-top: var(--space-l);
+  }
+
+  &__btn {
+    flex: 1;
+    padding: var(--space-s) var(--space-m);
+    border-radius: var(--profile-radius);
+    font-family: var(--font-family-text);
+    font-size: var(--font-size-m);
+    font-weight: 600;
+    cursor: pointer;
+    border: none;
+    transition:
+      background 0.15s ease,
+      opacity 0.15s ease;
+
+    &--confirm {
+      background: var(--color-brand-salmon);
+      color: var(--color-set-1-bg);
+
+      &:hover {
+        opacity: 0.9;
+      }
+    }
+
+    &--cancel {
+      background: var(--color-space-surface-faint);
+      color: var(--color-space-text-muted);
+      border: 1px solid var(--color-space-border);
+
+      &:hover {
+        background: var(--color-space-surface-soft);
+        color: var(--color-space-text);
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/pages/shop/_order.scss
+++ b/app/assets/stylesheets/pages/shop/_order.scss
@@ -727,6 +727,7 @@
   padding: var(--space-xl);
   max-width: 440px;
   width: 90%;
+  margin: auto;
   background: var(--color-set-2-bg);
   color: var(--color-space-text);
   font-family: var(--font-family-text);

--- a/app/javascript/controllers/customs_modal_controller.js
+++ b/app/javascript/controllers/customs_modal_controller.js
@@ -1,0 +1,105 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["dialog", "euNote"];
+  static values = {
+    itemType: String,
+    sourceRegion: String,
+    storageKey: String,
+    euCountries: Array,
+  };
+
+  connect() {
+    this.pendingSubmit = null;
+    this.currentCountry = null;
+  }
+
+  addressChanged(event) {
+    this.currentCountry = event.detail?.country || null;
+  }
+
+  interceptSubmit(event) {
+    if (!this.shouldShowModal()) return;
+    if (this.isDismissed()) return;
+
+    event.preventDefault();
+    this.pendingSubmit = event.target;
+    this.updateEuNote();
+    this.dialogTarget.showModal();
+  }
+
+  confirm() {
+    this.storeDismissal();
+    this.closeDialog();
+    if (this.pendingSubmit) {
+      this.pendingSubmit.requestSubmit();
+      this.pendingSubmit = null;
+    }
+  }
+
+  cancel() {
+    this.closeDialog();
+    this.pendingSubmit = null;
+  }
+
+  closeDialog() {
+    if (typeof this.dialogTarget.close === "function") {
+      this.dialogTarget.close();
+    } else {
+      this.dialogTarget.removeAttribute("open");
+    }
+  }
+
+  updateEuNote() {
+    if (!this.hasEuNoteTarget) return;
+    const isEu =
+      this.currentCountry &&
+      this.euCountriesValue.includes(this.currentCountry.toUpperCase());
+    this.euNoteTarget.style.display = isEu ? "block" : "none";
+  }
+
+  shouldShowModal() {
+    const itemType = this.itemTypeValue;
+    if (itemType === "none") return false;
+
+    const country = this.currentCountry;
+    if (!country) return false;
+
+    switch (itemType) {
+      case "us_origin":
+        return country !== "US";
+      case "uk_origin":
+        return country !== "GB";
+      case "unknown_origin":
+        return true;
+      case "custom_region":
+        return !this.isInRegion(country, this.sourceRegionValue);
+      default:
+        return false;
+    }
+  }
+
+  isInRegion(countryCode, regionCode) {
+    if (!regionCode) return true;
+    if (regionCode.toUpperCase() === "EU") {
+      return this.euCountriesValue.includes(countryCode.toUpperCase());
+    }
+    return false;
+  }
+
+  isDismissed() {
+    try {
+      return localStorage.getItem(this.storageKeyValue) === "1";
+    } catch {
+      return false;
+    }
+  }
+
+  storeDismissal() {
+    try {
+      localStorage.setItem(this.storageKeyValue, "1");
+    } catch {
+      // localStorage unavailable — fail open
+    }
+  }
+}

--- a/app/views/shop/items/_customs_modal.html.erb
+++ b/app/views/shop/items/_customs_modal.html.erb
@@ -7,7 +7,7 @@
     <p class="customs-modal__body">
       You're about to order an item that ships from Hack Club HQ!
       You may be charged customs or import fees.
-      It is your responsibility to pay them.<br/>
+      It is your responsibility to pay them.<br>
 
       If you can't pay customs, don't fret! Look for items without the "ships from US" label.
     </p>

--- a/app/views/shop/items/_customs_modal.html.erb
+++ b/app/views/shop/items/_customs_modal.html.erb
@@ -8,6 +8,8 @@
       You're about to order an item that ships from Hack Club HQ!
       You may be charged customs or import fees.
       It is your responsibility to pay them.
+
+      If you can't pay customs, don't fret! Look for items without the "ships from US" label.
     </p>
     <p class="customs-modal__body customs-modal__body--detail">
       This often includes handling fees (around ~$10) + 21% of the original price of your package.
@@ -16,8 +18,8 @@
       Additionally, new EU regulations add a flat &euro;3 fee for every item that ships from outside the EU.
     </p>
     <div class="customs-modal__actions">
-      <button type="button" class="customs-modal__btn customs-modal__btn--confirm" data-action="click->customs-modal#confirm">I understand, continue</button>
-      <button type="button" class="customs-modal__btn customs-modal__btn--cancel" data-action="click->customs-modal#cancel">Cancel</button>
+      <button type="button" class="customs-modal__btn customs-modal__btn--confirm" data-action="click->customs-modal#confirm">I will pay these customs</button>
+      <button type="button" class="customs-modal__btn customs-modal__btn--cancel" data-action="click->customs-modal#cancel">No, thanks</button>
     </div>
   </div>
 </dialog>

--- a/app/views/shop/items/_customs_modal.html.erb
+++ b/app/views/shop/items/_customs_modal.html.erb
@@ -7,7 +7,7 @@
     <p class="customs-modal__body">
       You're about to order an item that ships from Hack Club HQ!
       You may be charged customs or import fees.
-      It is your responsibility to pay them.
+      It is your responsibility to pay them.<br/>
 
       If you can't pay customs, don't fret! Look for items without the "ships from US" label.
     </p>

--- a/app/views/shop/items/_customs_modal.html.erb
+++ b/app/views/shop/items/_customs_modal.html.erb
@@ -1,0 +1,23 @@
+<dialog class="customs-modal"
+        data-controller="modal"
+        data-customs-modal-target="dialog">
+  <button type="button" class="customs-modal__close" aria-label="Close" data-action="click->customs-modal#cancel">&times;</button>
+  <div class="customs-modal__content">
+    <h3 class="customs-modal__title">Heads up!</h3>
+    <p class="customs-modal__body">
+      You're about to order an item that ships from Hack Club HQ!
+      You may be charged customs or import fees.
+      It is your responsibility to pay them.
+    </p>
+    <p class="customs-modal__body customs-modal__body--detail">
+      This often includes handling fees (around ~$10) + 21% of the original price of your package.
+    </p>
+    <p class="customs-modal__body customs-modal__body--eu customs-modal__eu-note" data-customs-modal-target="euNote" style="display: none;">
+      Additionally, new EU regulations add a flat &euro;3 fee for every item that ships from outside the EU.
+    </p>
+    <div class="customs-modal__actions">
+      <button type="button" class="customs-modal__btn customs-modal__btn--confirm" data-action="click->customs-modal#confirm">I understand, continue</button>
+      <button type="button" class="customs-modal__btn customs-modal__btn--cancel" data-action="click->customs-modal#cancel">Cancel</button>
+    </div>
+  </div>
+</dialog>

--- a/app/views/shop/items/show.html.erb
+++ b/app/views/shop/items/show.html.erb
@@ -97,9 +97,11 @@
             <div class="shop-order__customs-warning" data-customs-warning-target="warning" style="display: none;"></div>
         </div>
         <% if current_user %>
-        <div class="shop-order__details" data-controller="order-form" data-order-form-has-addresses-value="<%= @user_addresses.any? %>" data-order-form-base-ticket-cost-value="<%= @sale_price || @shop_item.ticket_cost || 0 %>" data-order-form-user-balance-value="<%= @user_balance %>" data-order-form-free-value="<%= @mission_submission.present? %>" data-order-form-addresses-value="<%= @user_addresses.to_json %>" data-order-form-blocked-countries-value="<%= @shop_item.blocked_countries.to_json %>" data-order-form-stardust-icon-url-value="<%= image_path('icons/stardust.png') %>" data-action="address-select:change@document->order-form#addressChanged">
+        <% eu_countries = %w[AT BE BG HR CY CZ DK EE FI FR DE GR HU IE IT LV LT LU MT NL PL PT RO SK SI ES SE] %>
+        <div class="shop-order__details" data-controller="order-form customs-modal" data-order-form-has-addresses-value="<%= @user_addresses.any? %>" data-order-form-base-ticket-cost-value="<%= @sale_price || @shop_item.ticket_cost || 0 %>" data-order-form-user-balance-value="<%= @user_balance %>" data-order-form-free-value="<%= @mission_submission.present? %>" data-order-form-addresses-value="<%= @user_addresses.to_json %>" data-order-form-blocked-countries-value="<%= @shop_item.blocked_countries.to_json %>" data-order-form-stardust-icon-url-value="<%= image_path('icons/stardust.png') %>" data-action="address-select:change@document->order-form#addressChanged address-select:change@document->customs-modal#addressChanged" data-customs-modal-item-type-value="<%= customs_warning_item_type(@shop_item) %>" data-customs-modal-source-region-value="<%= customs_warning_source_region(@shop_item) %>" data-customs-modal-storage-key-value="customs-modal-dismissed-<%= @shop_item.id %>" data-customs-modal-eu-countries-value="<%= eu_countries.to_json %>">
             <h2>Complete your order:</h2>
-            <%= form_with url: shop_orders_path(shop_item_id: @shop_item.id), method: :post, local: true, id: "order-form" do |form| %>
+            <%= form_with url: shop_orders_path(shop_item_id: @shop_item.id), method: :post, local: true, id: "order-form", data: { action: "submit->customs-modal#interceptSubmit" } do |form| %>
+                <%= render "shop/items/customs_modal" %>
                 <% if @mission_submission %>
                     <%= form.hidden_field :quantity, value: 1 %>
                     <%= form.hidden_field :mission_submission_id, value: @mission_submission.id %>


### PR DESCRIPTION
## what's this do?

personally, when I first got an item from a Hack Club YSWS that shipped from Burlington I got hit by quite a surprise bill! it's a bit better now with the warning on the shop page itself, but I think that especially now that the customs get even higher in Europe it is important we show a little modal to prevent packages being unnecessarily sent back!

## show it works

<img width="1919" height="1080" alt="image" src="https://github.com/user-attachments/assets/02ab7977-7886-4eba-80fb-39daedce5b51" />

## ai?

opencode/glm 4.6, but I reviewed everything it did and made sure it worked
