### PR TITLE
add RSVPs to the workshops table

### DIFF
--- a/app/jobs/airtable/workshop_rsvp_sync_job.rb
+++ b/app/jobs/airtable/workshop_rsvp_sync_job.rb
@@ -1,0 +1,62 @@
+class Airtable::WorkshopRsvpSyncJob < ApplicationJob
+  TABLE_ID = "tbleo5vkRpWz0dYH7"
+  EMAIL_FIELD = "Email"
+  SIGNUP_NAMES_FIELD = "Loops - stardanceWorkshopSignUpNames"
+
+  queue_as :literally_whenever
+
+  limits_concurrency to: 1, key: ->(user_id, _workshop_id) { user_id }, duration: 5.minutes
+  retry_on Norairrecord::Error, wait: :polynomially_longer, attempts: 3
+
+  def perform(user_id, workshop_id)
+    user = User.find_by(id: user_id)
+    workshop = Workshop.find_by(id: workshop_id)
+    return unless user&.email.present? && workshop
+
+    email = user.email.downcase.strip
+    record = find_record(email)
+    signup_names = merge_signup_names(record&.[](SIGNUP_NAMES_FIELD), signup_name(workshop))
+
+    if record
+      return if record[SIGNUP_NAMES_FIELD].to_s == signup_names
+
+      record.patch(SIGNUP_NAMES_FIELD => signup_names)
+    else
+      table.create(
+        EMAIL_FIELD => email,
+        SIGNUP_NAMES_FIELD => signup_names
+      )
+    end
+  end
+
+  private
+
+    def find_record(email)
+      table.all(filter: "LOWER({#{EMAIL_FIELD}}) = '#{escape_formula_string(email)}'").first
+    end
+
+    def signup_name(workshop)
+      date = workshop.starts_at.in_time_zone(Workshop::TIME_ZONE).to_date.iso8601
+      "#{workshop.title.strip} #{date}"
+    end
+
+    def merge_signup_names(current_value, new_signup_name)
+      (current_value.to_s.split(",") + [ new_signup_name ])
+        .map(&:strip)
+        .reject(&:blank?)
+        .uniq { |name| name.downcase }
+        .join(", ")
+    end
+
+    def escape_formula_string(value)
+      value.gsub(/['\\]/) { |character| "\\#{character}" }
+    end
+
+    def table
+      @table ||= Norairrecord.table(
+        Rails.application.credentials&.airtable&.api_key || ENV["AIRTABLE_API_KEY"],
+        Rails.application.credentials&.airtable&.base_id || ENV["AIRTABLE_BASE_ID"],
+        TABLE_ID
+      )
+    end
+end

--- a/app/models/workshop/rsvp.rb
+++ b/app/models/workshop/rsvp.rb
@@ -24,6 +24,14 @@ class Workshop::Rsvp < ApplicationRecord
   belongs_to :workshop
   belongs_to :user
 
+  after_create_commit :sync_to_airtable
+
   # No uniqueness validation: create_or_find_by! needs the DB index's raw
   # RecordNotUnique, not a validation error.
+
+  private
+
+    def sync_to_airtable
+      Airtable::WorkshopRsvpSyncJob.perform_later(user_id, workshop_id)
+    end
 end

--- a/test/controllers/workshops_controller_test.rb
+++ b/test/controllers/workshops_controller_test.rb
@@ -43,8 +43,10 @@ class WorkshopsControllerTest < ActionDispatch::IntegrationTest
     sign_in_linked_three
     workshop = workshops(:upcoming)
 
-    assert_difference -> { workshop.rsvps.count }, 1 do
-      post workshop_rsvp_path(workshop)
+    assert_enqueued_with(job: Airtable::WorkshopRsvpSyncJob, args: [ users(:three).id, workshop.id ]) do
+      assert_difference -> { workshop.rsvps.count }, 1 do
+        post workshop_rsvp_path(workshop)
+      end
     end
     assert_redirected_to workshop_path(workshop)
   end
@@ -53,8 +55,10 @@ class WorkshopsControllerTest < ActionDispatch::IntegrationTest
     sign_in users(:one)
     workshop = workshops(:upcoming)
 
-    assert_no_difference -> { workshop.rsvps.count } do
-      post workshop_rsvp_path(workshop)
+    assert_no_enqueued_jobs only: Airtable::WorkshopRsvpSyncJob do
+      assert_no_difference -> { workshop.rsvps.count } do
+        post workshop_rsvp_path(workshop)
+      end
     end
   end
 

--- a/test/jobs/airtable/workshop_rsvp_sync_job_test.rb
+++ b/test/jobs/airtable/workshop_rsvp_sync_job_test.rb
@@ -1,0 +1,113 @@
+require "test_helper"
+
+class Airtable::WorkshopRsvpSyncJobTest < ActiveJob::TestCase
+  FakeRecord = Struct.new(:fields, :patches) do
+    def [](field)
+      fields[field]
+    end
+
+    def patch(attributes)
+      patches << attributes
+      fields.merge!(attributes)
+    end
+  end
+
+  FakeTable = Struct.new(:records, :created, :filters) do
+    def all(filter:)
+      filters << filter
+      records
+    end
+
+    def create(attributes)
+      created << attributes
+    end
+  end
+
+  setup do
+    @user = users(:one)
+    @workshop = workshops(:upcoming)
+    @job = Airtable::WorkshopRsvpSyncJob.new
+  end
+
+  test "appends the dated workshop name to an existing email record" do
+    record = FakeRecord.new(
+      {
+        "Email" => @user.email,
+        "Loops List - stardanceWorkshops" => "generated-value",
+        "Loops - stardanceWorkshopSignUpNames" => "Soldering basics 2026-07-20"
+      },
+      []
+    )
+    table = FakeTable.new([ record ], [], [])
+
+    @job.stub(:table, table) do
+      @job.perform(@user.id, @workshop.id)
+    end
+
+    expected_signup = "#{@workshop.title} #{@workshop.starts_at.in_time_zone(Workshop::TIME_ZONE).to_date.iso8601}"
+    assert_equal(
+      [ { "Loops - stardanceWorkshopSignUpNames" => "Soldering basics 2026-07-20, #{expected_signup}" } ],
+      record.patches
+    )
+    assert_equal "generated-value", record["Loops List - stardanceWorkshops"]
+    assert_empty table.created
+  end
+
+  test "does not add a workshop more than once" do
+    signup = "#{@workshop.title} #{@workshop.starts_at.in_time_zone(Workshop::TIME_ZONE).to_date.iso8601}"
+    record = FakeRecord.new(
+      { "Loops - stardanceWorkshopSignUpNames" => "#{signup}, #{signup.downcase}" },
+      []
+    )
+    table = FakeTable.new([ record ], [], [])
+
+    @job.stub(:table, table) do
+      @job.perform(@user.id, @workshop.id)
+    end
+
+    assert_equal [ { "Loops - stardanceWorkshopSignUpNames" => signup } ], record.patches
+  end
+
+  test "does not patch Airtable when the workshop is already present once" do
+    signup = "#{@workshop.title} #{@workshop.starts_at.in_time_zone(Workshop::TIME_ZONE).to_date.iso8601}"
+    record = FakeRecord.new({ "Loops - stardanceWorkshopSignUpNames" => signup }, [])
+    table = FakeTable.new([ record ], [], [])
+
+    @job.stub(:table, table) do
+      @job.perform(@user.id, @workshop.id)
+    end
+
+    assert_empty record.patches
+    assert_empty table.created
+  end
+
+  test "creates an email record without writing the generated Loops list field" do
+    table = FakeTable.new([], [], [])
+
+    @job.stub(:table, table) do
+      @job.perform(@user.id, @workshop.id)
+    end
+
+    signup = "#{@workshop.title} #{@workshop.starts_at.in_time_zone(Workshop::TIME_ZONE).to_date.iso8601}"
+    assert_equal(
+      [
+        {
+          "Email" => @user.email.downcase.strip,
+          "Loops - stardanceWorkshopSignUpNames" => signup
+        }
+      ],
+      table.created
+    )
+  end
+
+  test "escapes the normalized email in the Airtable lookup formula" do
+    @user.update!(email: "STAR'GAZER@EXAMPLE.COM")
+    table = FakeTable.new([], [], [])
+
+    @job.stub(:table, table) do
+      @job.perform(@user.id, @workshop.id)
+    end
+
+    assert_equal "LOWER({Email}) = 'star\\'gazer@example.com'", table.filters.first
+  end
+end


### PR DESCRIPTION
## what's this do?
when a user RSVPs to a workshop, a record is created/updated (email is the key) and comma-appends the Workshop Name + Date to the `Loops - stardanceWorkshopSignUpNames` column.

olive help pls idk ruby 👉👈
## ai?
yes, 5.6 sol 
<!-- did you use AI tools? which ones? no judgment, we just wanna know. see AI_POLICY.md for details -->
