### PR TITLE
fix(payouts): send vote deficit notification once per ship event

### DIFF
--- a/app/models/post/ship_event/payouts.rb
+++ b/app/models/post/ship_event/payouts.rb
@@ -441,10 +441,8 @@ module Post::ShipEvent::Payouts
     end
 
     def notify_vote_deficit
-      cache_key = "vote_deficit_notified:#{id}"
-      return if Rails.cache.exist?(cache_key)
+      return if Notifications::Payouts::VoteDeficitBlocked.exists?(recipient: payout_recipient, record: self)
 
-      Rails.cache.write(cache_key, true, expires_in: 6.hours)
       Notifications::Payouts::VoteDeficitBlocked.notify(
         recipient: payout_recipient,
         record: self,

--- a/test/models/post/ship_event_test.rb
+++ b/test/models/post/ship_event_test.rb
@@ -147,6 +147,17 @@ class Post::ShipEventTest < ActiveSupport::TestCase
     assert_equal 3, notified[:params]["votes_needed"]
   end
 
+  test "issue_payout! notifies vote deficit only once per ship event" do
+    ship = create_ship_event(hours: 2, vote_count: Post::ShipEvent::VOTES_REQUIRED_FOR_PAYOUT)
+    @owner.update!(vote_balance: -3)
+    ship.reload.refresh_payout_score!
+
+    assert_difference -> { Notifications::Payouts::VoteDeficitBlocked.count }, 1 do
+      ship.issue_payout!
+      ship.issue_payout!
+    end
+  end
+
   test "issue_payout! is idempotent" do
     ship = create_ship_event(hours: 2, vote_count: Post::ShipEvent::VOTES_REQUIRED_FOR_PAYOUT)
 


### PR DESCRIPTION
## what's this do?

fixes the vote deficit message to only be once instead of once every 6 hours or the cache expiring

## ai?

claude
