### PR TITLE
feat(certification) payouts:  tier ysws reviewer devlog payout by review count, keep bonus window

### DIFF
--- a/app/models/certification/ysws.rb
+++ b/app/models/certification/ysws.rb
@@ -121,28 +121,55 @@ module Certification
       self[:todo_devlog_count].to_i
     end
 
-    # Estimated stardust a reviewer would earn per reviewed devlog. YSWS
-    # reviewing isn't a real payout source yet (no stardust_earned column), so
-    # the dashboard leaderboard uses this to show a projected payout.
-    STARDUST_PER_DEVLOG = 0.2
-
     # Default per-reviewer target for completed devlog reviews. Shown as a
     # "reviews left until goal reached" widget on the review queue.
     DEFAULT_DEVLOG_REVIEW_GOAL = 222
 
-    # Limited-time bonus rate: devlogs whose parent review was completed within
-    # BONUS_WINDOW pay out at this higher rate instead of STARDUST_PER_DEVLOG.
-    BONUS_STARDUST_PER_DEVLOG = 0.3
+    # Projected stardust per reviewed devlog, tiered by the reviewer's running
+    # devlog-review count: a reviewer's Nth devlog pays the rate for the tier N
+    # falls in. YSWS reviewing isn't a real payout source yet (no
+    # stardust_earned column), so this drives the dashboard leaderboard's
+    # projected payout only.
+    #
+    # Each entry is [threshold, rate]: devlogs *after* `threshold` (up to the
+    # next threshold) pay `rate`.
+    #   1..900     => 0.2
+    #   901..1500  => 0.3
+    #   1501..2100 => 0.35
+    #   2101..     => 0.4
+    DEVLOG_STARDUST_TIERS = [
+      [ 0,    0.2  ],
+      [ 900,  0.3  ],
+      [ 1500, 0.35 ],
+      [ 2100, 0.4  ]
+    ].freeze
+
+    # Limited-time bonus: devlogs whose parent review completed within
+    # BONUS_WINDOW earn this much extra stardust *on top of* their tier rate
+    # (additive, so a reviewer never loses their higher tier rate for reviewing
+    # during the window).
+    BONUS_STARDUST_PER_DEVLOG = 0.1
 
     # 11am EDT July 9 2026 → 4pm EDT July 13 2026 (uses the New York zone so the
     # EDT offset is applied correctly regardless of the app's default zone).
     BONUS_WINDOW = Time.find_zone!("America/New_York").local(2026, 7, 9, 11, 0)..
       Time.find_zone!("America/New_York").local(2026, 7, 13, 16, 0)
 
+    # Projected stardust for a reviewer who has completed `count` devlog
+    # reviews, applying DEVLOG_STARDUST_TIERS cumulatively across the tiers.
+    def self.stardust_for_devlog_count(count)
+      DEVLOG_STARDUST_TIERS.each_with_index.sum do |(threshold, rate), i|
+        upper   = DEVLOG_STARDUST_TIERS[i + 1]&.first || Float::INFINITY
+        in_tier = [ count, upper ].min - threshold
+        in_tier.positive? ? in_tier * rate : 0
+      end.round(2)
+    end
+
     # All-time devlog-review leaderboard. A devlog counts as reviewed once its
     # parent YSWS review is completed (reviewed_at present); completion already
-    # forces every child devlog out of :pending. Devlogs reviewed within
-    # BONUS_WINDOW pay out at the higher BONUS_STARDUST_PER_DEVLOG rate.
+    # forces every child devlog out of :pending. Projected stardust scales with
+    # each reviewer's total via the DEVLOG_STARDUST_TIERS rate tiers, plus a
+    # flat BONUS_STARDUST_PER_DEVLOG for devlogs reviewed within BONUS_WINDOW.
     #   => [{ reviewer_id:, name:, devlogs:, stardust: }, ...] desc by devlogs
     def self.reviewer_devlog_leaderboard
       bonus_sql = sanitize_sql_array([
@@ -151,7 +178,8 @@ module Certification
       ])
 
       # Count devlogs per reviewer, split by whether they fall in the bonus
-      # window, so each bucket can be paid out at its own rate.
+      # window, so tier rates apply to the total while the bonus applies only to
+      # the in-window bucket.
       Certification::Devlog
         .joins(ysws_review: :reviewer)
         .where.not(certification_ysws_reviews: { reviewed_at: nil })
@@ -159,15 +187,15 @@ module Certification
         .count
         .group_by { |(reviewer_id, name, _bonus), _count| [ reviewer_id, name ] }
         .map do |(reviewer_id, name), entries|
-          devlogs  = entries.sum { |_key, count| count }
-          stardust = entries.sum do |(_id, _name, bonus), count|
-            count * (bonus ? BONUS_STARDUST_PER_DEVLOG : STARDUST_PER_DEVLOG)
-          end
+          devlogs     = entries.sum { |_key, count| count }
+          bonus_count = entries.sum { |(_id, _name, bonus), count| bonus ? count : 0 }
+          stardust    = stardust_for_devlog_count(devlogs) +
+                        (bonus_count * BONUS_STARDUST_PER_DEVLOG)
           {
             reviewer_id: reviewer_id,
             name: name,
             devlogs: devlogs,
-            stardust: stardust.round(1)
+            stardust: stardust.round(2)
           }
         end
         .sort_by { |row| [ -row[:devlogs], row[:name] ] }


### PR DESCRIPTION
Projected stardust now scales with each reviewer's running devlog-review count (0.2/0.3/0.35/0.4 across 900/1500/2100 tiers). The Jul 9-13 window bonus is retained as an additive +0.1 per in-window devlog on top of the tier rate.
