### PR TITLE
Fixed devlog Ui / Ux Bug in Mobile view

### DIFF
--- a/app/assets/stylesheets/components/_feed.scss
+++ b/app/assets/stylesheets/components/_feed.scss
@@ -449,9 +449,18 @@
     }
   }
 
-  &__tools {
+  &__controls,
+  &__assist {
     display: flex;
     align-items: center;
+    min-width: 0;
+  }
+
+  &__controls {
+    gap: var(--space-xxs);
+  }
+
+  &__assist {
     gap: var(--space-xxs);
   }
 
@@ -590,6 +599,71 @@
 
     &--warn {
       color: var(--color-brand-salmon);
+    }
+  }
+
+  @media (max-width: 640px) {
+    &__toolbar {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      grid-template-areas:
+        "assist assist"
+        "tabs submit";
+      align-items: center;
+      column-gap: var(--space-xs);
+      row-gap: var(--space-xs);
+      margin-left: 0;
+    }
+
+    &__controls {
+      display: contents;
+    }
+
+    &__tabs {
+      grid-area: tabs;
+      justify-self: start;
+    }
+
+    &__assist {
+      grid-area: assist;
+      min-width: 0;
+    }
+
+    &__info,
+    &__info-wrap,
+    &__info-text {
+      min-width: 0;
+    }
+
+    &__info-text {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    &__submit-group {
+      grid-area: submit;
+      justify-self: end;
+    }
+  }
+
+  @media (min-width: 641px) {
+    &__toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-left: calc(var(--feed-content-offset) - 8px);
+    }
+
+    &__controls {
+      display: flex;
+    }
+
+    &__tabs,
+    &__assist,
+    &__submit-group {
+      grid-area: auto;
+      justify-self: auto;
     }
   }
 

--- a/app/components/posts/composer_component.html.erb
+++ b/app/components/posts/composer_component.html.erb
@@ -102,8 +102,8 @@
       </div>
 
       <div class="feed-composer__toolbar">
-        <div class="feed-composer__tools">
-          <div class="md-tabs" role="tablist">
+        <div class="feed-composer__controls">
+          <div class="md-tabs feed-composer__tabs" role="tablist">
             <button type="button" class="md-tabs__tab" role="tab" aria-selected="true"
                     data-markdown-preview-target="writeTab"
                     data-action="markdown-preview#showWrite">Write</button>
@@ -111,32 +111,35 @@
                     data-markdown-preview-target="previewTab"
                     data-action="markdown-preview#showPreview">Preview</button>
           </div>
-          <button type="button" class="feed-composer__tool-btn" aria-label="Markdown formatting help"
-                  data-action="markdown-preview#openHelp">
-            <%= inline_svg_tag "icons/question.svg", class: "feed-composer__tool-icon" %>
-          </button>
-          <div class="feed-composer__emoji-wrap">
-            <div class="feed-composer__emoji-popover"
-                 data-emoji-picker-target="popover"
-                 hidden></div>
-          </div>
 
-          <% if show_time_preview? %>
-            <div class="feed-composer__info-wrap" data-composer-target="footer">
-            <div class="feed-composer__info">
-              <turbo-frame id="devlog-preview-time"
-                           data-composer-target="timeFrame"
-                           <%= "hidden" unless hackatime_linked? %>>
-                <span class="feed-composer__info-text">Loading time...</span>
-              </turbo-frame>
-              <%= link_to "Link a Hackatime project to post",
-                    project_path(selected_project, editing: true),
-                    class: "feed-composer__info-text feed-composer__info-text--warn",
-                    data: { composer_target: "warn", turbo: false },
-                    hidden: hackatime_linked? %>
+          <div class="feed-composer__assist">
+            <button type="button" class="feed-composer__tool-btn" aria-label="Markdown formatting help"
+                    data-action="markdown-preview#openHelp">
+              <%= inline_svg_tag "icons/question.svg", class: "feed-composer__tool-icon" %>
+            </button>
+            <div class="feed-composer__emoji-wrap">
+              <div class="feed-composer__emoji-popover"
+                   data-emoji-picker-target="popover"
+                   hidden></div>
             </div>
-            </div>
-          <% end %>
+
+            <% if show_time_preview? %>
+              <div class="feed-composer__info-wrap" data-composer-target="footer">
+                <div class="feed-composer__info">
+                  <turbo-frame id="devlog-preview-time"
+                               data-composer-target="timeFrame"
+                               <%= "hidden" unless hackatime_linked? %>>
+                    <span class="feed-composer__info-text">Loading time...</span>
+                  </turbo-frame>
+                  <%= link_to "Link a Hackatime project to post",
+                        project_path(selected_project, editing: true),
+                        class: "feed-composer__info-text feed-composer__info-text--warn",
+                        data: { composer_target: "warn", turbo: false },
+                        hidden: hackatime_linked? %>
+                </div>
+              </div>
+            <% end %>
+          </div>
         </div>
 
         <div class="feed-composer__submit-group">


### PR DESCRIPTION
## What's this do?

This fixes the mobile layout of the post composer toolbar. The toolbar is now better organized, making the tabs, help button, emoji picker, Hackatime preview, and submit button easier to use on smaller screens.

### What my PR do?

* Fixed the toolbar layout on mobile.
* Grouped related buttons together.
* Kept the desktop layout unchanged.
* Prevented the Hackatime text from overflowing on small screens.

### How am I doing it?

* Split the toolbar into separate sections for better organization.
* Used a responsive grid layout for mobile screens.
* Switched back to the existing flex layout on desktop.
* Added text truncation so long messages fit properly.

### Before

Devlog section is not aligned properly in mobile view
<img width="601" height="462" alt="Before 2" src="https://github.com/user-attachments/assets/f545e3fe-5758-404f-8bc4-c9b24622204d" />


### After

Laptop View
<img width="1898" height="1078" alt="image" src="https://github.com/user-attachments/assets/a6287324-4a55-4c0f-b18f-feae1f824ff3" />

Tablet View
<img width="1916" height="1076" alt="image" src="https://github.com/user-attachments/assets/e1f6c628-9caa-43de-a0af-1931c754091f" />

Mobile View
<img width="1901" height="1078" alt="image" src="https://github.com/user-attachments/assets/b7908554-5f35-47c9-8803-fb006f9bd34e" />

https://github.com/user-attachments/assets/df7df36d-e3e7-40ef-84d1-1b457e9b6b73


## AI?
I used Copilot to help me understand the existing code and review my implementation. I tested the final changes locally before opening this PR, Please ignore Copilot review i dont know how to turn it off.