### PR TITLE
Show approved payout hours on hardware ship cards

### DIFF
--- a/app/assets/stylesheets/pages/projects/_show.scss
+++ b/app/assets/stylesheets/pages/projects/_show.scss
@@ -1190,6 +1190,12 @@ turbo-frame#project_hero {
   opacity: 0.75;
 }
 
+.project-show__latest-ship-stats-note {
+  color: var(--color-space-text-muted, #9b99b6);
+  font-size: 0.875rem;
+  margin-left: 0.35rem;
+}
+
 .project-show__latest-ship-media {
   border-radius: var(--profile-radius);
   overflow: hidden;

--- a/app/views/projects/_ship_card.html.erb
+++ b/app/views/projects/_ship_card.html.erb
@@ -6,6 +6,12 @@
   author      = post.user
   ship_text   = ship.body.to_s
   ship_hours  = ship.hours_at_ship.to_f.round
+  
+  # For hardware, expose the payout basis hours if available
+  payout_hours = if project.hardware? && ship.hours_at_payout.present?
+                   ship.hours_at_payout
+                 end
+  
   ship_number      = local_assigns[:ship_number]
   recert_modal_id  = local_assigns[:recert_modal_id]
   pending_review   = ship.certification_status == "pending"
@@ -125,6 +131,11 @@
     <li class="profile-project-card__meta-item profile-project-card__meta-item--time">
       <%= inline_svg_tag "icons/time.svg", class: "profile-project-card__meta-icon profile-project-card__meta-icon--time" %>
       <span><%= ship_hours %>h<%= " build" if project.hardware? %></span>
+      <% if payout_hours && payout_hours != ship_hours %>
+        <span class="project-show__latest-ship-stats-note" title="Only <%= number_with_precision(payout_hours, precision: 1) %> hours were approved by the YSWS reviewer for the Stardust payout">
+          (<%= number_with_precision(payout_hours, precision: 1) %>h approved)
+        </span>
+      <% end %>
     </li>
     <% if ship.multiplier.present? %>
       <li class="profile-project-card__meta-item profile-project-card__meta-item--multiplier" title="Quality multiplier">


### PR DESCRIPTION
### Problem

For hardware projects, Stardust payouts are computed from YSWS reviewer-approved minutes, but the ship card displays the raw logged Hackatime hours. This causes confusion: a project might show **11h build** and **5.63x multiplier**, but only award **4 Stardust** because the reviewer approved only ~43 minutes.

### Fix

This PR adds a small inline note on the ship card when `hours_at_payout` differs from the raw logged hours for a hardware ship:

- `app/views/projects/_ship_card.html.erb`: compute and expose `payout_hours` for hardware projects
- `app/assets/stylesheets/pages/projects/_show.scss`: add muted styling for the note

### Result

Users now see e.g. **11h build (0.7h approved)**, making it clear that the payout uses a smaller, reviewer-approved time basis.

### Related

Fixes the confusion observed on https://stardance.hackclub.com/projects/4309
