### PR TITLE
Fixed slack doodle alignment

### DIFF
--- a/app/assets/stylesheets/components/_slack_doodle.scss
+++ b/app/assets/stylesheets/components/_slack_doodle.scss
@@ -111,8 +111,9 @@
     }
   }
 
-  @media (max-width: 768px) {
+  @media (max-width: 960px) {
     width: 160px;
     right: 1rem;
+    bottom: 60px;
   }
 }


### PR DESCRIPTION
## what's this do?

This fixes the alignment of the Slack doodle. The doodle is now positioned correctly and matches the surrounding layout.

## show it works

- Ran the app locally.
- Checked the page where the Slack doodle is shown.
- Verified that the alignment is correct after the change.

### Before image on Mobile and Tab Devices
<img width="561" height="303" alt="Before 3" src="https://github.com/user-attachments/assets/9de56e44-ef55-4976-a5f9-29011187b0d3" />

### After image on Mobile and Tab Devices
<img width="1031" height="420" alt="After" src="https://github.com/user-attachments/assets/85c7c580-cf81-45fd-b30e-fe52f12e34df" />


## ai?

I used Copilot to help me understand the codebase and review my implementation. I made the changes myself and tested them locally before opening this PR.