### PR TITLE
fix(certification): link a real ship cert in the YSWS justification

### DIFF
--- a/app/jobs/certification/ysws_airtable_sync_job.rb
+++ b/app/jobs/certification/ysws_airtable_sync_job.rb
@@ -197,10 +197,12 @@ module Certification
         nil
       end
 
-      # Get ship cert info
+      # Get ship cert info. ship_cert_id_value is the Airtable upsert key, so it
+      # keeps falling back to the ship event id to stay unique per review; the
+      # cert itself resolves through the project for reships (see
+      # Certification::Ysws#effective_ship_cert).
       ship_cert_id_value = review.ship_cert_id&.to_s || review.post_ship_event_id&.to_s
-      ship_cert = review.ship_cert
-      ship_certifier_name = ship_cert&.reviewer&.display_name || ship_cert&.reviewer&.email || "Unknown"
+      ship_cert = review.effective_ship_cert
 
       # Get shop orders
       approved_orders = user.shop_orders
@@ -216,7 +218,7 @@ module Certification
         total_original_minutes: total_original_minutes,
         total_approved_minutes: total_approved_minutes,
         deducted_minutes: deducted_minutes,
-        ship_certifier_name: ship_certifier_name,
+        ship_cert: ship_cert,
         approved_orders: approved_orders
       )
 
@@ -269,7 +271,7 @@ module Certification
 
         # Review Data
         "reviewer" => review.reviewer&.display_name || review.reviewer&.email || "Unknown", # tik
-        "ship_certifier" => ship_certifier_name, # tik
+        "ship_certifier" => ship_certifier_name(ship_cert), # tik
         "reviewed_at" => review.reviewed_at&.iso8601, # tik
         "ship_certed_at" => ship_cert&.decided_at&.iso8601, # tik
         "airtable_synced_at" => Time.current.iso8601, # tik
@@ -331,10 +333,13 @@ module Certification
       "banned" => "Project rejected due to manual review of heartbeats."
     }.freeze
 
-    def build_justification(review:, integrity_check:, devlog_reviews:, total_original_minutes:, total_approved_minutes:, deducted_minutes:, ship_certifier_name:, approved_orders:)
+    def ship_certifier_name(ship_cert)
+      ship_cert&.reviewer&.display_name || ship_cert&.reviewer&.email || "Unknown"
+    end
+
+    def build_justification(review:, integrity_check:, devlog_reviews:, total_original_minutes:, total_approved_minutes:, deducted_minutes:, ship_cert:, approved_orders:)
       project_id = review.project_id
       ysws_review_id = review.id
-      ship_cert_id = review.ship_cert_id
       reviewer_name = review.reviewer&.display_name || review.reviewer&.email || "Unknown"
 
       # Format minutes
@@ -373,12 +378,20 @@ module Certification
 
       integrity_note = INTEGRITY_JUSTIFICATION_NOTES.fetch(integrity_check.status)
 
+      # A project with no ship cert at all can't be linked — say so rather than
+      # emitting a URL with an empty id, which reads as a broken review link.
+      ship_cert_line = if ship_cert
+        "The Ship Cert is at https://stardance.hackclub.com/admin/certification/ship/#{ship_cert.id}"
+      else
+        "No ship certification was issued for this project."
+      end
+
       justification = <<~JUSTIFICATION
         #{intro}
 
         In this time they wrote #{devlog_reviews.count} devlogs. #{approval_summary}.
 
-        This project was initially ship certified by #{ship_certifier_name}.
+        This project was initially ship certified by #{ship_certifier_name(ship_cert)}.
 
         Following this it was YSWS reviewed by #{reviewer_name}
 
@@ -391,7 +404,7 @@ module Certification
 
         The Full YSWS Review + devlogs are at https://stardance.hackclub.com/admin/certification/review/#{ysws_review_id}
 
-        The Ship Cert is at https://stardance.hackclub.com/admin/certification/ship/#{ship_cert_id}/
+        #{ship_cert_line}
       JUSTIFICATION
 
       # Add shop orders section if available

--- a/app/models/certification/ysws.rb
+++ b/app/models/certification/ysws.rb
@@ -132,6 +132,22 @@ module Certification
       self[:todo_devlog_count].to_i
     end
 
+    # The ship certification a reviewer should actually look at for this review.
+    #
+    # ship_cert_id is only populated when the ship event went through manual
+    # ship certification. Reships auto-approve off a passing URL probe and never
+    # mint a cert, so the column stays null even though the project was
+    # certified on an earlier ship. Fall back the same way #return_to_ship_cert
+    # does — match the ship event first, then the project's most recent approved
+    # cert — so reship reviews still point somewhere real.
+    def effective_ship_cert
+      return ship_cert if ship_cert
+
+      project_certs = Certification::Ship.where(project_id: project_id)
+      project_certs.find_by(post_ship_event_id: post_ship_event_id) ||
+        project_certs.approved.order(Arel.sql("decided_at DESC NULLS LAST"), id: :desc).first
+    end
+
     # Per-reviewer target for completed devlog reviews: a daily rate that
     # reviewers are expected to average across the review week, rather than hit
     # every single day. Drives the pace widget on the review queue.


### PR DESCRIPTION
## what's this do?

Fixes the broken ship cert link msw spotted in #this-is-fines.

The link we send to the Unified YSWS Airtable came out with no number on the end:

```
https://stardance.hackclub.com/admin/certification/ship//
```

Here's why. When someone ships a project the first time, we create a ship cert for a human to review. When they re-ship, we don't. If their links are still alive we just auto-approve it. So a re-ship has no ship cert attached, and the code was dropping that empty value straight into the URL. Same reason the text said "ship certified by Unknown".

It's not only re-ships. A migration back in May cleared that field for every review in the table, so older reviews have the same broken link.

The fix: if a review has no ship cert of its own, look up the one the project already got. If the project genuinely never had one, write a plain sentence instead of a link with a missing number.

One thing I left alone on purpose: the `ship_cert_id` field we send to Airtable. It looks wrong but it's the key Airtable uses to match rows on update. Changing it would create duplicate rows.

### what this doesn't do

- It doesn't fix rows already in Airtable. Only new syncs get the good link. Happy to do that separately, but I'd want to know how many rows we're talking about first.

## show it works

I set up a project the same way the reported one happened: first ship gets a cert, then a re-ship that auto-approves with no cert of its own. This is what the job now sends:

```
ship cert on the review = none          (the re-ship, same as the report)
ship certifier          = "msw"         (used to say "Unknown")

The Ship Cert is at https://stardance.hackclub.com/admin/certification/ship/150
```

That last line used to be `.../ship//`.

I wrote tests for all of this and they pass (16 tests, 55 assertions), but **they're not in this PR**, on purpose, to keep the change to the two files. Two of them I deliberately broke the fix to check they'd actually fail, and they did. Happy to send them as a follow-up if the team wants them. Worth knowing that without them, nothing stops this from breaking again later.

Ran the CI checks locally too: RuboCop, Brakeman, Zeitwerk and the annotation check all clean.

## ai?

Yes, Claude Code (Opus 5) for the digging, the fix, and the tests. I read through all of it and ran everything above myself.
