### PR TITLE
fix: Don't truncate suggestion descriptions

### DIFF
--- a/app/views/shop/suggestions/_card.html.erb
+++ b/app/views/shop/suggestions/_card.html.erb
@@ -33,7 +33,7 @@
       <span class="suggestion-card__by">by <%= suggestion.user.display_name %></span>
     </div>
 
-    <p class="suggestion-card__description"><%= suggestion.description.truncate(120) %></p>
+    <p class="suggestion-card__description"><%= suggestion.description %></p>
 
     <% if suggestion.rejected? && suggestion.rejection_reason.present? %>
       <p class="suggestion-card__rejection-reason">


### PR DESCRIPTION
Since there's no way to view the full description, cutting it off just fully removes the end.