### PR TITLE
feat: make shigimi eyes opt-out

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,7 +58,7 @@ module ApplicationHelper
   def admin_tool(compact: false, extra_class: nil, roles: [], &block)
     acting_user = impersonating? ? real_user : current_user
     allowed = acting_user&.admin? || roles.any? { |role| acting_user&.has_role?(role) }
-    return unless allowed && Flipper.enabled?(:shigimi_eyes, acting_user)
+    return unless allowed && !Flipper.enabled?(:no_shigimi_eyes, acting_user)
 
     classes = [ "admin", "tools-do" ]
     classes << "tools-do--inline" if compact

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -42,7 +42,7 @@ Rails.application.config.after_initialize do
         payout_recommendations
         disable_internal_sw_dash_reviews
         sharable_purchase
-        shigimi_eyes
+        no_shigimi_eyes
         devlog_review_pace
         mac_analysis
       ].each { |flag| Flipper.add(flag) }


### PR DESCRIPTION
## what's this do?

makes shigimi eyes (the hidden admin ui) opt out rather than opt in as it should've been from the start... Opt out is with `no_shigimi_eyes` flipper

## show it works

https://github.com/user-attachments/assets/a7d0f520-607f-450a-9cbf-8133fa389e0d

## ai?
no
