### PR TITLE
fix(security): require a signed-in user for direct uploads

### DIFF
--- a/config/initializers/direct_upload.rb
+++ b/config/initializers/direct_upload.rb
@@ -1,21 +1,36 @@
 Rails.application.config.to_prepare do
-    ActiveStorage::DirectUploadsController.class_eval do
-      private
+  ActiveStorage::DirectUploadsController.class_eval do
+    before_action :require_signed_in_uploader
 
-      alias_method :original_blob_args, :blob_args unless method_defined?(:original_blob_args)
+    private
 
-      def blob_args
-        # Parse JSON body if Content-Type is JSON and params[:blob] is missing because I'm dumb and I can't figure out what's fucked!
-        if request.content_type == "application/json" && params[:blob].blank?
-          raw = request.body.read
-          request.body.rewind
-          parsed = JSON.parse(raw) rescue {}
-          parsed = parsed["blob"] if parsed.is_a?(Hash)
-          parsed = parsed.symbolize_keys if parsed.is_a?(Hash)
-          return parsed if parsed.present?
-        end
+    def require_signed_in_uploader
+      return if signed_in_uploader?
 
-        original_blob_args
+      render json: { error: "You must be signed in to upload files." }, status: :unauthorized
+    end
+
+    def signed_in_uploader?
+      user = User.find_by(id: session[:user_id]) if session[:user_id].present?
+      return false if user.nil? || user.banned?
+
+      session[:auth_level] == "hca" || !user.hca_linked?
+    end
+
+    alias_method :original_blob_args, :blob_args unless method_defined?(:original_blob_args)
+
+    def blob_args
+      # Parse JSON body if Content-Type is JSON and params[:blob] is missing because I'm dumb and I can't figure out what's fucked!
+      if request.content_type == "application/json" && params[:blob].blank?
+        raw = request.body.read
+        request.body.rewind
+        parsed = JSON.parse(raw) rescue {}
+        parsed = parsed["blob"] if parsed.is_a?(Hash)
+        parsed = parsed.symbolize_keys if parsed.is_a?(Hash)
+        return parsed if parsed.present?
       end
+
+      original_blob_args
     end
   end
+end


### PR DESCRIPTION
## what's this do?

Gate uploads using the same before_action as ApplicationController#current_user instead of letting anyone without an account upload files. Now, only people who have signed up (either as trial users or full verified linked users) can upload files. 

## show it works


https://github.com/user-attachments/assets/c38bab0e-6172-48cf-96c0-0b6cca6b79f6


## ai?

Yes, Claude Opus 5