### PR TITLE
fix: tooltop acting wierd in follow list

### DIFF
--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -124,13 +124,6 @@ export default class extends Controller {
         break;
     }
 
-    const container = this.#container();
-    if (container !== document.body) {
-      const cr = container.getBoundingClientRect();
-      top -= cr.top;
-      left -= cr.left;
-    }
-
     this.popover.style.top = `${Math.max(8, top)}px`;
     this.popover.style.left = `${Math.max(8, left)}px`;
   }


### PR DESCRIPTION
## what's this do?

closes #927 

removes the code that tried to move the streak tooltip to the right place in the container but ended up breaking stuff

## show it works
befo
<img width="1097" height="741" alt="image" src="https://github.com/user-attachments/assets/85584c57-e9cf-4732-82d8-215fa0f65da7" />

afta
<img width="544" height="184" alt="image" src="https://github.com/user-attachments/assets/a1093833-5e5a-436e-a567-24e69f616269" />


## ai?

claude