### PR TITLE
fix(hardware): update tier examples and shorten funding button

### DIFF
--- a/app/models/certification/funding_request.rb
+++ b/app/models/certification/funding_request.rb
@@ -71,10 +71,10 @@ module Certification
     # Complexity tiers (B/A/S/X). Keyed by the integer stored in
     # complexity_tier; each carries a max grant + examples.
     TIERS = {
-      1 => { code: "B", name: "B Tier", max_cents: 2_500,  examples: "Macropads and very basic PCBs" },
-      2 => { code: "A", name: "A Tier", max_cents: 12_000, examples: "Keyboards and devboards" },
-      3 => { code: "S", name: "S Tier", max_cents: 20_000, examples: "Ambitious, polished builds" },
-      4 => { code: "X", name: "X Tier", max_cents: 60_000, examples: "Out of this world builds (may include a travel stipend)" }
+      1 => { code: "B", name: "B Tier", max_cents: 2_500,  examples: "Basic PCBs, Macropads, 3D prints" },
+      2 => { code: "A", name: "A Tier", max_cents: 12_000, examples: "Keyboards, devboards, basic gadgets" },
+      3 => { code: "S", name: "S Tier", max_cents: 20_000, examples: "More complex projects!" },
+      4 => { code: "X", name: "X Tier", max_cents: 60_000, examples: "3D printers, advanced PCBs, and more!" }
     }.freeze
 
     # tier => maximum grant, in cents / dollars.

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -616,7 +616,7 @@
                   ) %>
             <% elsif !@project.has_devlog_since_last_ship? %>
               <%= render ActionButtonComponent.new(
-                    text: "Submit Design to Get Project Funding",
+                    text: "Submit for funding",
                     variant: :primary,
                     type: :button,
                     icon: "icons/rocket.png",
@@ -629,7 +629,7 @@
                   ) %>
             <% elsif !@project.info_complete? %>
               <%= render ActionButtonComponent.new(
-                    text: "Submit Design to Get Project Funding",
+                    text: "Submit for funding",
                     variant: :primary,
                     type: :button,
                     icon: "icons/rocket.png",
@@ -642,7 +642,7 @@
                   ) %>
             <% else %>
               <%= render ActionButtonComponent.new(
-                    text: "Submit Design to Get Project Funding",
+                    text: "Submit for funding",
                     variant: :primary,
                     type: :button,
                     icon: "icons/rocket.png",


### PR DESCRIPTION
## what do 
update flavortext

## show work

<img width="182" height="109" alt="image" src="https://github.com/user-attachments/assets/847a5fbb-e89d-4c4d-91ea-8f33f20d5a05" />

## ai?

opus 4-6(7) 😂 