### PR TITLE
fix(url-probe): prefer IPv4 and handle more network errors

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -595,7 +595,9 @@ class ProjectsController < ApplicationController
     # so we don't confirm whether an internal host exists.
     Rails.logger.warn("URL validation rejected #{attribute}: #{e.message}")
     @project.errors.add(attribute, "nice try ding dong — #{name} has to be a real, public URL")
-  rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError => e
+  rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ECONNRESET,
+         Errno::ETIMEDOUT, Errno::ENETUNREACH, Errno::EPIPE,
+         Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError => e
     Rails.logger.warn("URL validation failed for #{attribute}: #{e.class}: #{e.message}")
     @project.errors.add(attribute, "#{name} could not be reached. Please make sure the URL is valid and publicly accessible.")
   rescue StandardError => e

--- a/app/lib/safe_url.rb
+++ b/app/lib/safe_url.rb
@@ -29,7 +29,8 @@ module SafeUrl
     # trick) is treated as hostile and rejected outright. We still return a
     # single verified IP so callers can pin the socket to it.
     raise Error, "Host resolves to a non-public IP" unless addresses.all? { |addr| public_ip?(addr) }
-    addresses.first
+    # Prefer IPv4 — many environments lack IPv6 connectivity.
+    addresses.sort_by { |addr| addr.include?(":") ? 1 : 0 }.first
   rescue URI::InvalidURIError, Resolv::ResolvError, ArgumentError => e
     raise Error, e.message
   end


### PR DESCRIPTION
## what do

prefer ipv4 over ipv6 and handle more network errors.

## show work

<img width="649" height="636" alt="image" src="https://github.com/user-attachments/assets/89dc450a-b1e7-48b5-beff-cdca2fc122a0" />


when updating with url that doesn't exist 
<img width="531" height="181" alt="image" src="https://github.com/user-attachments/assets/07ff9d83-e2d0-4eb2-b703-81c4b25ddb09" />


## ai?

claude opus 4.6 (too broke for fable and opus 5 sucks)
