### PR TITLE
feat(post): precompile video thumbnails

### DIFF
--- a/app/components/post_component.html.erb
+++ b/app/components/post_component.html.erb
@@ -7,5 +7,6 @@
       show_comments: show_comments,
       show_reposts: show_reposts,
       show_actions: show_actions,
-      track_engagement: track_engagement
+      track_engagement: track_engagement,
+      lazy_media: lazy_media
     ) %>

--- a/app/components/post_component.rb
+++ b/app/components/post_component.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class PostComponent < ViewComponent::Base
-  attr_reader :post, :current_user, :theme, :compact, :show_likes, :show_comments, :show_reposts, :show_actions, :track_engagement
+  attr_reader :post, :current_user, :theme, :compact, :show_likes, :show_comments, :show_reposts, :show_actions, :track_engagement, :lazy_media
 
-  def initialize(post:, current_user: nil, theme: :feed, compact: false, show_likes: true, show_comments: true, show_reposts: true, show_actions: true, track_engagement: true)
+  def initialize(post:, current_user: nil, theme: :feed, compact: false, show_likes: true, show_comments: true, show_reposts: true, show_actions: true, track_engagement: true, lazy_media: false)
     @post = post
     @current_user = current_user
     @theme = theme
@@ -13,5 +13,6 @@ class PostComponent < ViewComponent::Base
     @show_reposts = show_reposts
     @show_actions = show_actions
     @track_engagement = track_engagement
+    @lazy_media = lazy_media
   end
 end

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -860,7 +860,7 @@
                        payout_review: entry.postable == @votes_for_payout&.dig(:ship_event) ? @votes_for_payout : nil,
                        mission_resubmit_modal_id: mission_modal_id %>
           <% else %>
-            <%= render PostComponent.new(post: entry, current_user: current_user, theme: :profile_dark) %>
+            <%= render PostComponent.new(post: entry, current_user: current_user, theme: :profile_dark, lazy_media: true) %>
           <% end %>
         <% end %>
       </section>

--- a/app/views/shared/_post_media_item.html.erb
+++ b/app/views/shared/_post_media_item.html.erb
@@ -6,7 +6,9 @@
         loading: (lazy ? "lazy" : nil), decoding: (lazy ? "async" : nil) %>
 <% elsif attachment.content_type.to_s.start_with?("video/") %>
   <%= video_tag rails_storage_redirect_url(attachment), controls: true,
-        preload: (lazy ? "none" : "metadata"), class: "feed-post-card__video" %>
+        preload: (lazy ? "none" : "metadata"),
+        poster: (attachment.previewable? ? url_for(attachment.preview(resize_to_limit: [400, 225], format: :webp)) : nil),
+        class: "feed-post-card__video" %>
 <% else %>
   <%= link_to attachment.filename.to_s, url_for(attachment), class: "feed-post-card__file" %>
 <% end %>


### PR DESCRIPTION
<img width="748" height="546" alt="Screenshot 2026-07-22 at 15 58 05" src="https://github.com/user-attachments/assets/dd82d4c3-93ba-4758-b942-2c0759d9e1ea" />

this improves the post view by compiling video thumbnails & turns off preloading- a lot of the video files being uploaded aren't being transcoded for previews and it's causing a lot of unneeded downloads