### PR TITLE
Center project banner image in card view

### DIFF
--- a/app/assets/stylesheets/pages/user/_show.scss
+++ b/app/assets/stylesheets/pages/user/_show.scss
@@ -842,7 +842,7 @@ turbo-frame#profile_tabs {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  object-position: bottom;
+  object-position: center;
   display: block;
   aspect-ratio: 3;
 }


### PR DESCRIPTION
## what's this do?
aligns the project banner image to center in the Projects panel card view

## show it works
from
<img width="506" height="182" alt="image" src="https://github.com/user-attachments/assets/ce0332ba-456a-46e2-92ab-8a6fbf041d17" />
to
<img width="497" height="178" alt="image" src="https://github.com/user-attachments/assets/cad8525b-0430-4554-b091-77b54ed9706c" />
