### PR TITLE
fix(certification): keep hardware projects out of the Shipwright ship queue

### DIFF
--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -161,8 +161,24 @@ module Certification
         : joins(:project).where(projects: { project_type: type })
     }
 
+    # A hardware ship is certified in the hardware build queue
+    # (Admin::Certification::HardwareReviewsController), which selects the same
+    # rows with `hardware_stage IS NOT NULL`. This is the other half of that
+    # split: without it one review sits in both queues and a shipwright gets
+    # handed a build cert they aren't reviewing for.
+    #
+    # Deliberately not folded into `for_reviewer`/`available_for` — the hardware
+    # queue builds on those, so narrowing them there would empty it.
+    scope :software_only, -> { joins(:project).where(projects: { hardware_stage: nil }) }
+
     def self.available_for(user)
       super.merge(for_reviewer(user))
+    end
+
+    # Claim-next for the software queue. The hardware queue has its own
+    # candidate lookup, so this narrowing stays on Ship rather than the concern.
+    def self.next_eligible_scope(user)
+      super.software_only
     end
 
     # Health target for the pending queue. Above this we read as "behind".
@@ -173,24 +189,27 @@ module Certification
 
     # Snapshot of queue health for the reviewer dashboard. Counts are global
     # (every reviewer shares one queue), so this is intentionally not scoped
-    # to the current user the way the listing is.
+    # to the current user the way the listing is. Software only, so the header
+    # numbers agree with the rows the shipwright is actually shown.
     def self.dashboard_stats(now: Time.current)
       today = now.beginning_of_day
       week = now.beginning_of_week
-      approved_count = where(status: :approved).count
-      returned_count = where(status: :returned).count
+      base = software_only
+      approved_count = base.where(status: :approved).count
+      returned_count = base.where(status: :returned).count
       decided_count = approved_count + returned_count
 
-      decided = where.not(status: :pending)
+      decided = base.where.not(status: :pending)
 
-      pending_ages = where(status: :pending).pluck(:created_at)
+      pending_ages = base.where(status: :pending).pluck(:created_at)
       median_pending_wait = if pending_ages.any?
         sorted = pending_ages.map { |t| now - t }.sort
         (median_value(sorted) / 3600.0).round(1)
       end
 
+      # Table-qualified: `base` joins projects, which has its own created_at.
       avg_decision_secs = decided.where.not(decided_at: nil)
-        .average(Arel.sql("EXTRACT(EPOCH FROM (decided_at - created_at))"))
+        .average(Arel.sql("EXTRACT(EPOCH FROM (certification_ship_reviews.decided_at - certification_ship_reviews.created_at))"))
       avg_decision_hours = avg_decision_secs ? (avg_decision_secs / 3600.0).round(1) : nil
 
       {
@@ -200,13 +219,14 @@ module Certification
         decided: decided_count,
         approval_rate: decided_count.zero? ? nil : (approved_count * 100.0 / decided_count).round(1),
         decisions_today: decided.where(decided_at: today..).count,
-        new_today: where(created_at: today..).count,
+        new_today: base.where(created_at: today..).count,
         decisions_this_week: decided.where(decided_at: week..).count,
-        new_this_week: where(created_at: week..).count,
-        oldest_pending: where(status: :pending).order(created_at: :asc).first,
+        new_this_week: base.where(created_at: week..).count,
+        oldest_pending: base.where(status: :pending).order(created_at: :asc).first,
         queue_target: QUEUE_TARGET,
         sla_days: SLA_DAYS,
-        overdue_pending: where(status: :pending).where("created_at < ?", now - SLA_DAYS.days).count,
+        overdue_pending: base.where(status: :pending)
+                             .where("certification_ship_reviews.created_at < ?", now - SLA_DAYS.days).count,
         median_pending_wait_hours: median_pending_wait,
         avg_decision_hours: avg_decision_hours
       }

--- a/app/models/concerns/certification/reviewable.rb
+++ b/app/models/concerns/certification/reviewable.rb
@@ -26,8 +26,14 @@ module Certification
           .update_all(reviewer_id: nil, claim_expires_at: nil, updated_at: Time.current)
       end
 
+      # Records this queue may hand out next. Defaults to everything claimable;
+      # override to narrow when one model backs more than one queue.
+      def next_eligible_scope(user)
+        available_for(user)
+      end
+
       def next_eligible(user, skip_ids: [])
-        scope = available_for(user)
+        scope = next_eligible_scope(user)
         scope = scope.where.not(id: skip_ids) if skip_ids.any?
         scope.order(
           Arel.sql(sanitize_sql_array([ "CASE WHEN reviewer_id = ? THEN 0 ELSE 1 END", user.id ])),

--- a/app/policies/admin/certification/ship_policy.rb
+++ b/app/policies/admin/certification/ship_policy.rb
@@ -18,9 +18,12 @@ class Admin::Certification::ShipPolicy < ApplicationPolicy
   def report_fraud? = user&.can_review?
 
   class Scope < ApplicationPolicy::Scope
+    # Software only: hardware ships are listed by the hardware build queue.
+    # The hardware controller reads Certification::Ship directly rather than
+    # through this scope, so it keeps seeing them.
     def resolve
       return scope.none unless user&.can_review?
-      scope.joins(:project).where(projects: { deleted_at: nil })
+      scope.joins(:project).where(projects: { deleted_at: nil }).merge(::Certification::Ship.software_only)
     end
   end
 

--- a/test/controllers/admin/certification/ships_controller_test.rb
+++ b/test/controllers/admin/certification/ships_controller_test.rb
@@ -1,0 +1,74 @@
+require "test_helper"
+
+# Hardware ships are certified in the hardware build queue, so they must not
+# reach the shipwright ship queue — the same rows back both listings.
+class Admin::Certification::ShipsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @reviewer = create_user(slack_id: "U_SHIPQ_REV", display_name: "shipq-reviewer")
+    @reviewer.grant_role!(:project_certifier)
+
+    @owner = create_user(slack_id: "U_SHIPQ_OWNER", display_name: "shipq-owner")
+
+    @software = project("Software ship")
+    @software_ship = ::Certification::Ship.create!(project: @software, status: :pending)
+
+    @hardware = project("Hardware ship")
+    @hardware.update!(hardware_stage: "build")
+    @hardware_ship = ::Certification::Ship.create!(project: @hardware, status: :pending)
+
+    sign_in @reviewer
+  end
+
+  test "the ship queue lists software ships and hides hardware ones" do
+    get admin_certification_ships_path
+
+    assert_response :success
+    assert_select ".ship-queue__project-title", text: /Software ship/
+    assert_select ".ship-queue__project-title", text: /Hardware ship/, count: 0
+  end
+
+  # The header count comes from dashboard_stats while the rows come from the
+  # policy scope; if only one of them learns to skip hardware the page shows a
+  # backlog the reviewer can't see.
+  test "the queue-health count matches the rows on the page" do
+    get admin_certification_ships_path
+
+    assert_response :success
+    assert_select ".ship-queue__metric-value", text: /\A\s*1\s*\z/
+    assert_select ".ship-queue__table .ship-queue__project-title", count: 1
+  end
+
+  test "the review logs hide decided hardware ships" do
+    @software_ship.update!(reviewer: @reviewer, status: :approved)
+    @hardware_ship.update!(reviewer: @reviewer, status: :approved)
+
+    get logs_admin_certification_ships_path
+
+    assert_response :success
+    assert_select ".ship-queue__project-title", text: /Software ship/
+    assert_select ".ship-queue__project-title", text: /Hardware ship/, count: 0
+  end
+
+  test "claiming the next review never hands over a hardware ship" do
+    get next_admin_certification_ships_path
+
+    assert_redirected_to admin_certification_ship_path(@software_ship)
+
+    # With only hardware left the software queue reads as empty rather than
+    # falling through to a build cert. Reload first: the claim above bumped
+    # lock_version straight in the database.
+    @software_ship.reload.update!(reviewer: @reviewer, status: :approved)
+    get next_admin_certification_ships_path
+
+    assert_redirected_to admin_certification_ships_path
+    assert_equal "Queue is empty.", flash[:notice]
+  end
+
+  private
+
+  def project(title)
+    project = Project.create!(title: title, description: "A ship", ship_status: "submitted")
+    project.memberships.create!(user: @owner, role: :owner)
+    project
+  end
+end

--- a/test/models/certification/ship_test.rb
+++ b/test/models/certification/ship_test.rb
@@ -93,4 +93,54 @@ class Certification::ShipTest < ActiveSupport::TestCase
     assert_equal reviews.last.id, history[:recent].first.id
     assert history[:recent].first.project_with_deleted.deleted?
   end
+
+  test "software_only excludes ships whose project has a hardware stage" do
+    software = @project.ship_reviews.create!(status: :pending)
+    hardware = hardware_project.ship_reviews.create!(status: :pending)
+
+    ids = Certification::Ship.software_only.pluck(:id)
+
+    assert_includes ids, software.id
+    refute_includes ids, hardware.id
+  end
+
+  test "dashboard_stats counts software ships only" do
+    @project.ship_reviews.create!(status: :pending)
+    hardware_project.ship_reviews.create!(status: :pending)
+
+    assert_equal 1, Certification::Ship.dashboard_stats[:pending]
+  end
+
+  # The projects join makes bare `created_at` ambiguous in Postgres, so these
+  # two keys are the ones that break if a query loses its table qualifier.
+  test "dashboard_stats resolves created_at against the reviews table" do
+    @project.ship_reviews.create!(status: :pending, created_at: 10.days.ago)
+    decided = @project.ship_reviews.create!(status: :approved, reviewer: @reviewer)
+    decided.update_columns(created_at: 5.days.ago, decided_at: 4.days.ago)
+
+    stats = Certification::Ship.dashboard_stats
+
+    assert_equal 1, stats[:overdue_pending]
+    assert_in_delta 24.0, stats[:avg_decision_hours], 0.5
+  end
+
+  test "next_eligible never hands a shipwright a hardware ship" do
+    @reviewer.grant_role!(:project_certifier)
+    hardware = hardware_project.ship_reviews.create!(status: :pending)
+
+    assert_nil Certification::Ship.next_eligible(@reviewer)
+
+    software = @project.ship_reviews.create!(status: :pending)
+    assert_equal software.id, Certification::Ship.next_eligible(@reviewer).id
+    refute_equal hardware.id, Certification::Ship.next_eligible(@reviewer).id
+  end
+
+  private
+
+  def hardware_project(stage: "build")
+    project = Project.create!(title: "Hardware Ship", description: "A hardware build", ship_status: "submitted")
+    project.memberships.create!(user: @owner, role: :owner)
+    project.update!(hardware_stage: stage)
+    project
+  end
 end


### PR DESCRIPTION
## What & why

Hardware projects are showing up in the Shipwright ship queue at `/admin/certification/ship`. They shouldn't be there — hardware is certified in the hardware build queue.

The cause is that both queues are backed by the **same** `Certification::Ship` rows. `HardwareReviewsController` selects them with `hardware_stage IS NOT NULL`:

```ruby
def hardware_ship_list_scope
  ::Certification::Ship.for_reviewer(current_user)
    .joins(:project)
    .where.not(projects: { hardware_stage: nil })
end
```

Nothing ever selected the complement, so every hardware build cert sat in *both* queues and `next` would hand a Shipwright a build cert they aren't reviewing for.

## The fix

One `software_only` scope, applied to the three Shipwright-facing surfaces:

| Surface | Where |
|---|---|
| Listing, logs, sidebar pending count | `ShipPolicy::Scope#resolve` |
| "Review next" claim | `Certification::Ship.next_eligible_scope` |
| Queue-health header numbers | `Certification::Ship.dashboard_stats` |

`dashboard_stats` is included so the header count can't disagree with the rows underneath it — otherwise the page reads "12 in queue" over 7 visible rows.

## Two things worth reviewing

**The narrowing deliberately stays off `for_reviewer` / `available_for`.** The hardware queue builds its own scopes on top of both, so filtering there would empty the hardware queue rather than fix the software one. (This is why this isn't a cherry-pick of the corresponding part of #583 — that PR predates the hardware queue and puts the filter in `for_reviewer`, which would now break it.)

**`show?` / `update?` are untouched.** The hardware build review posts its verdict through `ShipsController#update` (see the `redirect_to_hardware` branch), so gating those on hardware would break hardware reviewing. A direct link to a hardware ship review still opens; it just no longer appears in, or is handed out by, the software queue.

Claim-next gets a small `next_eligible_scope` seam on `Certification::Reviewable` (default: today's behavior) so `Ship` can narrow it without duplicating the claim-priority ordering. `Certification::FundingRequest`, the other includer, is unaffected.

## Ambiguous-column footgun

`dashboard_stats` now joins `projects`, which has its own `created_at`. Two raw-SQL fragments referenced it unqualified and start throwing `PG::AmbiguousColumn`. Both are table-qualified here, and `dashboard_stats resolves created_at against the reviews table` fails with exactly that error if either qualifier is dropped.

## Tests

`36 runs, 142 assertions, 0 failures, 0 errors` — new model + controller tests, plus the full existing `hardware_reviews_controller_test` (22 tests) as the regression check that the hardware queue still lists, claims, and decides hardware.

Each new test was confirmed to fail without the fix: stubbing `software_only` to `-> { all }` breaks 3 model tests and 4 controller tests.

## Not included

Reviewer throughput charts on the monitor page (`daily_chart_data`, `reviewer_daily_data`) still count every decision including hardware. That looks correct to me — Shipwrights do review hardware build certs and are paid for them, so their throughput legitimately includes that work. Payout math (`ReviewerPayoutRequest.total_earned_for`) queries `Certification::Ship` directly and is untouched. Happy to change if you'd rather those be software-only too.

This does not backfill or reroute anything — existing hardware ship rows just stop appearing in the software queue and remain in the hardware build queue.
