### PR TITLE
Change devlog review goal per day to 30

### DIFF
--- a/app/models/certification/ysws.rb
+++ b/app/models/certification/ysws.rb
@@ -151,7 +151,7 @@ module Certification
     # Per-reviewer target for completed devlog reviews: a daily rate that
     # reviewers are expected to average across the review week, rather than hit
     # every single day. Drives the pace widget on the review queue.
-    DEVLOG_REVIEW_GOAL_PER_DAY = 45
+    DEVLOG_REVIEW_GOAL_PER_DAY = 30
 
     # Rolling window the reviewer leaderboard ranks on. Deliberately independent
     # of the review week: it's always this full span, so a reviewer's standing


### PR DESCRIPTION
Updated the daily devlog review goal from 45 to 30.

## what's this do?

<!-- a sentence or two! -->

## show it works

<!-- screen recording, screenshots, test output— whatever makes sense for the change -->

## ai?

<!-- did you use AI tools? which ones? no judgment, we just wanna know. see AI_POLICY.md for details -->
