### PR TITLE
fix(hardware): calculate build time right

### DIFF
--- a/app/models/post/ship_event.rb
+++ b/app/models/post/ship_event.rb
@@ -120,8 +120,9 @@ class Post::ShipEvent < ApplicationRecord
     update!(hours_at_ship: hours_logged_in_ship_window)
   end
 
-  # All non-deleted devlogs in this ship's window, regardless of phase —
-  # unlike hours_at_ship, which only counts build-phase devlogs on hardware.
+  # All non-deleted devlogs in this ship's window, regardless of phase or
+  # funding — unlike hours_at_ship, which on hardware drops explicit design
+  # work and anything logged before the funding request.
   def window_devlogs_count
     return 0 unless post&.project && post.created_at
 
@@ -136,8 +137,20 @@ class Post::ShipEvent < ApplicationRecord
     devlogs_in_ship_window.sum("post_devlogs.duration_seconds").to_f / 3600
   end
 
+  # Hardware pays for build time, not the design work the grant was awarded
+  # against. Explicit design-phase time is dropped; build time counts, and so
+  # does software time (phase nil) carried over from a project that started as
+  # software and converted to hardware later. On top of that the funding
+  # request, when there is one, is the real build boundary: anything logged
+  # before it is pre-funding and doesn't count, whatever its phase. A project
+  # that skipped funding has no cutoff, so all of its non-design time counts
+  # back to the project's start.
   def devlogs_in_ship_window
-    window_devlogs.then { |scope| project.hardware? ? scope.where(post_devlogs: { phase: "build" }) : scope }
+    return window_devlogs unless project.hardware?
+
+    scope = window_devlogs.where("post_devlogs.phase IS DISTINCT FROM 'design'")
+    cutoff = hardware_payout_cutoff
+    cutoff ? scope.where("posts.created_at >= ?", cutoff) : scope
   end
 
   def window_devlogs

--- a/app/models/post/ship_event/payouts.rb
+++ b/app/models/post/ship_event/payouts.rb
@@ -384,14 +384,9 @@ module Post::ShipEvent::Payouts
     def capped_logged_seconds
       return 0 unless post&.project && post.created_at
 
-      scope = devlogs_in_ship_window
-      # Same cutoff the reviewed branch applies: a hardware build is only paid
-      # for work done once funding was asked for.
-      if (cutoff = hardware_payout_cutoff)
-        scope = scope.where("posts.created_at >= ?", cutoff)
-      end
-
-      scope.pluck("post_devlogs.duration_seconds").sum do |duration_seconds|
+      # devlogs_in_ship_window already drops pre-funding and design-phase time
+      # on hardware, so the funding cutoff is applied there.
+      devlogs_in_ship_window.pluck("post_devlogs.duration_seconds").sum do |duration_seconds|
         [ duration_seconds.to_i, Post::ShipEvent::MAX_PAYOUT_SECONDS_PER_DEVLOG ].min
       end
     end

--- a/test/models/post/ship_event_hours_test.rb
+++ b/test/models/post/ship_event_hours_test.rb
@@ -61,6 +61,35 @@ class Post::ShipEventHoursTest < ActiveSupport::TestCase
     assert_in_delta 0.0, ship.hours, 0.001
   end
 
+  # --- software-origin conversions --------------------------------------------
+
+  # A project built as software (phase-less devlogs) that turned hardware without
+  # ever asking for funding used to pay nothing: none of its time was tagged
+  # "build". Its software time isn't design work, so it counts from the start.
+  test "a converted project with no funding counts its software time" do
+    project = Project.create!(title: "HW #{SecureRandom.hex(4)}", created_at: 5.days.ago)
+    create_devlog(project, seconds: 7200, phase: nil, at: 3.days.ago) # logged as software
+    project.update!(hardware_stage: "build")
+    ship = create_ship(project)
+
+    assert_in_delta 2.0, ship.reload.hours_at_ship, 0.001
+    assert_in_delta 2.0, ship.hours, 0.001
+  end
+
+  # Once the convert has a funding request, the same funding boundary applies:
+  # software time logged before it is pre-funding and doesn't count.
+  test "a converted project with funding still respects the funding boundary" do
+    project = hardware_project_with_approved_funding(requested_at: 2.days.ago)
+    software = create_devlog(project, seconds: 7200, phase: nil, at: 4.days.ago)
+    build    = create_devlog(project, seconds: 7200, phase: "build", at: 1.day.ago)
+    software.update_column(:created_at, 4.days.ago)
+    build.update_column(:created_at, 1.day.ago)
+    ship = create_ship(project)
+
+    # Only the post-funding build devlog counts: 2h, not 4h.
+    assert_in_delta 2.0, ship.reload.hours, 0.001
+  end
+
   # --- funding-request cutoff -------------------------------------------------
 
   test "hardware payout ignores reviewed time logged before the funding request" do


### PR DESCRIPTION
## what's this do?

previously build time was calculated wrong, now it's right!

the bug was when you switched a project from software to hardware, devlogs before you switched wouldn't be counted right. now they are!

## ai?

claude
