### PR TITLE
fix(video): try to fix cert video playback in ff

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -155,7 +155,7 @@ module ApplicationHelper
 
   def certification_verdict_video_src(cert)
     return if cert.nil?
-    return rails_storage_redirect_path(cert.verdict_video) if cert.verdict_video.attached?
+    return cert.verdict_video.url(disposition: :inline) if cert.verdict_video.attached?
 
     active_storage_redirect_url(safe_external_url(cert.proof_video_url))
   end


### PR DESCRIPTION
this is an attempt to fix this annoying bug on the cert review page:
<img width="935" height="554" alt="Screenshot 2026-07-25 at 12 37 20" src="https://github.com/user-attachments/assets/4ce8d1a5-aacc-4b8b-a81b-5e638d87d777" />

a bit hard to test this bug locally because it isn't consistent (i think it's caused by network issues)
