### PR TITLE
feat(admin): add admin root dashboard

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1,4 +1,5 @@
 /* Import page-specific styles */
+@use "pages/admin/dashboard";
 @use "pages/admin/missions_edit";
 @use "pages/admin/ysws_reviews";
 @use "pages/admin/integrity_reviews";
@@ -321,7 +322,8 @@ body.admin-page {
     content: unset;
   }
 
-  &:disabled {
+  &:disabled,
+  &.disabled {
     background: var(--color-space-surface-faint);
     color: var(--color-space-text-muted);
     cursor: not-allowed;

--- a/app/assets/stylesheets/pages/admin/_dashboard.scss
+++ b/app/assets/stylesheets/pages/admin/_dashboard.scss
@@ -1,0 +1,30 @@
+.admin-dashboard {
+  display: grid;
+  gap: var(--space-l);
+  max-width: 1200px;
+  margin: 0 auto;
+
+  &__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: var(--space-s);
+  }
+
+  &__button {
+    text-align: center;
+  }
+
+  &__count-pill {
+    background: var(--color-brand-salmon);
+    color: var(--color-space-bg);
+    border-radius: 999px;
+    padding: 0 0.5em;
+    font-size: 0.75em;
+    font-weight: 700;
+  }
+
+  &__count-pill--muted {
+    background: var(--color-space-surface-strong);
+    color: var(--color-space-text-muted);
+  }
+}

--- a/app/components/sidebar_component.rb
+++ b/app/components/sidebar_component.rb
@@ -51,22 +51,21 @@ class SidebarComponent < ViewComponent::Base
     ])
 
     if signed_in?
-      items << { slug: "projects", label: "my projects",   path: helpers.profile_projects_path(user.display_name),
-        icon: :avatar, active_prefix: "/@" }
-    end
+      items << {
+        slug: "projects",
+        label: "my projects",
+        path: helpers.profile_projects_path(user.display_name),
+        icon: :avatar,
+        active_prefix: "/@"
+      }
 
-    # Guardians of integrity only (not admins): YSWS certification review queue.
-    if signed_in? && user.guardian_of_integrity?
-      items << { slug: "guard", label: "Lets go GOI", path: helpers.admin_certification_ysws_reviews_path, icon: "eye" }
+      items << {
+        slug: "admin",
+        label: "admin",
+        path: helpers.admin_root_path,
+        icon: "eye"
+      } if user.roles.any?
     end
-
-    # items << { slug: "support", label: "support", path: helpers.admin_support_path, icon: "help" } if helpers.admin_policy(:support_dashboard).show?
-    # items << { slug: "fraud",   label: "fraud",   path: helpers.admin_fraud_path, icon: "code" } if helpers.admin_policy(:fraud_dashboard).show? && !user.admin?
-    # items << { slug: "admin",   label: "admin",   path: helpers.admin_users_path, icon: "code" } if user.admin?
-    # items << { slug: "shop",    label: "shop",    path: helpers.admin_shop_path, icon: "shopping_cart_1_fill" } if helpers.admin_policy(ShopItem).index?
-    # items << { slug: "fulfil",  label: "fulfil",  path: helpers.admin_shop_orders_path(view: "fulfillment"), icon: "shopping_cart_1_fill" } if user.fulfillment_person? && !user.admin?
-    # items << { slug: "seller",  label: "seller",  path: helpers.seller_orders_path, icon: "shopping_cart_1_fill" } if user.seller?
-    # items << { slug: "certify", label: "certify", path: "https://review.hackclub.com/", icon: "ship" } if user.project_certifier?
 
     items
   end

--- a/app/constraints/admin_constraint.rb
+++ b/app/constraints/admin_constraint.rb
@@ -9,13 +9,9 @@ class AdminConstraint
 
     return false unless user
 
-    policy = AdminPolicy.new(user, :admin)
-    policy.access_admin_endpoints? ||
-      policy.access_fulfillment_view? ||
-      policy.access_ship_review? ||
-      policy.access_ysws_review? ||
-      policy.access_raffles? ||
-      policy.access_workshops?
+    # Any granted role gets past the constraint — each page's controller
+    # authorization is the real per-page gate.
+    AdminPolicy.new(user, :admin).index?
   end
 
   def self.admin_user_for(request)

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -10,19 +10,6 @@ module Admin
 
     def index
       authorize :admin
-      if current_user.helper?
-        redirect_to admin_support_path
-      elsif current_user.fraud_dept? && !current_user.admin?
-        redirect_to admin_fraud_path
-      elsif current_user.shop_manager? && !current_user.admin?
-        redirect_to admin_shop_path
-      elsif current_user.has_role?(:raffle_admin) && !current_user.admin?
-        redirect_to admin_raffles_path
-      elsif current_user.workshop_manager? && !current_user.admin?
-        redirect_to admin_workshops_path
-      else
-        redirect_to admin_users_path
-      end
     end
 
     private

--- a/app/controllers/admin/dashboard_counts_controller.rb
+++ b/app/controllers/admin/dashboard_counts_controller.rb
@@ -1,0 +1,33 @@
+module Admin
+  class DashboardCountsController < ApplicationController
+    layout false
+
+    COUNTS = {
+      "shop_fulfillment" => -> {
+        ::ShopOrder.where(aasm_state: "awaiting_periodical_fulfillment").count
+      },
+      "fraud_checks" => -> {
+        ::ShopOrder.where(aasm_state: "pending").count +
+          ::Project::Report.pending.where(reason: "fraud").count
+      },
+      "ship_certifications" => -> {
+        policy_scope(::Certification::Ship).where(status: "pending").count
+      },
+      "ysws_reviews" => -> {
+        ::Certification::Ysws.pending.count
+      },
+      "mission_reviews" => -> {
+        ::Mission::Submission.where(status: "pending", deleted_at: nil).count
+      }
+    }.freeze
+
+    def show
+      authorize :admin, :index?
+      count = COUNTS[params[:key]]
+      return head :not_found unless count
+
+      @key = params[:key]
+      @count = instance_exec(&count)
+    end
+  end
+end

--- a/app/helpers/admin/dashboard_helper.rb
+++ b/app/helpers/admin/dashboard_helper.rb
@@ -1,0 +1,40 @@
+module Admin
+  module DashboardHelper
+    def admin_page_button(label, path, enabled:, count: nil)
+      link_to path,
+        class: class_names("btn-secondary admin-dashboard__button",
+                           "disabled" => !enabled) do
+        if count
+          safe_join([ label, turbo_frame_tag("admin_count_#{count}",
+            src: admin_dashboard_count_path(count), loading: :lazy) ], " ")
+        else
+          label
+        end
+      end
+    end
+
+    def greeting_message(user)
+      name = user.first_name.presence || user.display_name
+      time_of_day =
+        case Time.current.in_time_zone(user.timezone.presence || "UTC").hour
+        when 0..4 then "burning the midnight oil, #{name}?"
+        when 5..11 then "good morning, #{name}"
+        when 12..16 then "good afternoon, #{name}"
+        else "good evening, #{name}"
+        end
+
+      [
+        time_of_day,
+        "back at it, #{name}!",
+        "welcome back, #{name}!",
+        "what's on the docket, #{name}?",
+        "howdy!",
+        "you look wonderful today",
+        "hiya :3",
+        "ground control to #{name}",
+        "another day among the stars",
+        "you again? excellent :>"
+      ].sample
+    end
+  end
+end

--- a/app/policies/admin_policy.rb
+++ b/app/policies/admin_policy.rb
@@ -1,26 +1,10 @@
 class AdminPolicy < ApplicationPolicy
   def index?
-    user.admin? || user.fraud_dept? || user.shop_manager? || user.helper? || user.nda_helper? || user.workshop_manager?
-  end
-
-  def access_admin_endpoints?
-    user.admin? || user.fraud_dept? || user.shop_manager? || user.helper? || user.nda_helper?
+    user.roles.any?
   end
 
   def access_funnel?
     user.admin? || user.fraud_dept? || user.shop_manager? || user.helper?
-  end
-
-  def access_fulfillment_view?
-    user.admin? || user.fulfillment_person?
-  end
-
-  def access_ship_review?
-    user.admin? || user.has_role?(:project_certifier)
-  end
-
-  def access_ysws_review?
-    user.admin? || user.has_role?(:guardian_of_integrity)
   end
 
   def access_blazer?

--- a/app/views/admin/application/index.html.erb
+++ b/app/views/admin/application/index.html.erb
@@ -1,0 +1,66 @@
+<% content_for :title, "Admin" %>
+
+<div class="admin-dashboard">
+  <h1><%= greeting_message current_user %></h1>
+
+  <section>
+    <h2>Tasks</h2>
+    <div class="admin-dashboard__grid">
+      <%= admin_page_button "Ship Certifications", admin_certification_ships_path,
+        enabled: policy(Certification::Ship).index?,
+        count: "ship_certifications" %>
+      <%= admin_page_button "YSWS Reviews", admin_certification_ysws_reviews_path,
+        enabled: policy(Certification::Ysws).index?,
+        count: "ysws_reviews" %>
+      <%= admin_page_button "Fraud Checks", admin_fraud_path,
+        enabled: policy(:fraud_dashboard).show?,
+        count: "fraud_checks" %>
+      <%= admin_page_button "Shop Fulfillment", admin_shop_orders_path(view: "fulfillment"),
+        enabled: policy(ShopOrder).index?,
+        count: "shop_fulfillment" %>
+      <%= admin_page_button "Mission Reviews", admin_mission_reviews_path,
+        enabled: Pundit.policy!(pundit_user, Mission::Submission).index?,
+        count: "mission_reviews" %>
+    </div>
+  </section>
+
+  <section>
+    <h2>Dashboards</h2>
+    <div class="admin-dashboard__grid">
+      <%= admin_page_button "Support", admin_support_path, enabled: policy(:support_dashboard).show? %>
+      <%= admin_page_button "Fraud", admin_fraud_path, enabled: policy(:fraud_dashboard).show? %>
+      <%= admin_page_button "Shop", admin_shop_path, enabled: policy(ShopItem).index? %>
+      <%= admin_page_button "Raffles", admin_raffles_path, enabled: policy(:admin).access_raffles? %>
+    </div>
+  </section>
+
+  <section>
+    <h2>Models</h2>
+    <div class="admin-dashboard__grid">
+      <%= admin_page_button "Users", admin_users_path, enabled: policy(User).index? %>
+      <%= admin_page_button "Projects", admin_projects_path, enabled: policy(Project).index? %>
+      <%= admin_page_button "Missions", admin_missions_path, enabled: policy(Mission).index? %>
+      <%= admin_page_button "Certificates", admin_certificates_path, enabled: policy(Certificate).index? %>
+      <%= admin_page_button "Workshops", admin_workshops_path, enabled: policy(:admin).access_workshops? %>
+      <%= admin_page_button "Funnel", admin_funnel_path, enabled: policy(:admin).access_funnel? %>
+      <%= admin_page_button "Super Stars", admin_super_stars_path, enabled: policy(:super_star_dashboard).show? %>
+      <%= admin_page_button "Audit Logs", admin_audit_logs_path, enabled: policy(PaperTrail::Version).index? %>
+      <%= admin_page_button "Ledger Entries", admin_ledger_entries_path, enabled: policy(LedgerEntry).index? %>
+      <%= admin_page_button "Payout Reviews", admin_payout_reviews_path, enabled: policy(:payout_review).index? %>
+      <%= admin_page_button "Fulfillment Payouts", admin_fulfillment_payouts_path, enabled: policy(FulfillmentPayoutRun).index? %>
+      <%= admin_page_button "Fraud Payouts", admin_fraud_payouts_path, enabled: policy(FraudPayoutRun).index? %>
+      <%= admin_page_button "Vote Flags", admin_vote_flags_path, enabled: policy(Vote::Event).index? %>
+      <%= admin_page_button "Messages", admin_messages_path, enabled: policy(Message).index? %>
+      <%= admin_page_button "Email Templates", admin_email_templates_path, enabled: policy(:admin).access_email_templates? %>
+    </div>
+  </section>
+
+  <section>
+    <h2>Tools</h2>
+    <div class="admin-dashboard__grid">
+      <%= admin_page_button "Blazer", admin_blazer_path, enabled: policy(:admin).access_blazer? %>
+      <%= admin_page_button "Flipper", admin_flipper_path, enabled: policy(:admin).access_flipper? %>
+      <%= admin_page_button "Jobs", admin_mission_control_jobs_path, enabled: policy(:admin).access_jobs? %>
+    </div>
+  </section>
+</div>

--- a/app/views/admin/dashboard_counts/show.html.erb
+++ b/app/views/admin/dashboard_counts/show.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag "admin_count_#{@key}" do %>
+  <span class="<%= class_names("admin-dashboard__count-pill", "admin-dashboard__count-pill--muted" => @count.zero?) %>"><%= @count %></span>
+<% end %>

--- a/app/views/admin/shop/dashboard/show.html.erb
+++ b/app/views/admin/shop/dashboard/show.html.erb
@@ -4,9 +4,6 @@
     <h1 class="shop-dashboard__title">Manage Shop</h1>
     <div class="shop-dashboard__header-actions">
       <%= link_to current_user.shop_manager? && !current_user.admin? ? "New Draft" : "New Product", new_admin_shop_item_path, class: "btn-primary" %>
-      <% unless current_user.shop_manager? && !current_user.admin? %>
-        <%= button_to "Clear Carousel Cache", admin_clear_carousel_cache_path, method: :post, class: "btn-secondary", form: { onsubmit: "return confirm('Are you sure you want to clear the carousel cache?')" } %>
-      <% end %>
     </div>
   </header>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -619,14 +619,17 @@ Rails.application.routes.draw do
   end
 
   namespace :admin, constraints: AdminConstraint do
+    # Admin dashboard
     root to: "application#index"
+    get "dashboard/counts/:key", to: "dashboard_counts#show", as: :dashboard_count
+
     resource :funnel, only: [ :show ], controller: "funnel"
 
     mount Blazer::Engine, at: "blazer", constraints: ->(request) {
       AdminConstraint.allow?(request, :access_blazer?)
     }
 
-    mount Flipper::UI.app(Flipper), at: "flipper", constraints: ->(request) {
+    mount Flipper::UI.app(Flipper), at: "flipper", as: :flipper, constraints: ->(request) {
       AdminConstraint.allow?(request, :access_flipper?)
     }
 
@@ -716,7 +719,6 @@ Rails.application.routes.draw do
     end
 
     resource :shop, only: [ :show ], controller: "shop/dashboard"
-    post "shop/clear-carousel-cache", to: "shop/dashboard#clear_carousel_cache", as: :clear_carousel_cache
     namespace :shop do
       resources :items, only: [ :new, :create, :show, :edit, :update, :destroy ] do
         collection do
@@ -755,9 +757,6 @@ Rails.application.routes.draw do
     end
     resources :messages, only: [ :index, :create ]
     resources :email_templates, only: [ :index, :create, :destroy ]
-    resources :support_vibes, only: [ :index, :create ]
-    resources :sw_vibes, only: [ :index ]
-    resources :suspicious_votes, only: [ :index ]
     resources :audit_logs, only: [ :index, :show ]
     resources :fulfillment_payouts, only: [ :index, :show ] do
       member do


### PR DESCRIPTION
based on discussion: https://hackclub.slack.com/archives/C0AR0M43H61/p1785523683550749

<img width="1132" height="828" alt="Screenshot 2026-07-31 at 15 12 24" src="https://github.com/user-attachments/assets/8e233670-ca42-4df8-b0fe-0bb686f67c1a" />

This gives a new dashboard so people know the links to the admin tools they have! It'll also highlight what people with restricted access can load:

<img width="1452" height="869" alt="image" src="https://github.com/user-attachments/assets/5837bbaf-5132-4f4d-96a8-79927310fa74" />
