### PR TITLE
feat(certifications): improve GOI review queue workflow

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -69,7 +69,7 @@ body.admin-page {
     font-size: var(--font-size-l);
   }
 
-  a:not(.action-btn):not([class*="btn-"]) {
+  a:not(.action-btn):not([class*="btn-"]):not(.ysws-queue__view-btn) {
     color: var(--color-brand-highlight);
     text-decoration: none;
 

--- a/app/assets/stylesheets/pages/admin/_ysws_reviews.scss
+++ b/app/assets/stylesheets/pages/admin/_ysws_reviews.scss
@@ -105,7 +105,25 @@
   }
 
   & &__reset-filters {
+    display: inline-flex;
+    align-items: center;
     align-self: flex-end;
+    min-height: 3rem;
+    padding-inline: var(--space-s);
+    background: var(--color-set-1-bg);
+    border: 2px solid var(--color-set-1-fg-secondary);
+    border-radius: var(--profile-radius);
+    color: var(--color-space-text);
+    font-size: var(--font-size-s);
+    font-weight: 700;
+    text-decoration: none;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.06);
+      border-color: var(--color-brand-highlight);
+      color: var(--color-brand-highlight);
+      text-decoration: none;
+    }
   }
 
   // Sortable column header: the title doubles as a sort toggle, with an arrow
@@ -720,9 +738,32 @@ body:has(.certification-ysws) {
       flex-wrap: wrap;
     }
 
+    &__review-actions {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: var(--space-s);
+    }
+
     &__unclaim-form {
-      flex-basis: 100%;
       margin: 0;
+
+      .btn-secondary {
+        background: rgba(129, 255, 255, 0.08);
+        border: 2px solid var(--color-brand-mint);
+        border-radius: var(--profile-radius);
+        color: var(--color-brand-mint);
+        font-size: var(--font-size-s);
+        font-weight: 700;
+        box-shadow: none;
+
+        &:hover {
+          background: rgba(129, 255, 255, 0.16);
+          color: var(--color-brand-mint);
+          box-shadow: 0 4px 12px rgba(129, 255, 255, 0.25);
+          transform: translateY(-2px);
+        }
+      }
     }
 
     // Title row carries the page heading plus the shared Super Star (magic)
@@ -1587,8 +1628,14 @@ body:has(.certification-ysws) {
 
     .quick-adjust-buttons {
       display: flex;
-      flex-wrap: wrap;
+      flex-direction: column;
       gap: var(--space-xxs);
+
+      &__row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-xxs);
+      }
     }
 
     .adjust-btn {

--- a/app/assets/stylesheets/pages/admin/_ysws_reviews.scss
+++ b/app/assets/stylesheets/pages/admin/_ysws_reviews.scss
@@ -275,7 +275,7 @@
     background: var(--color-brand-salmon-soft);
     color: var(--color-brand-salmon);
   }
- // Small action primary, dark-bg variant with extra contrast for claimed rows.
+  // Small action primary, dark-bg variant with extra contrast for claimed rows.
   & &__view-btn {
     display: inline-block;
     padding: 3px 16px;

--- a/app/assets/stylesheets/pages/admin/_ysws_reviews.scss
+++ b/app/assets/stylesheets/pages/admin/_ysws_reviews.scss
@@ -271,28 +271,32 @@
     background: var(--color-brand-salmon-soft);
     color: var(--color-brand-salmon);
   }
-
-  // Small action primary, dark-bg variant (branding §4.2): highlight fill,
-  // dark text, no border, 16px bold, 16px/3px padding, fully rounded.
+ // Small action primary, dark-bg variant with extra contrast for claimed rows.
   & &__view-btn {
     display: inline-block;
     padding: 3px 16px;
+    border: 2px solid var(--color-brand-mint);
     border-radius: 999px;
-    background: var(--color-brand-highlight);
-    color: var(--color-set-1-bg);
+    background: var(--color-brand-blue);
+    color: var(--color-brand-yellow);
     font-size: var(--font-size-m);
     font-weight: 700;
     text-decoration: none;
     white-space: nowrap;
+    box-shadow: 0 0 0 2px var(--color-set-1-bg);
+
+    &:visited,
+    &:hover {
+      color: var(--color-brand-yellow);
+    }
 
     &:hover {
-      background: var(--color-brand-highlight-secondary);
-      color: var(--color-set-1-bg);
+      background: var(--color-brand-blue);
       text-decoration: none;
     }
 
     &:active {
-      background: var(--color-space-text);
+      background: var(--color-brand-highlight-secondary);
     }
 
     &:focus-visible {

--- a/app/assets/stylesheets/pages/admin/_ysws_reviews.scss
+++ b/app/assets/stylesheets/pages/admin/_ysws_reviews.scss
@@ -104,6 +104,10 @@
     letter-spacing: 0.05em;
   }
 
+  & &__reset-filters {
+    align-self: flex-end;
+  }
+
   // Sortable column header: the title doubles as a sort toggle, with an arrow
   // that points up/down when its column is the active sort and is dimmed
   // otherwise.
@@ -278,7 +282,7 @@
     border: 2px solid var(--color-brand-mint);
     border-radius: 999px;
     background: var(--color-brand-blue);
-    color: var(--color-brand-yellow);
+    color: #000;
     font-size: var(--font-size-m);
     font-weight: 700;
     text-decoration: none;
@@ -287,7 +291,7 @@
 
     &:visited,
     &:hover {
-      color: var(--color-brand-yellow);
+      color: #000;
     }
 
     &:hover {
@@ -714,6 +718,11 @@ body:has(.certification-ysws) {
       gap: var(--space-s);
       align-items: flex-start;
       flex-wrap: wrap;
+    }
+
+    &__unclaim-form {
+      flex-basis: 100%;
+      margin: 0;
     }
 
     // Title row carries the page heading plus the shared Super Star (magic)
@@ -1307,6 +1316,12 @@ body:has(.certification-ysws) {
       font-size: var(--font-size-l);
       font-weight: 700;
       font-family: var(--font-family-sans);
+    }
+
+    .devlog-date {
+      color: var(--color-set-1-fg-secondary);
+      font-size: var(--font-size-s);
+      font-weight: 600;
     }
 
     .devlog-status {

--- a/app/controllers/admin/certification/ysws_controller.rb
+++ b/app/controllers/admin/certification/ysws_controller.rb
@@ -1,9 +1,37 @@
 class Admin::Certification::YswsController < Admin::Certification::ApplicationController
+  FILTER_SESSION_KEY = :admin_ysws_review_filters
+
   def index
     authorize ::Certification::Ysws
-    @project_type = params[:project_type].presence
-    @sort         = params[:sort].presence_in(%w[length todo])
-    @dir          = params[:dir] == "asc" ? "asc" : "desc"
+    if params[:reset_filters].present?
+      session.delete(FILTER_SESSION_KEY)
+      redirect_to admin_certification_ysws_reviews_path
+      return
+    end
+
+    filters = ysws_review_filters
+    if params.key?(:project_type)
+      if params[:project_type].present?
+        filters["project_type"] = params[:project_type]
+      else
+        filters.delete("project_type")
+      end
+    end
+    if params.key?(:sort)
+      sort = params[:sort].presence_in(%w[length todo])
+      if sort
+        filters["sort"] = sort
+        filters["dir"] = params[:dir] == "asc" ? "asc" : "desc"
+      else
+        filters.delete("sort")
+        filters.delete("dir")
+      end
+    end
+    session[FILTER_SESSION_KEY] = filters
+
+    @project_type = filters["project_type"].presence
+    @sort         = filters["sort"].presence_in(%w[length todo])
+    @dir          = filters["dir"] == "asc" ? "asc" : "desc"
 
     scope = ::Certification::Ysws.pending.unclaimed_or_claimed_by(current_user)
 
@@ -34,7 +62,7 @@ class Admin::Certification::YswsController < Admin::Certification::ApplicationCo
 
   def show
     @review = ::Certification::Ysws
-      .includes(:project, :user, :reviewer, devlog_reviews: { post_devlog: :attachments_attachments })
+      .includes(:project, :user, :reviewer, devlog_reviews: { post_devlog: [ :post, :attachments_attachments ] })
       .find(params[:id])
     authorize @review
 
@@ -65,7 +93,7 @@ class Admin::Certification::YswsController < Admin::Certification::ApplicationCo
     @prior_reviews = ::Certification::Ysws
       .where(project_id: @review.project_id)
       .where("id < ?", @review.id)
-      .includes(devlog_reviews: { post_devlog: :attachments_attachments })
+      .includes(devlog_reviews: { post_devlog: [ :post, :attachments_attachments ] })
       .order(:id)
 
     # Prior (frozen) + current devlogs, in display order, counted together in
@@ -130,6 +158,10 @@ class Admin::Certification::YswsController < Admin::Certification::ApplicationCo
   end
 
   private
+
+  def ysws_review_filters
+    session[FILTER_SESSION_KEY].to_h.slice("project_type", "sort", "dir")
+  end
 
 
   # Fetches all commits in the review period and buckets them by devlog ID.
@@ -220,6 +252,17 @@ class Admin::Certification::YswsController < Admin::Certification::ApplicationCo
     else
       render json: { success: false, errors: report.errors.full_messages }, status: :unprocessable_entity
     end
+  end
+
+  def unclaim
+    @review = ::Certification::Ysws.includes(:project).find(params[:id])
+    authorize @review, :unclaim?
+
+    @review.release_claim!
+    Rails.logger.info "[YSWS#unclaim] user=#{current_user.id} review=#{@review.id} Released claim"
+
+    redirect_to admin_certification_ysws_reviews_path,
+                notice: "Unclaimed review for “#{@review.project&.title || "Review ##{@review.id}"}.”"
   end
 
   def complete

--- a/app/controllers/admin/certification/ysws_controller.rb
+++ b/app/controllers/admin/certification/ysws_controller.rb
@@ -9,7 +9,7 @@ class Admin::Certification::YswsController < Admin::Certification::ApplicationCo
       return
     end
 
-    filters = ysws_review_filters
+    filters = ysws_review_filter_params? ? {} : ysws_review_filters
     if params.key?(:project_type)
       if params[:project_type].present?
         filters["project_type"] = params[:project_type]
@@ -163,6 +163,10 @@ class Admin::Certification::YswsController < Admin::Certification::ApplicationCo
     session[FILTER_SESSION_KEY].to_h.slice("project_type", "sort", "dir")
   end
 
+  def ysws_review_filter_params?
+    params.key?(:project_type) || params.key?(:sort) || params.key?(:dir)
+  end
+
 
   # Fetches all commits in the review period and buckets them by devlog ID.
   # Returns { devlog_id (integer) => [commit_hash, ...] }.
@@ -258,11 +262,14 @@ class Admin::Certification::YswsController < Admin::Certification::ApplicationCo
     @review = ::Certification::Ysws.includes(:project).find(params[:id])
     authorize @review, :unclaim?
 
-    @review.release_claim!
-    Rails.logger.info "[YSWS#unclaim] user=#{current_user.id} review=#{@review.id} Released claim"
-
-    redirect_to admin_certification_ysws_reviews_path,
-                notice: "Unclaimed review for “#{@review.project&.title || "Review ##{@review.id}"}.”"
+    if @review.release_claim!
+      Rails.logger.info "[YSWS#unclaim] user=#{current_user.id} review=#{@review.id} Released claim"
+      redirect_to admin_certification_ysws_reviews_path,
+                  notice: "Unclaimed review for “#{@review.project&.title || "Review ##{@review.id}"}.”"
+    else
+      redirect_to admin_certification_ysws_reviews_path,
+                  alert: "That review can no longer be unclaimed."
+    end
   end
 
   def complete

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -140,7 +140,10 @@ module ApplicationHelper
     return if cert.nil?
     return url_for(cert.verdict_video) if cert.verdict_video.attached?
 
-    safe_external_url(cert.proof_video_url)
+    safe_external_url(cert.proof_video_url)&.sub(
+      "/rails/active_storage/blobs/proxy/",
+      "/rails/active_storage/blobs/redirect/"
+    )
   end
 
   def achievement_icon(icon_name, earned: true, **options)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -138,12 +138,21 @@ module ApplicationHelper
 
   def certification_verdict_video_src(cert)
     return if cert.nil?
-    return url_for(cert.verdict_video) if cert.verdict_video.attached?
+    return rails_storage_redirect_path(cert.verdict_video) if cert.verdict_video.attached?
 
-    safe_external_url(cert.proof_video_url)&.sub(
-      "/rails/active_storage/blobs/proxy/",
-      "/rails/active_storage/blobs/redirect/"
-    )
+    active_storage_redirect_url(safe_external_url(cert.proof_video_url))
+  end
+
+  def active_storage_redirect_url(url)
+    return if url.blank?
+
+    uri = URI.parse(url)
+    return url unless uri.path.start_with?("/rails/active_storage/blobs/proxy/")
+
+    uri.path = uri.path.sub("/rails/active_storage/blobs/proxy/", "/rails/active_storage/blobs/redirect/")
+    uri.to_s
+  rescue URI::InvalidURIError
+    url
   end
 
   def achievement_icon(icon_name, earned: true, **options)

--- a/app/javascript/controllers/certification/ysws/devlog_review_controller.js
+++ b/app/javascript/controllers/certification/ysws/devlog_review_controller.js
@@ -150,6 +150,9 @@ export default class extends Controller {
       case "25%":
         newMinutes = Math.round(currentMinutes * 0.25);
         break;
+      case "-15":
+        newMinutes = Math.max(0, currentMinutes - 15);
+        break;
       case "-30":
         newMinutes = Math.max(0, currentMinutes - 30);
         break;

--- a/app/javascript/controllers/certification/ysws/devlog_time_chart_controller.js
+++ b/app/javascript/controllers/certification/ysws/devlog_time_chart_controller.js
@@ -86,7 +86,7 @@ export default class extends Controller {
       .attr("y", (d) => y(d.label) + y.bandwidth() / 2)
       .attr("dy", "0.35em")
       .attr("text-anchor", "end")
-      .attr("fill", "white")
+      .attr("fill", "#000")
       .attr("font-size", "12px")
       .attr("font-weight", "700")
       .attr("font-family", "var(--font-family-sans)")

--- a/app/models/certification/ysws.rb
+++ b/app/models/certification/ysws.rb
@@ -48,6 +48,8 @@ module Certification
   class Ysws < ApplicationRecord
     self.table_name = "certification_ysws_reviews"
 
+    has_paper_trail
+
     belongs_to :reviewer, class_name: "User", optional: true
     belongs_to :user
     belongs_to :project, -> { with_deleted }, optional: true
@@ -218,6 +220,12 @@ module Certification
 
     def claimed_by?(user)
       claim_active? && claimed_by_id == user.id
+    end
+
+    def release_claim!
+      return false unless pending? && claim_active?
+
+      update!(claimed_by: nil, claimed_at: nil)
     end
 
     def approved_minutes_total

--- a/app/policies/admin/certification/ysws_policy.rb
+++ b/app/policies/admin/certification/ysws_policy.rb
@@ -20,6 +20,6 @@ class Admin::Certification::YswsPolicy < ApplicationPolicy
   end
 
   def unclaim?
-    user.present? && index? && record.claimed_by?(user)
+    user.present? && index? && record.pending? && record.claimed_by?(user)
   end
 end

--- a/app/policies/admin/certification/ysws_policy.rb
+++ b/app/policies/admin/certification/ysws_policy.rb
@@ -18,4 +18,8 @@ class Admin::Certification::YswsPolicy < ApplicationPolicy
   def report_fraud?
     index?
   end
+
+  def unclaim?
+    user.present? && index? && record.claimed_by?(user)
+  end
 end

--- a/app/services/certification/commit_graph_builder.rb
+++ b/app/services/certification/commit_graph_builder.rb
@@ -99,7 +99,7 @@ module Certification
       sha_el   = url ? %(<a href="#{esc(url)}" target="_blank" rel="noopener noreferrer">#{sha_text}</a>) : sha_text
 
       <<~SVG
-        <svg viewBox="0 0 200 88" width="100%" style="overflow:visible" class="commit-graph">
+        <svg viewBox="0 0 200 88" width="420" style="max-width:100%;height:auto;overflow:visible" class="commit-graph">
           #{STYLE}
           <text x="0"  y="12" fill="#{ADDS_COLOR}"  font-size="11" font-family="monospace">+#{adds}</text>
           <text x="40" y="12" fill="#{DELS_COLOR}"  font-size="11" font-family="monospace">-#{dels}</text>

--- a/app/views/admin/certification/ysws/_devlog_review.html.erb
+++ b/app/views/admin/certification/ysws/_devlog_review.html.erb
@@ -148,24 +148,28 @@
       </div>
       <% unless frozen %>
         <div class="quick-adjust-buttons">
-          <button class="adjust-btn"
-                  data-action="click->certification--ysws--devlog-review#quickAdjust"
-                  data-adjust-action="50%">50%</button>
-          <button class="adjust-btn"
-                  data-action="click->certification--ysws--devlog-review#quickAdjust"
-                  data-adjust-action="25%">25%</button>
-          <button class="adjust-btn"
-                  data-action="click->certification--ysws--devlog-review#quickAdjust"
-                  data-adjust-action="-15">-15min</button>
-          <button class="adjust-btn"
-                  data-action="click->certification--ysws--devlog-review#quickAdjust"
-                  data-adjust-action="-30">-30min</button>
-          <button class="adjust-btn"
-                  data-action="click->certification--ysws--devlog-review#quickAdjust"
-                  data-adjust-action="-60">-1hr</button>
-          <button class="adjust-btn"
-                  data-action="click->certification--ysws--devlog-review#quickAdjust"
-                  data-adjust-action="reset">Reset</button>
+          <div class="quick-adjust-buttons__row">
+            <button class="adjust-btn"
+                    data-action="click->certification--ysws--devlog-review#quickAdjust"
+                    data-adjust-action="50%">50%</button>
+            <button class="adjust-btn"
+                    data-action="click->certification--ysws--devlog-review#quickAdjust"
+                    data-adjust-action="25%">25%</button>
+            <button class="adjust-btn"
+                    data-action="click->certification--ysws--devlog-review#quickAdjust"
+                    data-adjust-action="-15">-15min</button>
+          </div>
+          <div class="quick-adjust-buttons__row">
+            <button class="adjust-btn"
+                    data-action="click->certification--ysws--devlog-review#quickAdjust"
+                    data-adjust-action="-30">-30min</button>
+            <button class="adjust-btn"
+                    data-action="click->certification--ysws--devlog-review#quickAdjust"
+                    data-adjust-action="-60">-1hr</button>
+            <button class="adjust-btn"
+                    data-action="click->certification--ysws--devlog-review#quickAdjust"
+                    data-adjust-action="reset">Reset</button>
+          </div>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/certification/ysws/_devlog_review.html.erb
+++ b/app/views/admin/certification/ysws/_devlog_review.html.erb
@@ -24,6 +24,9 @@
   <div class="devlog-main">
     <div class="devlog-header-row">
       <span class="devlog-id">Devlog #<%= devlog_review.post_devlog.id %></span>
+      <% if (devlog_posted_at = devlog_review.post_devlog.post&.created_at) %>
+        <span class="devlog-date"><%= devlog_posted_at.strftime("%b %-d, %Y") %></span>
+      <% end %>
       <% if devlog_review.approved? %>
         <span class="devlog-status status-approved">Approved</span>
       <% elsif devlog_review.rejected? %>
@@ -151,6 +154,9 @@
           <button class="adjust-btn"
                   data-action="click->certification--ysws--devlog-review#quickAdjust"
                   data-adjust-action="25%">25%</button>
+          <button class="adjust-btn"
+                  data-action="click->certification--ysws--devlog-review#quickAdjust"
+                  data-adjust-action="-15">-15min</button>
           <button class="adjust-btn"
                   data-action="click->certification--ysws--devlog-review#quickAdjust"
                   data-adjust-action="-30">-30min</button>

--- a/app/views/admin/certification/ysws/index.html.erb
+++ b/app/views/admin/certification/ysws/index.html.erb
@@ -48,6 +48,12 @@
         <span class="ysws-queue__goal-label">Goal of <%= @devlog_goal %> devlogs reached</span>
       <% end %>
     </div>
+
+    <% if @project_type.present? || @sort.present? %>
+      <%= link_to "Reset filters",
+                  admin_certification_ysws_reviews_path(reset_filters: 1),
+                  class: "btn-secondary slim ysws-queue__reset-filters" %>
+    <% end %>
   <% end %>
 
   <% if @reviews.any? %>

--- a/app/views/admin/certification/ysws/show.html.erb
+++ b/app/views/admin/certification/ysws/show.html.erb
@@ -222,14 +222,16 @@
             </span>
           </div>
 
-          <% if @review.reviewer %>
-            <div class="detail-item">
-              <span class="detail-key">YSWS Reviewer:</span>
-              <span class="detail-value">
-                <%= link_to (@review.reviewer.display_name || "Unknown"), admin_user_path(@review.reviewer), class: "link-primary" %>
-              </span>
-            </div>
-          <% end %>
+          <div class="detail-item">
+            <span class="detail-key">Reviewed by:</span>
+            <span class="detail-value">
+              <% if @review.reviewer %>
+                <%= link_to (@review.reviewer.display_name.presence || "Unknown"), admin_user_path(@review.reviewer), class: "link-primary" %>
+              <% else %>
+                Not reviewed yet
+              <% end %>
+            </span>
+          </div>
 
           <% if @review.summary_justification.present? %>
             <div class="detail-item">

--- a/app/views/admin/certification/ysws/show.html.erb
+++ b/app/views/admin/certification/ysws/show.html.erb
@@ -59,6 +59,14 @@
         <button class="btn-action btn-report" data-action="click->certification--ysws--fraud-report#open">
           🚩 Report to Fraud Squad!
         </button>
+
+        <% if @review.claimed_by?(current_user) %>
+          <%= button_to "Unclaim review",
+                        admin_certification_ysws_claim_path(@review),
+                        method: :delete,
+                        class: "btn-secondary slim",
+                        form: { class: "review-detail-header__unclaim-form" } %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/admin/certification/ysws/show.html.erb
+++ b/app/views/admin/certification/ysws/show.html.erb
@@ -56,17 +56,19 @@
           </button>
         <% end %>
 
-        <button class="btn-action btn-report" data-action="click->certification--ysws--fraud-report#open">
-          🚩 Report to Fraud Squad!
-        </button>
+        <div class="review-detail-header__review-actions">
+          <button class="btn-action btn-report" data-action="click->certification--ysws--fraud-report#open">
+            🚩 Report to Fraud Squad!
+          </button>
 
-        <% if @review.claimed_by?(current_user) %>
-          <%= button_to "Unclaim review",
-                        admin_certification_ysws_claim_path(@review),
-                        method: :delete,
-                        class: "btn-secondary slim",
-                        form: { class: "review-detail-header__unclaim-form" } %>
-        <% end %>
+          <% if @review.pending? && @review.claimed_by?(current_user) %>
+            <%= button_to "Unclaim review",
+                          admin_certification_ysws_claim_path(@review),
+                          method: :delete,
+                          class: "btn-secondary slim",
+                          form: { class: "review-detail-header__unclaim-form" } %>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -859,6 +859,7 @@ Rails.application.routes.draw do
       get "review/:id", to: "ysws#show", as: "ysws_review"
       get "review/:id/commits", to: "ysws#commits", as: "ysws_commits"
       post "review/:id/report_fraud", to: "ysws#report_fraud", as: "ysws_report_fraud"
+      delete "review/:id/claim", to: "ysws#unclaim", as: "ysws_claim"
       post "review/:id/complete", to: "ysws#complete", as: "complete_ysws_review"
       post "review/:id/return_to_ship_cert", to: "ysws#return_to_ship_cert", as: "return_to_ship_cert_ysws_review"
 


### PR DESCRIPTION
## what's this do?
- Adds an unclaim review button for GOI reviews so reviewers can release a project back to the queue.
- Persists GOI queue filters until reset.
- Adds a Reset filters button.
- fixes unable to scroll ship cert videos
- Shows each devlogs posted date in the review UI.
- Adds a -15min deduction button.
- Improved GOI dash UI (minor changes)
- Shows which GOI reviewed the project on the dash

## show it works
https://cdn.hackclub.com/019f8b04-f6da-74d6-8071-7a5da4c7d872/goi_changes.mp4

## ai?
Codex GPT 5.5
