### PR TITLE
feat(hardware): make hardware missions fully work!

### DIFF
--- a/app/assets/stylesheets/pages/admin/_missions_edit.scss
+++ b/app/assets/stylesheets/pages/admin/_missions_edit.scss
@@ -125,6 +125,17 @@
   gap: var(--space-xxs);
 }
 
+.admin-mission-edit__prize-name {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.admin-mission-edit__prize-category {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xxs);
+}
+
 .admin-mission-edit__guide-editor {
   display: grid;
   grid-template-columns: 1fr;

--- a/app/assets/stylesheets/pages/missions/_show.scss
+++ b/app/assets/stylesheets/pages/missions/_show.scss
@@ -423,6 +423,16 @@
   gap: 12px;
 }
 
+.mission-home__prize-group-label {
+  margin-top: 6px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-brand-cream);
+  opacity: 0.75;
+}
+
 .mission-home__prize {
   display: flex;
   align-items: center;

--- a/app/controllers/admin/certification/application_controller.rb
+++ b/app/controllers/admin/certification/application_controller.rb
@@ -1,2 +1,50 @@
 class Admin::Certification::ApplicationController < Admin::ApplicationController
+  # The hardware review views (queue + show) reference these path helpers. The
+  # global dash and the funding/ship verdict controllers use the global routes;
+  # the per-mission dash overrides them (see Admin::Missions::HardwareReviews).
+  helper_method :hardware_review_path, :hardware_queue_path, :hardware_next_path,
+                :hardware_queue_title, :hardware_back_link
+
+  private
+
+  def hardware_review_path(project)
+    admin_certification_hardware_review_path(project)
+  end
+
+  def hardware_queue_path(stage)
+    stage.to_s == "build" ? build_admin_certification_hardware_reviews_path : design_admin_certification_hardware_reviews_path
+  end
+
+  def hardware_next_path(stage:, skip: nil)
+    next_admin_certification_hardware_reviews_path(stage: stage, skip: skip)
+  end
+
+  def hardware_queue_title(design)
+    "#{design ? 'Design' : 'Build'} review queue"
+  end
+
+  def hardware_back_link
+    { label: "← back to admin", path: admin_root_path }
+  end
+
+  # Hardware review lives in two places: the global dash for non-mission
+  # hardware, and a per-mission dash for hardware-mission projects. Verdicts and
+  # claims return the reviewer to whichever one the project belongs to.
+  def hardware_review_path_for(project)
+    mission = project.current_mission
+    if mission&.hardware?
+      admin_mission_hardware_review_path(mission.slug, project)
+    else
+      admin_certification_hardware_review_path(project)
+    end
+  end
+
+  def hardware_review_next_path_for(project, stage)
+    mission = project.current_mission
+    if mission&.hardware?
+      next_admin_mission_hardware_reviews_path(mission.slug, stage: stage)
+    else
+      next_admin_certification_hardware_reviews_path(stage: stage)
+    end
+  end
 end

--- a/app/controllers/admin/certification/funding_requests/claims_controller.rb
+++ b/app/controllers/admin/certification/funding_requests/claims_controller.rb
@@ -33,6 +33,6 @@ class Admin::Certification::FundingRequests::ClaimsController < Admin::Certifica
   end
 
   def hardware_review_path
-    admin_certification_hardware_review_path(@funding_request.project_id)
+    hardware_review_path_for(@funding_request.project)
   end
 end

--- a/app/controllers/admin/certification/funding_requests_controller.rb
+++ b/app/controllers/admin/certification/funding_requests_controller.rb
@@ -11,7 +11,7 @@ class Admin::Certification::FundingRequestsController < Admin::Certification::Ap
       notice = "#{verb} funding for “#{@funding_request.project.title}.” That's #{count} reviewed today. Keep going!"
       # Straight on to the next design review; `next` claims it, and falls back
       # to the queue when there's nothing left.
-      redirect_to next_admin_certification_hardware_reviews_path(stage: "design"), notice: notice
+      redirect_to hardware_review_next_path_for(@funding_request.project, "design"), notice: notice
     else
       load_hardware_review_context
       render "admin/certification/hardware_reviews/show", status: :unprocessable_entity

--- a/app/controllers/admin/certification/hardware_reviews_controller.rb
+++ b/app/controllers/admin/certification/hardware_reviews_controller.rb
@@ -1,20 +1,19 @@
 # frozen_string_literal: true
 
-# Hardware review queues and project page. Design funding and build
-# certification are genuinely different jobs, with different evidence and a
-# different decision, so they get one queue each rather than a merged list with
-# a type column. Mutations still go through the existing funding/ship endpoints
-# so PaperTrail remains attached to the underlying record.
+# The global hardware review queue: design funding + build certification for
+# hardware projects that are NOT attached to a hardware mission. Mission-attached
+# hardware is reviewed by that mission's own team (Admin::Missions::HardwareReviews).
+# Mutations still go through the funding/ship endpoints so PaperTrail stays attached.
 class Admin::Certification::HardwareReviewsController < Admin::Certification::ApplicationController
+  include HardwareReviewQueue
+
   before_action -> { head :not_found unless Flipper.enabled?(:hardware_flow, current_user) }
   before_action :set_project, only: [ :show ]
   before_action -> { head :not_found unless @project.hardware? }, only: [ :show ]
-  before_action :set_body_class
 
-  # GET /admin/certification/hardware
-  # Kept so older links land somewhere sensible.
+  # GET /admin/certification/hardware - kept so older links land somewhere sensible.
   def index
-    authorize Project, policy_class: Admin::Certification::HardwareReviewPolicy
+    authorize_hardware_queue
     # Only the queue's own filters carry over; splatting raw query params would
     # let reserved url_for keys (host, script_name, ...) retarget the redirect.
     redirect_to design_admin_certification_hardware_reviews_path(
@@ -22,348 +21,26 @@ class Admin::Certification::HardwareReviewsController < Admin::Certification::Ap
     )
   end
 
-  # GET /admin/certification/hardware/design
-  def design
-    authorize Project, policy_class: Admin::Certification::HardwareReviewPolicy
-    load_queue(:design)
-    render :queue
-  end
-
-  # GET /admin/certification/hardware/build
-  def build
-    authorize Project, policy_class: Admin::Certification::HardwareReviewPolicy
-    load_queue(:build)
-    render :queue
-  end
-
-  # GET /admin/certification/hardware/next?stage=design|build
-  # Stays within the queue the reviewer started from, so "Start reviewing" on the
-  # design queue never hands them a build certification.
-  def next
-    authorize Project, policy_class: Admin::Certification::HardwareReviewPolicy
-
-    stage = params[:stage].presence_in(%w[design build]) || "design"
-    skip = parse_skip_tokens
-    candidate = next_candidate(skip, stage)
-    if candidate.nil?
-      redirect_to queue_path_for(stage), notice: "#{stage.capitalize} queue is empty." and return
-    end
-
-    claimed = claim_candidate(candidate)
-    if claimed
-      redirect_to admin_certification_hardware_review_path(claimed.project_id)
-    else
-      redirect_to next_admin_certification_hardware_reviews_path(
-        stage: stage, skip: (skip[:tokens] + [ candidate[:token] ]).join(",")
-      )
-    end
-  end
-
-  # GET /admin/certification/hardware/:project_id
-  def show
-    authorize @project, policy_class: Admin::Certification::HardwareReviewPolicy
-
-    load_review_context
-  end
-
   private
 
-  # One stage's queue: its own rows, its own counts. Nothing about the other
-  # stage leaks in except the tab count, so the two read as separate queues.
-  def load_queue(stage)
-    @stage = stage.to_s
-    @status = params[:status].presence_in(%w[pending approved returned all]) || "pending"
-    @sort = params[:sort] == "newest" ? "newest" : "oldest"
-    @search = params[:search].to_s.strip
-    @from = parse_date(params[:from])
-    @to = parse_date(params[:to])
-    @lb_period = params[:lb].presence_in(%w[daily weekly alltime]) || "daily"
-
-    @review_items = sort_review_items(queue_items(@stage))
-    @hackpad_project_ids = hackpad_project_ids(@review_items.map { |item| item[:project].id })
-    @stats = stage_stats(@stage)
-    @tab_counts = {
-      "design" => stage_list_scope("design").pending.count,
-      "build" => stage_list_scope("build").pending.count
-    }
-    @leaderboards = {
-      "daily" => hardware_leaderboard(:daily),
-      "weekly" => hardware_leaderboard(:weekly),
-      "alltime" => hardware_leaderboard(:alltime)
-    }
-    @my_stats = my_hardware_stats
+  # Hardware projects not attached to a hardware mission.
+  def reviewable_projects
+    Project.where.not(hardware_stage: nil).where.not(id: hardware_mission_project_ids)
   end
 
-  # The reviewer's own numbers, scoped to hardware. The site-wide My Stats page
-  # counts Certification::Ship only, so a design reviewer shows up there as
-  # having done nothing even though their payout balance includes the work.
-  def my_hardware_stats
-    hardware = Project.where.not(hardware_stage: nil)
-    design = ::Certification::FundingRequest.where(reviewer: current_user, project: hardware).where.not(status: :pending)
-    build = ::Certification::Ship.where(reviewer: current_user, project: hardware).where.not(status: :pending)
-    today = Time.current.beginning_of_day
-
-    {
-      design: decision_tally(design),
-      build: decision_tally(build),
-      stardust: design.sum(:stardust_earned).to_f + build.sum(:stardust_earned).to_f,
-      today: design.where(decided_at: today..).count + build.where(decided_at: today..).count
-    }
+  def hardware_mission_project_ids
+    Project::MissionAttachment.active.joins(:mission).where(missions: { hardware: true }).select(:project_id)
   end
 
-  def decision_tally(scope)
-    by_status = scope.group(:status).count
-    approved = by_status["approved"].to_i
-    returned = by_status["returned"].to_i
-    total = approved + returned
-
-    {
-      total: total,
-      approved: approved,
-      returned: returned,
-      approval_rate: total.zero? ? nil : (approved * 100.0 / total).round
-    }
+  def authorize_hardware_queue
+    authorize Project, policy_class: Admin::Certification::HardwareReviewPolicy
   end
 
-  def stage_model(stage)
-    stage.to_s == "design" ? ::Certification::FundingRequest : ::Certification::Ship
-  end
-
-  def stage_list_scope(stage)
-    stage.to_s == "design" ? hardware_funding_list_scope : hardware_ship_list_scope
-  end
-
-  def queue_items(stage)
-    scope = apply_queue_filters(stage_list_scope(stage), stage_model(stage))
-
-    if stage == "design"
-      scope.includes(:reviewer, project: { memberships: :user }).map do |request|
-        review_item(:funding, request, request.project, request.owner, request.created_at)
-      end
-    else
-      scope.includes(:reviewer, :post_ship_event, project: { memberships: :user }).map do |ship|
-        review_item(:ship, ship, ship.project, ship.owner, ship.created_at)
-      end
-    end
+  def authorize_hardware_review(project)
+    authorize project, policy_class: Admin::Certification::HardwareReviewPolicy
   end
 
   def set_project
     @project = Project.find(params[:project_id])
-  end
-
-  def review_owner
-    @review_owner ||= @project.memberships.owner.first&.user
-  end
-
-  def load_review_context
-    @funding_request = @project.latest_funding_request
-    @ship = @project.ship_reviews.order(created_at: :desc).first
-    @owner = review_owner
-    @active_review =
-      if @funding_request&.pending?
-        @funding_request
-      elsif @ship&.pending?
-        @ship
-      end
-    @active_review_type =
-      case @active_review
-      when ::Certification::FundingRequest then :funding
-      when ::Certification::Ship then :ship
-      end
-    @past_reviews = past_reviews
-    @lapse_timelapses = lapse_timelapses_for_review
-    @lookout_recordings = lookout_recordings_for_review
-  end
-
-  # Every decided funding request and ship for this project, newest first, so a
-  # reviewer sees the full history and any prior feedback under "More context".
-  # The active (pending) review is left out - it's the thing being decided.
-  def past_reviews
-    reviews = @project.certification_funding_requests.includes(:reviewer).to_a +
-              @project.ship_reviews.includes(:reviewer).to_a
-    reviews
-      .reject { |review| review.pending? || review == @active_review }
-      .sort_by(&:created_at)
-      .reverse
-  end
-
-  def hardware_funding_scope
-    ::Certification::FundingRequest.available_for(current_user)
-      .joins(:project)
-      .where.not(projects: { hardware_stage: nil })
-  end
-
-  def hardware_ship_scope
-    ::Certification::Ship.available_for(current_user)
-      .joins(:project)
-      .where.not(projects: { hardware_stage: nil })
-  end
-
-  def hardware_funding_list_scope
-    ::Certification::FundingRequest.for_reviewer(current_user)
-      .joins(:project)
-      .where.not(projects: { hardware_stage: nil })
-  end
-
-  def hardware_ship_list_scope
-    ::Certification::Ship.for_reviewer(current_user)
-      .joins(:project)
-      .where.not(projects: { hardware_stage: nil })
-  end
-
-  def review_item(type, record, project, owner, submitted_at)
-    {
-      type: type,
-      stage: type == :funding ? "design" : "build",
-      stage_label: type == :funding ? "Design" : "Build",
-      record: record,
-      project: project,
-      owner: owner,
-      submitted_at: submitted_at,
-      token: "#{type}:#{record.id}"
-    }
-  end
-
-  # Of the given project ids, those whose active mission is Hackpad — so the
-  # queue can flag them with a pill without an N+1 of Project#current_mission
-  # per row. Returns a Set for O(1) lookup in the view.
-  def hackpad_project_ids(project_ids)
-    return Set.new if project_ids.empty?
-
-    Project::MissionAttachment.active
-      .joins(:mission)
-      .where(missions: { slug: "hackpad" }, project_id: project_ids)
-      .pluck(:project_id)
-      .to_set
-  end
-
-  # Only what a reviewer working this queue can act on: how much is waiting, how
-  # stale the worst of it is, and whether today is keeping up with intake.
-  def stage_stats(stage)
-    scope = stage_list_scope(stage)
-    model = stage_model(stage)
-    sla_days = model::SLA_DAYS
-    today = Time.current.beginning_of_day
-    oldest = scope.pending.order(:created_at).first
-
-    {
-      pending: scope.pending.count,
-      oldest_pending: oldest && review_item(
-        stage == "design" ? :funding : :ship, oldest, oldest.project, oldest.owner, oldest.created_at
-      ),
-      overdue_pending: scope.pending.where("#{model.table_name}.created_at < ?", Time.current - sla_days.days).count,
-      sla_days: sla_days,
-      decisions_today: scope.where.not(status: :pending).where(decided_at: today..).count,
-      new_today: scope.where(created_at: today..).count
-    }
-  end
-
-  def apply_queue_filters(scope, model)
-    scope = scope.where(status: @status) unless @status == "all"
-    scope = scope.where("#{model.table_name}.created_at >= ?", @from.beginning_of_day) if @from
-    scope = scope.where("#{model.table_name}.created_at <= ?", @to.end_of_day) if @to
-    return scope if @search.blank?
-
-    if @search.match?(/\A\d+\z/)
-      scope.where("#{model.table_name}.id = :id OR projects.title ILIKE :q",
-                  id: @search.to_i, q: "%#{@search}%")
-    else
-      scope.where("projects.title ILIKE ?", "%#{@search}%")
-    end
-  end
-
-  def sort_review_items(items)
-    sorted = items.sort_by { |item| item[:submitted_at] || Time.zone.at(0) }
-    @sort == "newest" ? sorted.reverse : sorted
-  end
-
-  def hardware_leaderboard(period, now: Time.current, limit: 10)
-    rows = Hash.new(0)
-    [ ::Certification::FundingRequest, ::Certification::Ship ].each do |model|
-      scope = model.joins(:reviewer)
-        .where.not(reviewer_id: nil)
-        .where.not(status: :pending)
-        .where(project_id: Project.where.not(hardware_stage: nil))
-      case period.to_sym
-      when :daily then scope = scope.where(decided_at: now.beginning_of_day..)
-      when :weekly then scope = scope.where(decided_at: now.beginning_of_week..)
-      end
-      scope.group("users.display_name").count.each do |name, count|
-        rows[name] += count
-      end
-    end
-    rows.sort_by { |name, count| [ -count, name ] }.first(limit).map { |name, count| { name: name, count: count } }
-  end
-
-  def parse_date(value)
-    Date.parse(value.to_s)
-  rescue ArgumentError, TypeError
-    nil
-  end
-
-  def parse_skip_tokens
-    tokens = params[:skip].to_s.split(",").map(&:strip).reject(&:blank?).uniq
-    {
-      tokens: tokens,
-      funding_ids: tokens.filter_map { |token| token.delete_prefix("funding:").to_i if token.start_with?("funding:") },
-      ship_ids: tokens.filter_map { |token| token.delete_prefix("ship:").to_i if token.start_with?("ship:") }
-    }
-  end
-
-  def next_candidate(skip, stage)
-    if stage == "design"
-      scope = hardware_funding_scope
-      scope = scope.where.not(id: skip[:funding_ids]) if skip[:funding_ids].any?
-      record = scope.order(claim_order_sql(::Certification::FundingRequest), :created_at).first
-      record && review_item(:funding, record, record.project, record.owner, record.created_at)
-    else
-      scope = hardware_ship_scope
-      scope = scope.where.not(id: skip[:ship_ids]) if skip[:ship_ids].any?
-      record = scope.order(claim_order_sql(::Certification::Ship), :created_at).first
-      record && review_item(:ship, record, record.project, record.owner, record.created_at)
-    end
-  end
-
-  def queue_path_for(stage)
-    stage == "build" ? build_admin_certification_hardware_reviews_path : design_admin_certification_hardware_reviews_path
-  end
-  helper_method :queue_path_for
-
-  def claim_candidate(candidate)
-    case candidate[:type]
-    when :funding
-      ::Certification::FundingRequest.atomic_claim!(candidate[:record].id, current_user)
-    when :ship
-      ::Certification::Ship.atomic_claim!(candidate[:record].id, current_user)
-    end
-  end
-
-  def claim_order_sql(model)
-    Arel.sql(model.sanitize_sql_array([ "CASE WHEN reviewer_id = ? THEN 0 ELSE 1 END", current_user.id ]))
-  end
-
-  # Provider URLs expire after ~1h, so a short cache keyed by project kills the
-  # per-render HTTP fan-out without staling them.
-  RECORDINGS_CACHE_TTL = 1.minute
-
-  def lapse_timelapses_for_review
-    Rails.cache.fetch([ "hardware_review_recordings", "lapse", @project.id ], expires_in: RECORDINGS_CACHE_TTL) do
-      LapseService.timelapses_for_project(
-        hackatime_user_id: review_owner&.hackatime_identity&.uid,
-        project_keys: @project.hackatime_keys
-      )
-    end
-  end
-
-  def lookout_recordings_for_review
-    Rails.cache.fetch([ "hardware_review_recordings", "lookout", @project.id ], expires_in: RECORDINGS_CACHE_TTL) do
-      LookoutService.recordings_for_project(@project)
-    end
-  end
-
-  # The .app-layout wrapper reserves the sidebar gutter itself; this body class
-  # zeroes the body's own sidebar margin so the two don't stack into a huge gap.
-  def set_body_class
-    @body_class = "app-layout-page"
   end
 end

--- a/app/controllers/admin/certification/ships/claims_controller.rb
+++ b/app/controllers/admin/certification/ships/claims_controller.rb
@@ -39,6 +39,6 @@ class Admin::Certification::Ships::ClaimsController < Admin::Certification::Appl
   end
 
   def hardware_review_path
-    admin_certification_hardware_review_path(@ship.project_id)
+    hardware_review_path_for(@ship.project)
   end
 end

--- a/app/controllers/admin/certification/ships_controller.rb
+++ b/app/controllers/admin/certification/ships_controller.rb
@@ -138,7 +138,7 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
       if params[:redirect_to_hardware].present?
         # Straight on to the next build review; `next` claims it, and falls back
         # to the queue when there's nothing left.
-        redirect_to next_admin_certification_hardware_reviews_path(stage: "build"), notice: notice
+        redirect_to hardware_review_next_path_for(@ship.project, "build"), notice: notice
       else
         redirect_to admin_certification_ships_path, notice: notice
       end
@@ -191,7 +191,7 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
 
   def ship_redirect_path
     if params[:redirect_to_hardware].present?
-      admin_certification_hardware_review_path(@ship.project_id)
+      hardware_review_path_for(@ship.project)
     else
       admin_certification_ship_path(@ship)
     end

--- a/app/controllers/admin/missions/hardware_reviews_controller.rb
+++ b/app/controllers/admin/missions/hardware_reviews_controller.rb
@@ -1,0 +1,65 @@
+module Admin
+  module Missions
+    # A hardware mission's own two-stage review dash (design funding + build
+    # certification), reviewed by that mission's team (per-mission reviewers,
+    # global mission_reviewers, admins). Shares the queue machinery with the
+    # global hardware dash via HardwareReviewQueue; only the covered projects,
+    # authorization, and route helpers differ.
+    class HardwareReviewsController < BaseController
+      include HardwareReviewQueue
+
+      skip_before_action :authorize_mission_management
+      before_action -> { head :not_found unless Flipper.enabled?(:hardware_flow, current_user) }
+      before_action :set_project, only: [ :show ]
+
+      def index
+        authorize_hardware_queue
+        redirect_to design_admin_mission_hardware_reviews_path(@mission.slug)
+      end
+
+      private
+
+      # The mission's own hardware projects (active attachment, hardware stage set).
+      def reviewable_projects
+        ::Project.where.not(hardware_stage: nil)
+                 .where(id: ::Project::MissionAttachment.active.where(mission: @mission).select(:project_id))
+      end
+
+      def authorize_hardware_queue
+        authorize @mission, :review?
+      end
+
+      def authorize_hardware_review(_project)
+        authorize @mission, :review?
+      end
+
+      def hardware_review_path(project)
+        admin_mission_hardware_review_path(@mission.slug, project)
+      end
+
+      def hardware_queue_path(stage)
+        if stage.to_s == "build"
+          build_admin_mission_hardware_reviews_path(@mission.slug)
+        else
+          design_admin_mission_hardware_reviews_path(@mission.slug)
+        end
+      end
+
+      def hardware_next_path(stage:, skip: nil)
+        next_admin_mission_hardware_reviews_path(@mission.slug, stage: stage, skip: skip)
+      end
+
+      def hardware_queue_title(design)
+        "#{@mission.name} #{design ? 'design' : 'build'} review queue"
+      end
+
+      def hardware_back_link
+        { label: "← back to mission", path: admin_mission_reviews_path }
+      end
+
+      def set_project
+        @project = ::Project.find(params[:project_id])
+      end
+    end
+  end
+end

--- a/app/controllers/admin/missions/prizes_controller.rb
+++ b/app/controllers/admin/missions/prizes_controller.rb
@@ -32,7 +32,7 @@ module Admin
       end
 
       def prize_params
-        params.require(:mission_prize).permit(:shop_item_id, :position)
+        params.require(:mission_prize).permit(:shop_item_id, :position, :category)
       end
 
       def next_position

--- a/app/controllers/admin/missions/submissions_controller.rb
+++ b/app/controllers/admin/missions/submissions_controller.rb
@@ -6,6 +6,10 @@ module Admin
       skip_before_action :authorize_mission_management
       before_action :release_other_claims, only: [ :next, :claim ]
       before_action :set_submission, only: [ :show, :update, :claim, :undo ]
+      # Hardware missions are reviewed on their own hardware dash (split
+      # design/build), never the software submission queue.
+      before_action :redirect_hardware_mission, only: [ :index, :next ]
+      before_action :redirect_hardware_submission, only: [ :show, :update, :claim, :undo ]
       before_action :set_body_class
 
       def overview
@@ -26,12 +30,17 @@ module Admin
                            .group(:mission_id)
                            .minimum(Arel.sql("COALESCE(pending_at, created_at)"))
 
+        # Hardware missions are reviewed as funding requests + ship certs, not
+        # submissions (which the build-review collapse auto-approves), so their
+        # pending count comes from those queues instead.
+        hardware_pending = hardware_pending_counts(@missions.select(&:hardware?))
+
         @mission_stats = @missions.map do |m|
-          {
-            mission: m,
-            pending: pending_counts[m.id] || 0,
-            oldest: oldest_pending[m.id]
-          }
+          if m.hardware?
+            { mission: m, pending: hardware_pending[m.id] || 0, oldest: nil }
+          else
+            { mission: m, pending: pending_counts[m.id] || 0, oldest: oldest_pending[m.id] }
+          end
         end.sort_by { |s| -s[:pending] }
       end
 
@@ -51,6 +60,7 @@ module Admin
 
         scope = policy_scope(Mission::Submission)
                   .includes(:reviewed_by, ship_event: { post: [ :user, :project ] })
+                  .where.not(mission_id: Mission.where(hardware: true).select(:id))
         scope = scope.where(mission_id: @mission.id) if @mission
 
         scope = apply_filters(scope)
@@ -97,8 +107,7 @@ module Admin
           if new_status == "approved"
             @submission.update!(reviewed_by: current_user, reviewed_at: Time.current, rejection_message: nil)
             @submission.approve!
-            grant_mission_achievement_if_configured
-            grant_fixed_stardust_if_configured
+            @submission.grant_rewards!(reviewer_id: current_user.id)
           else
             @submission.update!(reviewed_by: current_user, reviewed_at: Time.current, rejection_message: feedback)
             @submission.reject!
@@ -120,10 +129,15 @@ module Admin
         end
         skip_ids = parse_skip_ids
 
+        # Hardware missions have their own dash, so the software "next" pool is
+        # always software-only.
         missions_filter = if @mission
           @mission
-        elsif !global_reviewer?
-          current_user.mission_memberships.select(:mission_id)
+        elsif global_reviewer?
+          Mission.where(hardware: false).select(:id)
+        else
+          current_user.mission_memberships.joins(:mission)
+                      .where(missions: { hardware: false }).select(:mission_id)
         end
         candidate = Mission::Submission.next_eligible(current_user, missions: missions_filter, skip_ids: skip_ids)
         unless candidate
@@ -156,14 +170,48 @@ module Admin
         Mission::Submission.transaction do
           @submission.update!(reviewed_by: nil, reviewed_at: nil, rejection_message: nil)
           @submission.undo!
-          reverse_fixed_stardust_if_granted
-          revoke_mission_achievement_if_granted
+          @submission.reverse_rewards!(reviewer_id: current_user.id)
         end
         redirect_to admin_mission_submission_path(mission_slug, @submission),
                     notice: "Submission moved back to pending."
       end
 
       private
+
+      def redirect_hardware_mission
+        return unless @mission&.hardware?
+        redirect_to design_admin_mission_hardware_reviews_path(@mission.slug)
+      end
+
+      def redirect_hardware_submission
+        return unless @submission&.mission&.hardware?
+        project = @submission.ship_event&.post&.project
+        if project
+          redirect_to admin_mission_hardware_review_path(@submission.mission.slug, project)
+        else
+          redirect_to admin_mission_reviews_path
+        end
+      end
+
+      # Pending hardware review work (funding requests + ship certs) per mission,
+      # keyed by mission id, for the review overview.
+      def hardware_pending_counts(missions)
+        return {} if missions.empty?
+
+        project_to_mission = ::Project::MissionAttachment.active
+                               .where(mission_id: missions.map(&:id))
+                               .pluck(:project_id, :mission_id).to_h
+        return {} if project_to_mission.empty?
+
+        project_ids = project_to_mission.keys
+        counts = Hash.new(0)
+        [ ::Certification::FundingRequest, ::Certification::Ship ].each do |model|
+          model.where(project_id: project_ids, status: :pending).pluck(:project_id).each do |pid|
+            counts[project_to_mission[pid]] += 1
+          end
+        end
+        counts
+      end
 
       # Path segment for redirects: the mission's slug, or "all" for the
       # cross-mission queue.
@@ -234,57 +282,6 @@ module Admin
         scope
       end
 
-      def grant_mission_achievement_if_configured
-        mission = @submission.mission
-        return if mission.achievement_slug.blank?
-        builder = @submission.ship_event&.post&.user
-        return unless builder
-
-        return if builder.achievements.exists?(achievement_slug: mission.achievement_slug)
-
-        builder.achievements.create!(
-          achievement_slug: mission.achievement_slug,
-          earned_at: Time.current
-        )
-      end
-
-      def revoke_mission_achievement_if_granted
-        mission = @submission.mission
-        return if mission.achievement_slug.blank?
-        builder = @submission.ship_event&.post&.user
-        return unless builder
-
-        builder.achievements.where(achievement_slug: mission.achievement_slug).destroy_all
-      end
-
-      def grant_fixed_stardust_if_configured
-        mission = @submission.mission
-        return unless mission.fixed_stardust_payout&.positive?
-        return unless @submission.ledger_entries.sum(:amount).zero?
-        builder = @submission.ship_event&.post&.user
-        return unless builder
-
-        @submission.ledger_entries.create!(
-          user: builder,
-          amount: mission.fixed_stardust_payout,
-          reason: "Mission: #{mission.name}",
-          created_by: "mission_submission:#{@submission.id} (#{current_user.id})"
-        )
-      end
-
-      def reverse_fixed_stardust_if_granted
-        net = @submission.ledger_entries.sum(:amount)
-        return unless net.positive?
-        builder = @submission.ship_event&.post&.user
-        return unless builder
-
-        @submission.ledger_entries.create!(
-          user: builder,
-          amount: -net,
-          reason: "Mission reversal: #{@submission.mission.name}",
-          created_by: "mission_submission:#{@submission.id} undo (#{current_user.id})"
-        )
-      end
 
       def notify_builder(status)
         builder = @submission.ship_event&.post&.user

--- a/app/controllers/concerns/hardware_review_queue.rb
+++ b/app/controllers/concerns/hardware_review_queue.rb
@@ -1,0 +1,336 @@
+# frozen_string_literal: true
+
+# The two-stage hardware review dash (design funding + build certification),
+# shared between the global reviewer queue (Admin::Certification::HardwareReviews)
+# and a mission's own queue (Admin::Missions::HardwareReviews). The host controller
+# supplies which projects it covers, how to authorize, and the route helpers; the
+# queue building, stats, leaderboards and review context live here.
+#
+# Host controllers must implement:
+#   reviewable_projects            -> a Project relation (the hardware projects this dash reviews)
+#   authorize_hardware_queue       -> per-action auth for the list/next actions
+#   authorize_hardware_review(project)
+#   hardware_review_path(project)
+#   hardware_queue_path(stage)     -> "design" | "build"
+#   hardware_next_path(stage:, skip: nil)
+module HardwareReviewQueue
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_body_class
+    helper_method :hardware_review_path, :hardware_queue_path, :hardware_next_path,
+                  :hardware_queue_title, :hardware_back_link
+  end
+
+  def design
+    authorize_hardware_queue
+    load_queue(:design)
+    render "admin/certification/hardware_reviews/queue"
+  end
+
+  def build
+    authorize_hardware_queue
+    load_queue(:build)
+    render "admin/certification/hardware_reviews/queue"
+  end
+
+  # Stays within the queue the reviewer started from, so "Start reviewing" on the
+  # design queue never hands them a build certification.
+  def next
+    authorize_hardware_queue
+
+    stage = params[:stage].presence_in(%w[design build]) || "design"
+    skip = parse_skip_tokens
+    candidate = next_candidate(skip, stage)
+    if candidate.nil?
+      redirect_to hardware_queue_path(stage), notice: "#{stage.capitalize} queue is empty." and return
+    end
+
+    claimed = claim_candidate(candidate)
+    if claimed
+      redirect_to hardware_review_path(claimed.project_id)
+    else
+      redirect_to hardware_next_path(stage: stage, skip: (skip[:tokens] + [ candidate[:token] ]).join(","))
+    end
+  end
+
+  def show
+    authorize_hardware_review(@project)
+    load_review_context
+    render "admin/certification/hardware_reviews/show"
+  end
+
+  private
+
+  def load_queue(stage)
+    @stage = stage.to_s
+    @status = params[:status].presence_in(%w[pending approved returned all]) || "pending"
+    @sort = params[:sort] == "newest" ? "newest" : "oldest"
+    @search = params[:search].to_s.strip
+    @from = parse_date(params[:from])
+    @to = parse_date(params[:to])
+    @lb_period = params[:lb].presence_in(%w[daily weekly alltime]) || "daily"
+
+    @review_items = sort_review_items(queue_items(@stage))
+    @hackpad_project_ids = hackpad_project_ids(@review_items.map { |item| item[:project].id })
+    @stats = stage_stats(@stage)
+    @tab_counts = {
+      "design" => stage_list_scope("design").pending.count,
+      "build" => stage_list_scope("build").pending.count
+    }
+    @leaderboards = {
+      "daily" => hardware_leaderboard(:daily),
+      "weekly" => hardware_leaderboard(:weekly),
+      "alltime" => hardware_leaderboard(:alltime)
+    }
+    @my_stats = my_hardware_stats
+  end
+
+  # The reviewer's own numbers, scoped to the projects this dash covers.
+  def my_hardware_stats
+    design = ::Certification::FundingRequest.where(reviewer: current_user, project: reviewable_projects).where.not(status: :pending)
+    build = ::Certification::Ship.where(reviewer: current_user, project: reviewable_projects).where.not(status: :pending)
+    today = Time.current.beginning_of_day
+
+    {
+      design: decision_tally(design),
+      build: decision_tally(build),
+      stardust: design.sum(:stardust_earned).to_f + build.sum(:stardust_earned).to_f,
+      today: design.where(decided_at: today..).count + build.where(decided_at: today..).count
+    }
+  end
+
+  def decision_tally(scope)
+    by_status = scope.group(:status).count
+    approved = by_status["approved"].to_i
+    returned = by_status["returned"].to_i
+    total = approved + returned
+
+    {
+      total: total,
+      approved: approved,
+      returned: returned,
+      approval_rate: total.zero? ? nil : (approved * 100.0 / total).round
+    }
+  end
+
+  def stage_model(stage)
+    stage.to_s == "design" ? ::Certification::FundingRequest : ::Certification::Ship
+  end
+
+  def stage_list_scope(stage)
+    stage.to_s == "design" ? hardware_funding_list_scope : hardware_ship_list_scope
+  end
+
+  def queue_items(stage)
+    scope = apply_queue_filters(stage_list_scope(stage), stage_model(stage))
+
+    if stage == "design"
+      scope.includes(:reviewer, project: { memberships: :user }).map do |request|
+        review_item(:funding, request, request.project, request.owner, request.created_at)
+      end
+    else
+      scope.includes(:reviewer, :post_ship_event, project: { memberships: :user }).map do |ship|
+        review_item(:ship, ship, ship.project, ship.owner, ship.created_at)
+      end
+    end
+  end
+
+  def review_owner
+    @review_owner ||= @project.memberships.owner.first&.user
+  end
+
+  def load_review_context
+    @funding_request = @project.latest_funding_request
+    @ship = @project.ship_reviews.order(created_at: :desc).first
+    @owner = review_owner
+    @active_review =
+      if @funding_request&.pending?
+        @funding_request
+      elsif @ship&.pending?
+        @ship
+      end
+    @active_review_type =
+      case @active_review
+      when ::Certification::FundingRequest then :funding
+      when ::Certification::Ship then :ship
+      end
+    @past_reviews = past_reviews
+    @lapse_timelapses = lapse_timelapses_for_review
+    @lookout_recordings = lookout_recordings_for_review
+  end
+
+  # Every decided funding request and ship for this project, newest first. The
+  # active (pending) review is left out - it's the thing being decided.
+  def past_reviews
+    reviews = @project.certification_funding_requests.includes(:reviewer).to_a +
+              @project.ship_reviews.includes(:reviewer).to_a
+    reviews
+      .reject { |review| review.pending? || review == @active_review }
+      .sort_by(&:created_at)
+      .reverse
+  end
+
+  def hardware_funding_scope
+    ::Certification::FundingRequest.available_for(current_user).joins(:project).where(project: reviewable_projects)
+  end
+
+  def hardware_ship_scope
+    ::Certification::Ship.available_for(current_user).joins(:project).where(project: reviewable_projects)
+  end
+
+  def hardware_funding_list_scope
+    ::Certification::FundingRequest.for_reviewer(current_user).joins(:project).where(project: reviewable_projects)
+  end
+
+  def hardware_ship_list_scope
+    ::Certification::Ship.for_reviewer(current_user).joins(:project).where(project: reviewable_projects)
+  end
+
+  def review_item(type, record, project, owner, submitted_at)
+    {
+      type: type,
+      stage: type == :funding ? "design" : "build",
+      stage_label: type == :funding ? "Design" : "Build",
+      record: record,
+      project: project,
+      owner: owner,
+      submitted_at: submitted_at,
+      token: "#{type}:#{record.id}"
+    }
+  end
+
+  # Of the given project ids, those whose active mission is Hackpad - so the
+  # queue can flag them with a pill without an N+1. Returns a Set.
+  def hackpad_project_ids(project_ids)
+    return Set.new if project_ids.empty?
+
+    Project::MissionAttachment.active
+      .joins(:mission)
+      .where(missions: { slug: "hackpad" }, project_id: project_ids)
+      .pluck(:project_id)
+      .to_set
+  end
+
+  def stage_stats(stage)
+    scope = stage_list_scope(stage)
+    model = stage_model(stage)
+    sla_days = model::SLA_DAYS
+    today = Time.current.beginning_of_day
+    oldest = scope.pending.order(:created_at).first
+
+    {
+      pending: scope.pending.count,
+      oldest_pending: oldest && review_item(
+        stage == "design" ? :funding : :ship, oldest, oldest.project, oldest.owner, oldest.created_at
+      ),
+      overdue_pending: scope.pending.where("#{model.table_name}.created_at < ?", Time.current - sla_days.days).count,
+      sla_days: sla_days,
+      decisions_today: scope.where.not(status: :pending).where(decided_at: today..).count,
+      new_today: scope.where(created_at: today..).count
+    }
+  end
+
+  def apply_queue_filters(scope, model)
+    scope = scope.where(status: @status) unless @status == "all"
+    scope = scope.where("#{model.table_name}.created_at >= ?", @from.beginning_of_day) if @from
+    scope = scope.where("#{model.table_name}.created_at <= ?", @to.end_of_day) if @to
+    return scope if @search.blank?
+
+    if @search.match?(/\A\d+\z/)
+      scope.where("#{model.table_name}.id = :id OR projects.title ILIKE :q", id: @search.to_i, q: "%#{@search}%")
+    else
+      scope.where("projects.title ILIKE ?", "%#{@search}%")
+    end
+  end
+
+  def sort_review_items(items)
+    sorted = items.sort_by { |item| item[:submitted_at] || Time.zone.at(0) }
+    @sort == "newest" ? sorted.reverse : sorted
+  end
+
+  def hardware_leaderboard(period, now: Time.current, limit: 10)
+    rows = Hash.new(0)
+    [ ::Certification::FundingRequest, ::Certification::Ship ].each do |model|
+      scope = model.joins(:reviewer)
+        .where.not(reviewer_id: nil)
+        .where.not(status: :pending)
+        .where(project: reviewable_projects)
+      case period.to_sym
+      when :daily then scope = scope.where(decided_at: now.beginning_of_day..)
+      when :weekly then scope = scope.where(decided_at: now.beginning_of_week..)
+      end
+      scope.group("users.display_name").count.each do |name, count|
+        rows[name] += count
+      end
+    end
+    rows.sort_by { |name, count| [ -count, name ] }.first(limit).map { |name, count| { name: name, count: count } }
+  end
+
+  def parse_date(value)
+    Date.parse(value.to_s)
+  rescue ArgumentError, TypeError
+    nil
+  end
+
+  def parse_skip_tokens
+    tokens = params[:skip].to_s.split(",").map(&:strip).reject(&:blank?).uniq
+    {
+      tokens: tokens,
+      funding_ids: tokens.filter_map { |token| token.delete_prefix("funding:").to_i if token.start_with?("funding:") },
+      ship_ids: tokens.filter_map { |token| token.delete_prefix("ship:").to_i if token.start_with?("ship:") }
+    }
+  end
+
+  def next_candidate(skip, stage)
+    if stage == "design"
+      scope = hardware_funding_scope
+      scope = scope.where.not(id: skip[:funding_ids]) if skip[:funding_ids].any?
+      record = scope.order(claim_order_sql(::Certification::FundingRequest), :created_at).first
+      record && review_item(:funding, record, record.project, record.owner, record.created_at)
+    else
+      scope = hardware_ship_scope
+      scope = scope.where.not(id: skip[:ship_ids]) if skip[:ship_ids].any?
+      record = scope.order(claim_order_sql(::Certification::Ship), :created_at).first
+      record && review_item(:ship, record, record.project, record.owner, record.created_at)
+    end
+  end
+
+  def claim_candidate(candidate)
+    case candidate[:type]
+    when :funding
+      ::Certification::FundingRequest.atomic_claim!(candidate[:record].id, current_user)
+    when :ship
+      ::Certification::Ship.atomic_claim!(candidate[:record].id, current_user)
+    end
+  end
+
+  def claim_order_sql(model)
+    Arel.sql(model.sanitize_sql_array([ "CASE WHEN reviewer_id = ? THEN 0 ELSE 1 END", current_user.id ]))
+  end
+
+  # Provider URLs expire after ~1h, so a short cache keyed by project kills the
+  # per-render HTTP fan-out without staling them.
+  RECORDINGS_CACHE_TTL = 1.minute
+
+  def lapse_timelapses_for_review
+    Rails.cache.fetch([ "hardware_review_recordings", "lapse", @project.id ], expires_in: RECORDINGS_CACHE_TTL) do
+      LapseService.timelapses_for_project(
+        hackatime_user_id: review_owner&.hackatime_identity&.uid,
+        project_keys: @project.hackatime_keys
+      )
+    end
+  end
+
+  def lookout_recordings_for_review
+    Rails.cache.fetch([ "hardware_review_recordings", "lookout", @project.id ], expires_in: RECORDINGS_CACHE_TTL) do
+      LookoutService.recordings_for_project(@project)
+    end
+  end
+
+  # The .app-layout wrapper reserves the sidebar gutter itself; this body class
+  # zeroes the body's own sidebar margin so the two don't stack into a huge gap.
+  def set_body_class
+    @body_class = "app-layout-page"
+  end
+end

--- a/app/controllers/mission_submissions_controller.rb
+++ b/app/controllers/mission_submissions_controller.rb
@@ -4,7 +4,7 @@ class MissionSubmissionsController < ApplicationController
 
   def redeem
     authorize @submission
-    prizes = @submission.mission.prizes.ordered.includes(:shop_item).to_a
+    prizes = @submission.mission.prizes.after_shipping.ordered.includes(:shop_item).to_a
 
     if prizes.size == 1
       redirect_to shop_item_path(prizes.first.shop_item, mission_submission_id: @submission.id)

--- a/app/controllers/projects/funding_requests_controller.rb
+++ b/app/controllers/projects/funding_requests_controller.rb
@@ -7,12 +7,12 @@ class Projects::FundingRequestsController < ApplicationController
   def create
     authorize @project, :ship?
 
-    @project.certification_funding_requests.create!(
-      user: current_user,
-      complexity_tier: params[:complexity_tier].to_i,
-      requested_amount_cents: params[:requested_amount].to_i * 100,
-      status: :pending
-    )
+    # Kit missions submit no tier/amount; the model defaults them. Only forward
+    # what the form actually sent so a kit request stays valid.
+    funding_request = @project.certification_funding_requests.new(user: current_user, status: :pending)
+    funding_request.complexity_tier = params[:complexity_tier] if params[:complexity_tier].present?
+    funding_request.requested_amount_cents = params[:requested_amount].to_i * 100 if params[:requested_amount].present?
+    funding_request.save!
 
     track_event "funding_requested", { project_id: @project.id, complexity_tier: params[:complexity_tier] }
     redirect_to project_path(@project),

--- a/app/controllers/shop/base_controller.rb
+++ b/app/controllers/shop/base_controller.rb
@@ -69,6 +69,13 @@ class Shop::BaseController < ApplicationController
     }
   end
 
+  # The approval that unlocks a free prize redemption for this item: an
+  # after-ship submission or an after-design funding kit. Returns the gate
+  # record (used as the PrizeRedemption source) or nil.
+  def load_redeemable_gate(shop_item)
+    load_redeemable_submission(shop_item) || load_redeemable_funding_request(shop_item)
+  end
+
   def load_redeemable_submission(shop_item)
     return nil unless current_user
     submission_id = params[:mission_submission_id]
@@ -81,8 +88,27 @@ class Shop::BaseController < ApplicationController
     return nil unless submission.approved?
     return nil unless submission.shop_order_id.nil?
     return nil unless submission.ship_event&.post&.user_id == current_user.id
-    return nil unless submission.mission.prizes.exists?(shop_item_id: shop_item.id)
+    return nil unless submission.mission.prizes.after_shipping.exists?(shop_item_id: shop_item.id)
 
     submission
+  end
+
+  def load_redeemable_funding_request(shop_item)
+    return nil unless current_user
+    funding_request_id = params[:funding_request_id]
+    return nil if funding_request_id.blank?
+
+    funding_request = Certification::FundingRequest
+      .includes(project: [ :memberships, { mission_attachments: :mission } ])
+      .find_by(id: funding_request_id)
+    return nil unless funding_request&.approved?
+    return nil unless funding_request.owner == current_user
+
+    mission = funding_request.project.current_mission
+    return nil unless mission&.prizes&.after_design&.exists?(shop_item_id: shop_item.id)
+    # One design kit per approved request.
+    return nil if Mission::PrizeRedemption.exists?(source: funding_request)
+
+    funding_request
   end
 end

--- a/app/controllers/shop/items_controller.rb
+++ b/app/controllers/shop/items_controller.rb
@@ -20,14 +20,14 @@ class Shop::ItemsController < Shop::BaseController
     authorize :shop
 
     @shop_item = ShopItem.find(params[:id])
-    @mission_submission = load_redeemable_submission(@shop_item)
+    @redeemable = load_redeemable_gate(@shop_item)
 
-    if @mission_submission.nil? && @shop_item.mission_prize_only?
+    if @redeemable.nil? && @shop_item.mission_prize_only?
       redirect_to shop_path, alert: "This item can only be claimed by redeeming a mission prize."
       return
     end
 
-    unless @shop_item.enabled? || @mission_submission.present?
+    unless @shop_item.enabled? || @redeemable.present?
       redirect_to shop_path, alert: "This item cannot be ordered."
       return
     end
@@ -37,7 +37,7 @@ class Shop::ItemsController < Shop::BaseController
       return
     end
 
-    @mission_locked = @mission_submission.nil? && @shop_item.mission_locked_for?(current_user)
+    @mission_locked = @redeemable.nil? && @shop_item.mission_locked_for?(current_user)
     @unlocking_missions = @mission_locked ? @shop_item.unlocking_missions : []
 
     @user_region = user_region

--- a/app/controllers/shop/orders_controller.rb
+++ b/app/controllers/shop/orders_controller.rb
@@ -18,14 +18,14 @@ class Shop::OrdersController < Shop::BaseController
     end
 
     @shop_item = ShopItem.find(params[:shop_item_id])
-    @mission_submission = load_redeemable_submission(@shop_item)
+    @redeemable = load_redeemable_gate(@shop_item)
 
     unless @shop_item.enabled?
       redirect_to shop_path, alert: "This item cannot be ordered."
       return
     end
 
-    if @mission_submission.nil? && @shop_item.mission_prize_only?
+    if @redeemable.nil? && @shop_item.mission_prize_only?
       redirect_to shop_path, alert: "This item can only be claimed by redeeming a mission prize."
       return
     end
@@ -98,7 +98,7 @@ class Shop::OrdersController < Shop::BaseController
         current_user.lock!
         @shop_item.lock! if @shop_item.limited?
 
-        if @mission_submission.nil?
+        if @redeemable.nil?
           user_balance = current_user.balance
           if total_cost > user_balance
             redirect_to shop_item_path(@shop_item), alert: "Insufficient balance. You need #{total_cost} Stardust but only have #{user_balance} Stardust."
@@ -108,20 +108,17 @@ class Shop::OrdersController < Shop::BaseController
 
         @order = current_user.shop_orders.new(
           shop_item: @shop_item,
-          quantity: @mission_submission ? 1 : quantity,
+          quantity: @redeemable ? 1 : quantity,
           frozen_address: selected_address,
-          frozen_modifiers_price: @mission_submission ? 0 : modifiers_total
+          frozen_modifiers_price: @redeemable ? 0 : modifiers_total
         )
-        @order.redeeming_mission_submission = @mission_submission if @mission_submission
+        assign_redemption_gate(@order, @redeemable) if @redeemable
         @order.aasm_state = "pending" if @order.respond_to?(:aasm_state=)
         @order.save!
 
-        if @mission_submission
-          chosen_prize = @mission_submission.mission.prizes.find_by(shop_item_id: @shop_item.id)
-          @mission_submission.update!(shop_order_id: @order.id, chosen_prize_id: chosen_prize&.id)
-        end
+        Mission::PrizeRedemption.record!(shop_order: @order, gate: @redeemable) if @redeemable
 
-        unless @mission_submission
+        unless @redeemable
           @accessories.each do |accessory|
             accessory_order = current_user.shop_orders.new(
               shop_item: accessory,
@@ -195,6 +192,15 @@ class Shop::OrdersController < Shop::BaseController
   end
 
   private
+
+  # The free-price accessor differs by gate; it must be set before save so the
+  # price freezes to 0.
+  def assign_redemption_gate(order, gate)
+    case gate
+    when Mission::Submission           then order.redeeming_mission_submission = gate
+    when Certification::FundingRequest then order.redeeming_funding_request = gate
+    end
+  end
 
   def find_sharable_order
     return nil unless Flipper.enabled?(:sharable_purchase, current_user)

--- a/app/models/certification/funding_request.rb
+++ b/app/models/certification/funding_request.rb
@@ -43,6 +43,11 @@ module Certification
   # ship certifications (Certification::Reviewable). On approval the project
   # switches to the build stage and an HCB card grant is issued for the approved
   # amount, capped by the tier's max.
+  #
+  # When the project's mission hands out a design kit (an after_design prize),
+  # approval delivers that kit for redemption instead of a cash grant: no HCB
+  # grant is issued and the tier/amount fields are vestigial (defaulted, hidden
+  # in the request form).
   class FundingRequest < ApplicationRecord
     self.table_name = "certification_funding_requests"
 
@@ -84,8 +89,11 @@ module Certification
     # Stardust a reviewer earns per completed funding review.
     REVIEW_BOUNTY = 1
 
+    before_validation :default_kit_request_fields, on: :create, if: :awards_design_kit?
+
     validates :complexity_tier, inclusion: { in: TIER_MAX_CENTS.keys }
-    validates :requested_amount_cents, numericality: { only_integer: true, greater_than: 0 }
+    validates :requested_amount_cents,
+              numericality: { only_integer: true, greater_than: 0 }, unless: :awards_design_kit?
     validates :approved_amount_cents,
               numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
     validates :feedback, length: { maximum: 10_000 }, allow_blank: true
@@ -181,6 +189,18 @@ module Certification
       @owner ||= project.memberships.owner.first&.user || user
     end
 
+    # True when the project's active mission delivers a physical kit at design
+    # approval (an after_design prize) rather than a cash grant.
+    def awards_design_kit?
+      project&.current_mission&.prizes&.after_design&.exists? || false
+    end
+
+    # The after-design kit this request can redeem for `shop_item`, if any.
+    # Part of the redemption-gate interface (see Mission::PrizeRedemption.record!).
+    def redeemable_prize_for(shop_item)
+      project&.current_mission&.prizes&.after_design&.find_by(shop_item_id: shop_item.id)
+    end
+
     # Locals for the verdict notification's Slack template.
     def notification_locals
       routes = Rails.application.routes.url_helpers
@@ -193,6 +213,7 @@ module Certification
         project_title: project.title,
         project_url: routes.project_url(project, **url_opts),
         approved: approved?,
+        awards_kit: awards_design_kit?,
         amount_dollars: final_amount_dollars,
         tier_label: tier_label,
         reviewer_name: reviewer&.display_name,
@@ -228,7 +249,7 @@ module Certification
     # retries the next time the request is saved instead of being stranded.
     # issue_hcb_grant! already returns early when a grant exists.
     after_save_commit :notify_owner!, if: -> { saved_change_to_status? && !pending? }
-    after_save_commit :issue_hcb_grant!, if: -> { approved? && hcb_grant_hashid.blank? }
+    after_save_commit :issue_hcb_grant!, if: -> { approved? && hcb_grant_hashid.blank? && !awards_design_kit? }
 
     private
 
@@ -265,6 +286,14 @@ module Certification
 
     def default_approved_amount
       self.approved_amount_cents ||= requested_amount_cents
+    end
+
+    # Kit missions have no cash amount, but the columns are NOT NULL. Seed the
+    # smallest valid tier and a zero amount so the record persists; the form
+    # hides both fields for these requests.
+    def default_kit_request_fields
+      self.complexity_tier ||= TIER_MAX_CENTS.keys.min
+      self.requested_amount_cents ||= 0
     end
 
     def assign_stardust_earned

--- a/app/models/certification/funding_request.rb
+++ b/app/models/certification/funding_request.rb
@@ -195,10 +195,25 @@ module Certification
       project&.current_mission&.prizes&.after_design&.exists? || false
     end
 
+    # True unless a newer funding request has superseded this one (a resubmit
+    # after a return). A superseded request's verdict is inert: it must not
+    # advance the project or issue a grant/kit, so approving the wrong one can't
+    # move the project while a newer request is still live.
+    def latest_for_project?
+      return true unless project
+      !project.certification_funding_requests.where("id > ?", id).exists?
+    end
+
     # The after-design kit this request can redeem for `shop_item`, if any.
     # Part of the redemption-gate interface (see Mission::PrizeRedemption.record!).
     def redeemable_prize_for(shop_item)
       project&.current_mission&.prizes&.after_design&.find_by(shop_item_id: shop_item.id)
+    end
+
+    # The kit shipped when this design is approved (the mission's first
+    # after_design prize), for reviewer-facing copy.
+    def design_kit_shop_item
+      project&.current_mission&.prizes&.after_design&.ordered&.first&.shop_item
     end
 
     # Locals for the verdict notification's Slack template.
@@ -249,7 +264,7 @@ module Certification
     # retries the next time the request is saved instead of being stranded.
     # issue_hcb_grant! already returns early when a grant exists.
     after_save_commit :notify_owner!, if: -> { saved_change_to_status? && !pending? }
-    after_save_commit :issue_hcb_grant!, if: -> { approved? && hcb_grant_hashid.blank? && !awards_design_kit? }
+    after_save_commit :issue_hcb_grant!, if: -> { approved? && hcb_grant_hashid.blank? && !awards_design_kit? && latest_for_project? }
 
     private
 
@@ -312,6 +327,7 @@ module Certification
     # before_save so it's set by the time this runs.
     def apply_verdict_to_project!
       return if pending?
+      return unless latest_for_project?
       project.with_lock do
         case status.to_sym
         when :approved

--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -446,6 +446,7 @@ module Certification
             project.approve! if project.may_approve?
           end
           create_ysws_review_for_ship(ship_event) if ship_event
+          collapse_mission_build_review!(ship_event)
         when :returned
           ship_event&.update!(certification_status: "returned")
           if latest
@@ -454,6 +455,20 @@ module Certification
           end
         end
       end
+    end
+
+    # Hardware missions review the build as one decision: certifying the ship
+    # (just above, which cascades the mission submission to `pending`) also
+    # finalizes that submission, granting the after-ship prize and any
+    # achievement. Software missions keep their separate mission approval.
+    def collapse_mission_build_review!(ship_event)
+      submission = ship_event&.mission_submission
+      return unless submission&.mission&.hardware?
+      return unless submission.may_approve?
+
+      submission.update!(reviewed_by: reviewer, reviewed_at: Time.current, rejection_message: nil)
+      submission.approve!
+      submission.grant_rewards!(reviewer_id: reviewer&.id)
     end
 
     def create_ysws_review_for_ship(ship_event)

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -47,6 +47,7 @@ class Mission < ApplicationRecord
   has_many :memberships, class_name: "Mission::Membership", dependent: :destroy
   has_many :shop_unlocks, class_name: "Mission::ShopUnlock", dependent: :destroy
   has_many :submissions, class_name: "Mission::Submission", dependent: :destroy
+  has_many :prize_redemptions, class_name: "Mission::PrizeRedemption", dependent: :destroy
   has_many :attachments, class_name: "Project::MissionAttachment", dependent: :destroy
   has_many :projects, through: :attachments
   has_many :guide_variants, -> { order(:position, :id) },

--- a/app/models/mission/prize.rb
+++ b/app/models/mission/prize.rb
@@ -3,6 +3,7 @@
 # Table name: mission_prizes
 #
 #  id           :bigint           not null, primary key
+#  category     :integer          default("after_shipping"), not null
 #  deleted_at   :datetime
 #  position     :integer          default(0), not null
 #  created_at   :datetime         not null
@@ -31,6 +32,17 @@ class Mission::Prize < ApplicationRecord
 
   belongs_to :mission, inverse_of: :prizes, counter_cache: true
   belongs_to :shop_item
+  has_many :redemptions, class_name: "Mission::PrizeRedemption", inverse_of: :mission_prize, dependent: :destroy
+
+  # after_shipping is the historical default (redeemed once a ship is approved);
+  # after_design gates a kit on funding/design approval.
+  enum :category, { after_shipping: 0, after_design: 1 }, default: :after_shipping
+
+  # Builder-facing heading for each category on the mission page.
+  CATEGORY_LABELS = { "after_design" => "After design", "after_shipping" => "After shipping" }.freeze
+
+  # Order categories follow in the mission flow (earn the kit, then ship).
+  CATEGORY_ORDER = %w[after_design after_shipping].freeze
 
   validates :position, presence: true, numericality: { only_integer: true }
 

--- a/app/models/mission/prize.rb
+++ b/app/models/mission/prize.rb
@@ -38,11 +38,8 @@ class Mission::Prize < ApplicationRecord
   # after_design gates a kit on funding/design approval.
   enum :category, { after_shipping: 0, after_design: 1 }, default: :after_shipping
 
-  # Builder-facing heading for each category on the mission page.
+  # Admin-facing label for each category (mission prize editor).
   CATEGORY_LABELS = { "after_design" => "After design", "after_shipping" => "After shipping" }.freeze
-
-  # Order categories follow in the mission flow (earn the kit, then ship).
-  CATEGORY_ORDER = %w[after_design after_shipping].freeze
 
   validates :position, presence: true, numericality: { only_integer: true }
 

--- a/app/models/mission/prize_redemption.rb
+++ b/app/models/mission/prize_redemption.rb
@@ -1,0 +1,66 @@
+# == Schema Information
+#
+# Table name: mission_prize_redemptions
+#
+#  id               :bigint           not null, primary key
+#  source_type      :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  mission_id       :bigint           not null
+#  mission_prize_id :bigint           not null
+#  shop_order_id    :bigint           not null
+#  source_id        :bigint           not null
+#  user_id          :bigint           not null
+#
+# Indexes
+#
+#  index_mission_prize_redemptions_on_mission_id        (mission_id)
+#  index_mission_prize_redemptions_on_mission_prize_id  (mission_prize_id)
+#  index_mission_prize_redemptions_on_shop_order_id     (shop_order_id) UNIQUE
+#  index_mission_prize_redemptions_on_source            (source_type,source_id)
+#  index_mission_prize_redemptions_on_user_id           (user_id)
+#  index_prize_redemptions_on_source_and_prize          (source_type,source_id,mission_prize_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (mission_id => missions.id)
+#  fk_rails_...  (mission_prize_id => mission_prizes.id)
+#  fk_rails_...  (shop_order_id => shop_orders.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class Mission::PrizeRedemption < ApplicationRecord
+  self.table_name = "mission_prize_redemptions"
+
+  has_paper_trail
+
+  belongs_to :user
+  belongs_to :mission
+  belongs_to :mission_prize, class_name: "Mission::Prize", inverse_of: :redemptions
+  belongs_to :shop_order
+  # Gate that unlocked the redemption: a Certification::FundingRequest (after_design)
+  # or a Mission::Submission (after_shipping).
+  belongs_to :source, polymorphic: true
+
+  validates :shop_order_id, uniqueness: true
+  validates :source_id, uniqueness: { scope: [ :source_type, :mission_prize_id ] }
+
+  # Records a redemption for a freshly-placed free order. `gate` is the approval
+  # that unlocked it (a Mission::Submission or Certification::FundingRequest) and
+  # answers `redeemable_prize_for`. Submissions keep their inline link populated
+  # until that column is retired. Returns the redemption, or nil if the item is
+  # not actually a prize on the gate's mission.
+  def self.record!(shop_order:, gate:)
+    prize = gate.redeemable_prize_for(shop_order.shop_item)
+    return unless prize
+
+    redemption = create!(
+      user: shop_order.user,
+      mission: prize.mission,
+      mission_prize: prize,
+      shop_order: shop_order,
+      source: gate
+    )
+    gate.update!(shop_order_id: shop_order.id, chosen_prize_id: prize.id) if gate.is_a?(Mission::Submission)
+    redemption
+  end
+end

--- a/app/models/mission/submission.rb
+++ b/app/models/mission/submission.rb
@@ -120,6 +120,19 @@ class Mission::Submission < ApplicationRecord
     mission.prizes.after_shipping.find_by(shop_item_id: shop_item.id)
   end
 
+  # Rewards granted when a submission is approved: the mission achievement and
+  # any fixed stardust. Idempotent. reviewer_id is recorded on the ledger entry.
+  def grant_rewards!(reviewer_id:)
+    grant_mission_achievement
+    grant_fixed_stardust(reviewer_id: reviewer_id)
+  end
+
+  # Undoes grant_rewards! when a decision is reversed.
+  def reverse_rewards!(reviewer_id:)
+    reverse_fixed_stardust(reviewer_id: reviewer_id)
+    revoke_mission_achievement
+  end
+
   # Per-mission reviewers/owners, minus teammates (no self-review). Global
   # mission_reviewers manage every mission but are deliberately left out here —
   # they opt into the queue rather than being paged for each submission.
@@ -153,6 +166,51 @@ class Mission::Submission < ApplicationRecord
   end
 
   private
+
+  def reward_recipient
+    ship_event&.post&.user
+  end
+
+  def grant_mission_achievement
+    return if mission.achievement_slug.blank?
+    return unless reward_recipient
+    return if reward_recipient.achievements.exists?(achievement_slug: mission.achievement_slug)
+
+    reward_recipient.achievements.create!(achievement_slug: mission.achievement_slug, earned_at: Time.current)
+  end
+
+  def grant_fixed_stardust(reviewer_id:)
+    return unless mission.fixed_stardust_payout&.positive?
+    return unless ledger_entries.sum(:amount).zero?
+    return unless reward_recipient
+
+    ledger_entries.create!(
+      user: reward_recipient,
+      amount: mission.fixed_stardust_payout,
+      reason: "Mission: #{mission.name}",
+      created_by: "mission_submission:#{id} (#{reviewer_id})"
+    )
+  end
+
+  def reverse_fixed_stardust(reviewer_id:)
+    net = ledger_entries.sum(:amount)
+    return unless net.positive?
+    return unless reward_recipient
+
+    ledger_entries.create!(
+      user: reward_recipient,
+      amount: -net,
+      reason: "Mission reversal: #{mission.name}",
+      created_by: "mission_submission:#{id} undo (#{reviewer_id})"
+    )
+  end
+
+  def revoke_mission_achievement
+    return if mission.achievement_slug.blank?
+    return unless reward_recipient
+
+    reward_recipient.achievements.where(achievement_slug: mission.achievement_slug).destroy_all
+  end
 
   def stamp_pending_at
     self.pending_at = Time.current

--- a/app/models/mission/submission.rb
+++ b/app/models/mission/submission.rb
@@ -114,6 +114,12 @@ class Mission::Submission < ApplicationRecord
     pending_at || created_at
   end
 
+  # The after-ship prize this submission can redeem for `shop_item`, if any.
+  # Part of the redemption-gate interface (see Mission::PrizeRedemption.record!).
+  def redeemable_prize_for(shop_item)
+    mission.prizes.after_shipping.find_by(shop_item_id: shop_item.id)
+  end
+
   # Per-mission reviewers/owners, minus teammates (no self-review). Global
   # mission_reviewers manage every mission but are deliberately left out here —
   # they opt into the queue rather than being paged for each submission.

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -163,6 +163,12 @@ class Project < ApplicationRecord
     current_mission_attachment&.mission
   end
 
+  # The active mission delivers a physical kit at design approval (an
+  # after_design prize) instead of a cash grant.
+  def awards_design_kit?
+    current_mission&.prizes&.after_design&.exists? || false
+  end
+
   def display_banner
     if banner.attached?
       banner

--- a/app/models/shop_order.rb
+++ b/app/models/shop_order.rb
@@ -99,7 +99,14 @@ class ShopOrder < ApplicationRecord
   validate :check_mission_unlock_requirement, on: :create
   validate :check_mission_prize_requires_redemption, on: :create
 
-  attr_accessor :redeeming_mission_submission
+  # A free mission-prize redemption is gated by one of two approvals: a
+  # Mission::Submission (after-ship prize) or a Certification::FundingRequest
+  # (after-design kit). Either one makes the order free.
+  attr_accessor :redeeming_mission_submission, :redeeming_funding_request
+
+  def redeeming_prize?
+    redeeming_mission_submission.present? || redeeming_funding_request.present?
+  end
 
   validates :internal_rejection_reason, presence: true, if: :rejected?
   validates :fraud_related_project_id, presence: true, if: :rejected?
@@ -409,7 +416,7 @@ class ShopOrder < ApplicationRecord
     # normal price: freezing 0 skips the balance check, the negative payout,
     # and any refund-on-reject (all gated on frozen_item_price > 0), so a
     # regular shop item given as a static prize never touches the ledger.
-    if redeeming_mission_submission.present?
+    if redeeming_prize?
       self.frozen_item_price = 0
       return
     end
@@ -449,7 +456,7 @@ class ShopOrder < ApplicationRecord
   end
 
   def check_user_balance
-    return if redeeming_mission_submission.present?
+    return if redeeming_prize?
     return unless frozen_item_price&.positive? && quantity.present?
 
     total_cost_for_validation = frozen_item_price * quantity
@@ -466,8 +473,8 @@ class ShopOrder < ApplicationRecord
 
   def check_mission_prize_requires_redemption
     return unless shop_item&.mission_prize_only?
-    return if redeeming_mission_submission.present?
-    errors.add(:base, "This item can only be claimed by redeeming an approved mission submission.")
+    return if redeeming_prize?
+    errors.add(:base, "This item can only be claimed by redeeming an approved mission prize.")
   end
 
   USPS_SUSPENDED_COUNTRIES = %w[

--- a/app/policies/admin/certification/funding_request_policy.rb
+++ b/app/policies/admin/certification/funding_request_policy.rb
@@ -3,10 +3,10 @@
 class Admin::Certification::FundingRequestPolicy < ApplicationPolicy
   def index? = user&.can_review?
 
-  def show? = user&.can_review? && not_own_project?
+  def show? = can_review_hardware? && not_own_project?
 
   def update?
-    return false unless user&.can_review? && not_own_project?
+    return false unless can_review_hardware? && not_own_project?
     record.claim_held_by?(user) || (record.reviewer_id == user.id && record.claim_expired?)
   end
 

--- a/app/policies/admin/certification/funding_requests/claim_policy.rb
+++ b/app/policies/admin/certification/funding_requests/claim_policy.rb
@@ -4,11 +4,11 @@
 # destroy? → reviewer can unclaim the funding request
 class Admin::Certification::FundingRequests::ClaimPolicy < ApplicationPolicy
   def create?
-    user&.can_review? && not_own_project?
+    can_review_hardware? && not_own_project?
   end
 
   def destroy?
-    return false unless user&.can_review? && not_own_project?
+    return false unless can_review_hardware? && not_own_project?
 
     record.claim_held_by?(user) || (record.reviewer_id == user.id && record.claim_expired?)
   end

--- a/app/policies/admin/certification/ship_policy.rb
+++ b/app/policies/admin/certification/ship_policy.rb
@@ -5,7 +5,7 @@ class Admin::Certification::ShipPolicy < ApplicationPolicy
 
   def logs? = user&.can_review?
 
-  def show? = user&.can_review? && not_own_project?
+  def show? = can_review_hardware? && not_own_project?
 
   def update? = show?
 

--- a/app/policies/admin/certification/ships/claim_policy.rb
+++ b/app/policies/admin/certification/ships/claim_policy.rb
@@ -4,11 +4,11 @@
 # destroy? → reviewer can unclaim the ship
 class Admin::Certification::Ships::ClaimPolicy < ApplicationPolicy
   def create?
-    user&.can_review? && not_own_project?
+    can_review_hardware? && not_own_project?
   end
 
   def destroy?
-    return false unless user&.can_review? && not_own_project?
+    return false unless can_review_hardware? && not_own_project?
 
     record.claim_held_by?(user) || (record.reviewer_id == user.id && record.claim_expired?)
   end

--- a/app/policies/admin/mission_policy.rb
+++ b/app/policies/admin/mission_policy.rb
@@ -21,6 +21,15 @@ class Admin::MissionPolicy < ApplicationPolicy
     MissionPolicy.new(user, mission).manage?
   end
 
+  # Reviewing a mission's queue: site admins, the global mission_reviewer role,
+  # or a per-mission reviewer/owner membership (matches the submission queue's
+  # accessible_mission? rule).
+  def review?
+    return true if mission_admin?
+    mission = mission_record
+    mission.is_a?(Mission) && mission.memberships.exists?(user_id: user&.id)
+  end
+
   private
 
   def mission_admin? = user&.admin? || user&.mission_reviewer?

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -57,6 +57,21 @@ class ApplicationPolicy
 
   private
 
+  # Hardware reviews (funding requests + ship certs) can be reviewed by the
+  # global reviewer team, or by a reviewer of the project's hardware mission
+  # (per-mission membership or the global mission_reviewer role).
+  def can_review_hardware?
+    user&.can_review? || hardware_mission_reviewer?
+  end
+
+  def hardware_mission_reviewer?
+    return false unless record.respond_to?(:project)
+    mission = record.project&.current_mission
+    return false unless mission&.hardware?
+
+    user&.mission_reviewer? || mission.memberships.exists?(user_id: user&.id)
+  end
+
   def logged_in?
     user.present? && user.hca_linked?
   end

--- a/app/views/admin/certification/funding_requests/_form.html.erb
+++ b/app/views/admin/certification/funding_requests/_form.html.erb
@@ -43,15 +43,21 @@
     </label>
   </fieldset>
 
-  <div class="review-form__field">
-    <%= f.label :approved_amount_dollars, "Approved amount ($) — up to the #{funding_request.tier_label} max of $#{funding_request.tier_max_dollars}" %>
-    <%= f.number_field :approved_amount_dollars,
-          value: (funding_request.approved_amount_dollars || funding_request.requested_amount_dollars),
-          min: 0, max: funding_request.tier_max_dollars, step: 1 %>
+  <% if funding_request.awards_design_kit? %>
     <p class="review-form__hint">
-      Requested $<%= funding_request.requested_amount_dollars %>. Approving issues an HCB card grant for the approved amount.
+      Approving ships the <%= funding_request.design_kit_shop_item&.name || "design kit" %> and moves the project to the build stage. No grant is issued.
     </p>
-  </div>
+  <% else %>
+    <div class="review-form__field">
+      <%= f.label :approved_amount_dollars, "Approved amount ($) — up to the #{funding_request.tier_label} max of $#{funding_request.tier_max_dollars}" %>
+      <%= f.number_field :approved_amount_dollars,
+            value: (funding_request.approved_amount_dollars || funding_request.requested_amount_dollars),
+            min: 0, max: funding_request.tier_max_dollars, step: 1 %>
+      <p class="review-form__hint">
+        Requested $<%= funding_request.requested_amount_dollars %>. Approving issues an HCB card grant for the approved amount.
+      </p>
+    </div>
+  <% end %>
 
   <div class="review-form__field">
     <%= f.label :feedback, "Feedback for the user (visible to the project owner)" %>
@@ -60,8 +66,8 @@
 
   <div class="review-form__actions">
     <%= f.submit "Submit verdict", class: "action-btn action-btn--large action-btn--primary" %>
-    <%= link_to "Skip and get next", next_admin_certification_hardware_reviews_path(skip: "funding:#{funding_request.id}"),
+    <%= link_to "Skip and get next", hardware_next_path(stage: "design", skip: "funding:#{funding_request.id}"),
           class: "action-btn action-btn--small action-btn--secondary" %>
-    <%= link_to "Back to queue", design_admin_certification_hardware_reviews_path, class: "review-form__back" %>
+    <%= link_to "Back to queue", hardware_queue_path("design"), class: "review-form__back" %>
   </div>
 <% end %>

--- a/app/views/admin/certification/hardware_reviews/_review_facts.html.erb
+++ b/app/views/admin/certification/hardware_reviews/_review_facts.html.erb
@@ -15,18 +15,25 @@
   </div>
 
   <% if review_type == :funding %>
-    <div class="hardware-review__fact hardware-review__fact--primary">
-      <dt>Requested</dt>
-      <dd>$<%= review.requested_amount_dollars %></dd>
-    </div>
-    <div class="hardware-review__fact">
-      <dt><%= review.tier_label %> max</dt>
-      <dd>$<%= review.tier_max_dollars %></dd>
-    </div>
-    <div class="hardware-review__fact hardware-review__fact--wide">
-      <dt>Tier examples</dt>
-      <dd><%= review.tier_examples %></dd>
-    </div>
+    <% if review.awards_design_kit? %>
+      <div class="hardware-review__fact hardware-review__fact--primary hardware-review__fact--wide">
+        <dt>Kit</dt>
+        <dd><%= review.design_kit_shop_item&.name || "Design kit" %></dd>
+      </div>
+    <% else %>
+      <div class="hardware-review__fact hardware-review__fact--primary">
+        <dt>Requested</dt>
+        <dd>$<%= review.requested_amount_dollars %></dd>
+      </div>
+      <div class="hardware-review__fact">
+        <dt><%= review.tier_label %> max</dt>
+        <dd>$<%= review.tier_max_dollars %></dd>
+      </div>
+      <div class="hardware-review__fact hardware-review__fact--wide">
+        <dt>Tier examples</dt>
+        <dd><%= review.tier_examples %></dd>
+      </div>
+    <% end %>
   <% else %>
     <div class="hardware-review__fact hardware-review__fact--primary">
       <dt>Hours logged</dt>

--- a/app/views/admin/certification/hardware_reviews/queue.html.erb
+++ b/app/views/admin/certification/hardware_reviews/queue.html.erb
@@ -1,5 +1,5 @@
 <% design = @stage == "design" %>
-<% content_for :title, "#{design ? "Design" : "Build"} review queue" %>
+<% content_for :title, hardware_queue_title(design) %>
 
 <%
   status_labels = { "pending" => "Pending", "approved" => "Approved", "returned" => "Returned", "all" => "All" }
@@ -13,11 +13,11 @@
      data-certification--queue-server-now-value="<%= Time.current.iso8601 %>"
      data-certification--queue-period-value="<%= @lb_period %>">
   <div class="app-layout__main app-layout__main--wide ship-queue hardware-queue">
-    <%= link_to "← back to admin", admin_root_path, class: "ship-queue__back" %>
+    <%= link_to hardware_back_link[:label], hardware_back_link[:path], class: "ship-queue__back" %>
 
     <header class="ship-queue__header">
       <div class="ship-queue__title">
-        <h1><%= design ? "Design" : "Build" %> review queue</h1>
+        <h1><%= hardware_queue_title(design) %></h1>
         <span class="hardware-queue__subtitle">
           <%= design ? "Funding requests waiting on a grant decision" : "Finished builds waiting on certification" %>
         </span>
@@ -27,20 +27,20 @@
                 onclick="document.getElementById('hardware-my-stats').showModal()">
           My Stats
         </button>
-        <%= link_to "Start reviewing", next_admin_certification_hardware_reviews_path(stage: @stage),
+        <%= link_to "Start reviewing", hardware_next_path(stage: @stage),
               class: "action-btn action-btn--large action-btn--primary" %>
       </div>
     </header>
 
     <%# The two queues are separate jobs; this is the only place they meet. %>
     <nav class="hardware-queue__stages" aria-label="Review queues">
-      <%= link_to design_admin_certification_hardware_reviews_path,
+      <%= link_to hardware_queue_path("design"),
             class: class_names("hardware-queue__stage", "is-active" => design),
             aria: { current: (design ? "page" : nil) } do %>
         <span class="hardware-queue__stage-name">Design</span>
         <span class="hardware-queue__stage-count"><%= @tab_counts["design"] %></span>
       <% end %>
-      <%= link_to build_admin_certification_hardware_reviews_path,
+      <%= link_to hardware_queue_path("build"),
             class: class_names("hardware-queue__stage", "is-active" => !design),
             aria: { current: (design ? nil : "page") } do %>
         <span class="hardware-queue__stage-name">Build</span>
@@ -58,7 +58,7 @@
 
       <div class="hardware-queue__vital">
         <% if oldest %>
-          <%= link_to admin_certification_hardware_review_path(oldest[:project]),
+          <%= link_to hardware_review_path(oldest[:project]),
                 class: class_names("hardware-queue__vital-value", "hardware-queue__vital-value--link" => true,
                                    "is-negative" => oldest_days >= @stats[:sla_days]) do %>
             <%= oldest_days %>d
@@ -87,7 +87,7 @@
       </div>
     </section>
 
-    <%= form_with url: queue_path_for(@stage), method: :get,
+    <%= form_with url: hardware_queue_path(@stage), method: :get,
           data: { certification__queue_target: "filters" }, class: "ship-queue__filters" do %>
       <div class="ship-queue__filter">
         <label for="filter-status">Status</label>
@@ -121,7 +121,7 @@
       </details>
       <div class="ship-queue__filter-actions">
         <button type="submit" class="action-btn action-btn--small action-btn--secondary">Apply</button>
-        <%= link_to "Reset", queue_path_for(@stage), class: "ship-queue__reset" %>
+        <%= link_to "Reset", hardware_queue_path(@stage), class: "ship-queue__reset" %>
       </div>
     <% end %>
 
@@ -145,12 +145,12 @@
             <% @review_items.each do |item| %>
               <% wait_days = ((Time.current - item[:submitted_at]) / 1.day).floor %>
               <tr class="ship-queue__row ship-queue__row--link"
-                  onclick="window.location = <%= admin_certification_hardware_review_path(item[:project]).to_json %>">
+                  onclick="window.location = <%= hardware_review_path(item[:project]).to_json %>">
                 <td class="ship-queue__cell-project">
                   <div class="ship-queue__project-head">
                     <span class="ship-queue__project-title"><%= item[:project].title %></span>
                     <span class="ship-queue__project-id">#<%= item[:project].id %></span>
-                    <%= render "hackpad_tag", project: item[:project], hackpad_project_ids: @hackpad_project_ids %>
+                    <%= render "admin/certification/hardware_reviews/hackpad_tag", project: item[:project], hackpad_project_ids: @hackpad_project_ids %>
                   </div>
                   <div class="ship-queue__project-meta">
                     <% if design %>
@@ -162,7 +162,7 @@
                 </td>
                 <td><%= item[:owner]&.display_name || "—" %></td>
                 <td class="hardware-queue__cell-ask">
-                  <%= render "queue_ask", item: item, design: design %>
+                  <%= render "admin/certification/hardware_reviews/queue_ask", item: item, design: design %>
                 </td>
                 <td class="ship-queue__cell-wait">
                   <span class="ship-queue__wait-badge <%= "is-negative" if wait_days >= @stats[:sla_days] %>"><%= wait_days %>d</span>
@@ -179,16 +179,16 @@
       <div class="ship-queue__cards">
         <% @review_items.each do |item| %>
           <% wait_days = ((Time.current - item[:submitted_at]) / 1.day).floor %>
-          <%= link_to admin_certification_hardware_review_path(item[:project]), class: "ship-queue__card" do %>
+          <%= link_to hardware_review_path(item[:project]), class: "ship-queue__card" do %>
             <div class="ship-queue__card-top">
               <span class="ship-queue__project-title">
                 <%= item[:project].title %>
-                <%= render "hackpad_tag", project: item[:project], hackpad_project_ids: @hackpad_project_ids %>
+                <%= render "admin/certification/hardware_reviews/hackpad_tag", project: item[:project], hackpad_project_ids: @hackpad_project_ids %>
               </span>
               <span class="status-pill status-pill--<%= item[:record].status %>"><%= item[:record].status.capitalize %></span>
             </div>
             <div class="ship-queue__project-meta">
-              <%= render "queue_ask", item: item, design: design %>
+              <%= render "admin/certification/hardware_reviews/queue_ask", item: item, design: design %>
               <span class="ship-queue__dot" aria-hidden="true">·</span>
               <span>by <%= item[:owner]&.display_name || "—" %></span>
               <span class="ship-queue__dot" aria-hidden="true">·</span>
@@ -237,6 +237,6 @@
       <% end %>
     </section>
 
-    <%= render "my_stats_modal", stats: @my_stats %>
+    <%= render "admin/certification/hardware_reviews/my_stats_modal", stats: @my_stats %>
   </div>
 </div>

--- a/app/views/admin/certification/hardware_reviews/show.html.erb
+++ b/app/views/admin/certification/hardware_reviews/show.html.erb
@@ -6,7 +6,7 @@
   ship_can_review = @active_review_type == :ship && @ship.claim_held_by?(current_user)
   can_review = funding_can_review || ship_can_review
   stage_label = @active_review_type == :funding ? "Design funding" : "Build certification"
-  queue_path = queue_path_for(@active_review_type == :ship ? "build" : "design")
+  queue_path = hardware_queue_path(@active_review_type == :ship ? "build" : "design")
 %>
 
 <div class="app-layout app-layout--wide"
@@ -29,7 +29,7 @@
       </div>
 
       <% if @active_review %>
-        <%= render "review_facts", project: @project, owner: @owner,
+        <%= render "admin/certification/hardware_reviews/review_facts", project: @project, owner: @owner,
               review: @active_review, review_type: @active_review_type %>
       <% end %>
 
@@ -73,8 +73,12 @@
                 <% if @funding_request %>
                   <span class="status-pill status-pill--<%= @funding_request.status %>"><%= @funding_request.status.capitalize %></span>
                   <span class="hardware-review__timeline-meta">
-                    $<%= @funding_request.final_amount_dollars %>
-                    <% if @funding_request.approved? %> approved<% elsif @funding_request.pending? %> requested<% end %>
+                    <% if @funding_request.awards_design_kit? %>
+                      <%= @funding_request.design_kit_shop_item&.name || "Kit" %>
+                    <% else %>
+                      $<%= @funding_request.final_amount_dollars %>
+                      <% if @funding_request.approved? %> approved<% elsif @funding_request.pending? %> requested<% end %>
+                    <% end %>
                   </span>
                 <% else %>
                   <span class="hardware-review__timeline-meta">Skipped</span>
@@ -107,7 +111,9 @@
                       <span class="hardware-review__timeline-label"><%= is_funding ? "Design funding" : "Build certification" %></span>
                       <span class="status-pill status-pill--<%= review.status %>"><%= review.status.capitalize %></span>
                       <% if is_funding %>
-                        <span class="hardware-review__timeline-meta">$<%= review.final_amount_dollars %> · <%= review.tier_label %></span>
+                        <span class="hardware-review__timeline-meta">
+                          <%= review.awards_design_kit? ? (review.design_kit_shop_item&.name || "Kit") : "$#{review.final_amount_dollars} · #{review.tier_label}" %>
+                        </span>
                       <% end %>
                       <% if review.decided_at %>
                         <span class="hardware-review__timeline-meta"><%= l(review.decided_at.to_date, format: :short) %></span>

--- a/app/views/admin/certification/ships/_form.html.erb
+++ b/app/views/admin/certification/ships/_form.html.erb
@@ -125,7 +125,7 @@
     <%= f.submit "Submit verdict", class: "action-btn action-btn--large action-btn--primary",
           data: { "certification--video-drop-target": "submitBtn" } %>
     <% if local_assigns[:redirect_to_hardware] %>
-      <%= link_to "Skip and get next", next_admin_certification_hardware_reviews_path(stage: "build", skip: "ship:#{ship.id}"),
+      <%= link_to "Skip and get next", hardware_next_path(stage: "build", skip: "ship:#{ship.id}"),
             class: "action-btn action-btn--small action-btn--secondary" %>
     <% else %>
       <%= link_to "Skip and get next", next_admin_certification_ships_path(skip: ship.id),

--- a/app/views/admin/missions/_prizes_frame.html.erb
+++ b/app/views/admin/missions/_prizes_frame.html.erb
@@ -18,7 +18,13 @@
     <ul class="admin-mission-edit__prizes">
       <% prizes.each do |prize| %>
         <li class="admin-mission-edit__prize">
-          <%= prize.shop_item.name %>
+          <span class="admin-mission-edit__prize-name"><%= prize.shop_item.name %></span>
+          <%= form_with url: admin_mission_prize_path(mission.slug, prize), method: :patch, class: "admin-mission-edit__prize-category" do %>
+            <%= select_tag "mission_prize[category]",
+                  options_for_select(Mission::Prize::CATEGORY_LABELS.map { |value, label| [ label, value ] }, prize.category),
+                  aria: { label: "Prize category" } %>
+            <%= submit_tag "Save", class: "action-btn action-btn--small action-btn--secondary" %>
+          <% end %>
           <%= button_to "Remove",
                         admin_mission_prize_path(mission.slug, prize),
                         method: :delete,
@@ -42,6 +48,14 @@
                 [ "Shop items", ShopItem.where(mission_prize_only: false, enabled: true).order(:name).pluck(:name, :id) ]
               ]),
               prompt: "Select a shop item" %>
+      </label>
+      <label>Category
+        <small class="admin-mission-edit__hint">
+          "After design" prizes (kits) are claimed when a funding request is approved.
+          "After shipping" prizes are claimed once a ship is approved.
+        </small>
+        <%= select_tag "mission_prize[category]",
+              options_for_select(Mission::Prize::CATEGORY_LABELS.map { |value, label| [ label, value ] }, "after_shipping") %>
       </label>
       <%= submit_tag "Add prize", class: "action-btn action-btn--large action-btn--primary" %>
     <% end %>

--- a/app/views/admin/missions/submissions/overview.html.erb
+++ b/app/views/admin/missions/submissions/overview.html.erb
@@ -33,7 +33,8 @@
                   <% end %>
                 </div>
               </div>
-              <%= link_to "Review", admin_mission_submissions_path(m.slug),
+              <% review_path = m.hardware? ? design_admin_mission_hardware_reviews_path(m.slug) : admin_mission_submissions_path(m.slug) %>
+              <%= link_to "Review", review_path,
                     class: "action-btn action-btn--small action-btn--primary" %>
             </li>
           <% end %>

--- a/app/views/missions/_prize_tile.html.erb
+++ b/app/views/missions/_prize_tile.html.erb
@@ -1,0 +1,18 @@
+<%# One shop-item prize tile. Locals: prize, tone %>
+<li class="mission-home__prize mission-home__prize--<%= tone %>">
+  <div class="mission-home__prize-tile">
+    <% if prize.shop_item.respond_to?(:image) && prize.shop_item.image.respond_to?(:attached?) && prize.shop_item.image.attached? %>
+      <%= image_tag prize.shop_item.image, alt: "", class: "mission-home__prize-img" %>
+    <% else %>
+      <svg viewBox="0 0 24 24" width="28" height="28" class="mission-home__prize-glyph" aria-hidden="true">
+        <path d="M12 1.5 13.6 10.4 22.5 12 13.6 13.6 12 22.5 10.4 13.6 1.5 12 10.4 10.4Z" />
+      </svg>
+    <% end %>
+  </div>
+  <div class="mission-home__prize-body">
+    <p class="mission-home__prize-title"><%= prize.shop_item.name %></p>
+    <% if prize.shop_item.description.present? %>
+      <p class="mission-home__prize-blurb"><%= prize.shop_item.description %></p>
+    <% end %>
+  </div>
+</li>

--- a/app/views/missions/_rating_status.html.erb
+++ b/app/views/missions/_rating_status.html.erb
@@ -1,3 +1,16 @@
+<%# Hardware projects aren't community-rated; build hours earn a flat per-hour
+    stardust payout instead. %>
+<% if mission.hardware? %>
+  <li class="mission-home__prize mission-home__prize--yellow">
+    <div class="mission-home__prize-tile">
+      <%= stardust_icon(extra_class: "mission-home__prize-img") %>
+    </div>
+    <div class="mission-home__prize-body">
+      <p class="mission-home__prize-title">Gets stardust</p>
+      <p class="mission-home__prize-blurb">The build hours will get <%= Post::ShipEvent::Payouts::HARDWARE_STARDUST_PER_HOUR %> <%= stardust_icon %> per hour.</p>
+    </div>
+  </li>
+<% else %>
 <% rated = mission.submissions_enter_rating? %>
 <% modal_id = "rating-info-modal-#{mission.id}" %>
 <% rewards = [] %>
@@ -46,3 +59,4 @@
     </dialog>
   <% end %>
 </li>
+<% end %>

--- a/app/views/missions/show.html.erb
+++ b/app/views/missions/show.html.erb
@@ -196,25 +196,37 @@
                 </li>
                 <% tone_idx += 1 %>
               <% end %>
-              <% @ordered_prizes.each_with_index do |prize, idx| %>
-                <% tone = tones[(tone_idx + idx) % tones.length] %>
-                <li class="mission-home__prize mission-home__prize--<%= tone %>">
-                  <div class="mission-home__prize-tile">
-                    <% if prize.shop_item.respond_to?(:image) && prize.shop_item.image.respond_to?(:attached?) && prize.shop_item.image.attached? %>
-                      <%= image_tag prize.shop_item.image, alt: "", class: "mission-home__prize-img" %>
-                    <% else %>
-                      <svg viewBox="0 0 24 24" width="28" height="28" class="mission-home__prize-glyph" aria-hidden="true">
-                        <path d="M12 1.5 13.6 10.4 22.5 12 13.6 13.6 12 22.5 10.4 13.6 1.5 12 10.4 10.4Z" />
-                      </svg>
-                    <% end %>
-                  </div>
-                  <div class="mission-home__prize-body">
-                    <p class="mission-home__prize-title"><%= prize.shop_item.name %></p>
-                    <% if prize.shop_item.description.present? %>
-                      <p class="mission-home__prize-blurb"><%= prize.shop_item.description %></p>
-                    <% end %>
-                  </div>
-                </li>
+              <%# Group prizes by category, but only label the groups when the
+                  mission actually spans more than one category. %>
+              <% prize_groups = @ordered_prizes.group_by(&:category) %>
+              <% ordered_categories = Mission::Prize::CATEGORY_ORDER & prize_groups.keys %>
+              <% show_group_labels = ordered_categories.size > 1 %>
+              <% prize_idx = 0 %>
+              <% ordered_categories.each do |category| %>
+                <% if show_group_labels %>
+                  <li class="mission-home__prize-group-label"><%= Mission::Prize::CATEGORY_LABELS.fetch(category, category.humanize) %></li>
+                <% end %>
+                <% prize_groups[category].each do |prize| %>
+                  <% tone = tones[(tone_idx + prize_idx) % tones.length] %>
+                  <li class="mission-home__prize mission-home__prize--<%= tone %>">
+                    <div class="mission-home__prize-tile">
+                      <% if prize.shop_item.respond_to?(:image) && prize.shop_item.image.respond_to?(:attached?) && prize.shop_item.image.attached? %>
+                        <%= image_tag prize.shop_item.image, alt: "", class: "mission-home__prize-img" %>
+                      <% else %>
+                        <svg viewBox="0 0 24 24" width="28" height="28" class="mission-home__prize-glyph" aria-hidden="true">
+                          <path d="M12 1.5 13.6 10.4 22.5 12 13.6 13.6 12 22.5 10.4 13.6 1.5 12 10.4 10.4Z" />
+                        </svg>
+                      <% end %>
+                    </div>
+                    <div class="mission-home__prize-body">
+                      <p class="mission-home__prize-title"><%= prize.shop_item.name %></p>
+                      <% if prize.shop_item.description.present? %>
+                        <p class="mission-home__prize-blurb"><%= prize.shop_item.description %></p>
+                      <% end %>
+                    </div>
+                  </li>
+                  <% prize_idx += 1 %>
+                <% end %>
               <% end %>
               <% @shop_unlocks.each_with_index do |shop_unlock, idx| %>
                 <% tone = tones[(tone_idx + @ordered_prizes.size + idx) % tones.length] %>

--- a/app/views/missions/show.html.erb
+++ b/app/views/missions/show.html.erb
@@ -181,9 +181,25 @@
               <em class="mission-home__card-title-accent">Prizes</em>
             </h2>
             <ul class="mission-home__prize-list">
-              <%= render "missions/rating_status", mission: @mission %>
               <% tones = %w[yellow lilac peach mint] %>
               <% tone_idx = 0 %>
+              <%# The kit is claimed at design approval; the voting/stardust reward
+                  and any after-ship prizes come after building. Only a mission with
+                  a design kit is split into labelled sections. %>
+              <% design_prizes = @ordered_prizes.select(&:after_design?) %>
+              <% building_prizes = @ordered_prizes.reject(&:after_design?) %>
+              <% split_sections = design_prizes.any? %>
+
+              <% if split_sections %>
+                <li class="mission-home__prize-group-label">After design</li>
+                <% design_prizes.each do |prize| %>
+                  <%= render "missions/prize_tile", prize: prize, tone: tones[tone_idx % tones.length] %>
+                  <% tone_idx += 1 %>
+                <% end %>
+                <li class="mission-home__prize-group-label">After building</li>
+              <% end %>
+
+              <%= render "missions/rating_status", mission: @mission %>
               <% if has_stardust %>
                 <li class="mission-home__prize mission-home__prize--<%= tones[tone_idx % tones.length] %>">
                   <div class="mission-home__prize-tile">
@@ -196,40 +212,12 @@
                 </li>
                 <% tone_idx += 1 %>
               <% end %>
-              <%# Group prizes by category, but only label the groups when the
-                  mission actually spans more than one category. %>
-              <% prize_groups = @ordered_prizes.group_by(&:category) %>
-              <% ordered_categories = Mission::Prize::CATEGORY_ORDER & prize_groups.keys %>
-              <% show_group_labels = ordered_categories.size > 1 %>
-              <% prize_idx = 0 %>
-              <% ordered_categories.each do |category| %>
-                <% if show_group_labels %>
-                  <li class="mission-home__prize-group-label"><%= Mission::Prize::CATEGORY_LABELS.fetch(category, category.humanize) %></li>
-                <% end %>
-                <% prize_groups[category].each do |prize| %>
-                  <% tone = tones[(tone_idx + prize_idx) % tones.length] %>
-                  <li class="mission-home__prize mission-home__prize--<%= tone %>">
-                    <div class="mission-home__prize-tile">
-                      <% if prize.shop_item.respond_to?(:image) && prize.shop_item.image.respond_to?(:attached?) && prize.shop_item.image.attached? %>
-                        <%= image_tag prize.shop_item.image, alt: "", class: "mission-home__prize-img" %>
-                      <% else %>
-                        <svg viewBox="0 0 24 24" width="28" height="28" class="mission-home__prize-glyph" aria-hidden="true">
-                          <path d="M12 1.5 13.6 10.4 22.5 12 13.6 13.6 12 22.5 10.4 13.6 1.5 12 10.4 10.4Z" />
-                        </svg>
-                      <% end %>
-                    </div>
-                    <div class="mission-home__prize-body">
-                      <p class="mission-home__prize-title"><%= prize.shop_item.name %></p>
-                      <% if prize.shop_item.description.present? %>
-                        <p class="mission-home__prize-blurb"><%= prize.shop_item.description %></p>
-                      <% end %>
-                    </div>
-                  </li>
-                  <% prize_idx += 1 %>
-                <% end %>
+              <% building_prizes.each do |prize| %>
+                <%= render "missions/prize_tile", prize: prize, tone: tones[tone_idx % tones.length] %>
+                <% tone_idx += 1 %>
               <% end %>
               <% @shop_unlocks.each_with_index do |shop_unlock, idx| %>
-                <% tone = tones[(tone_idx + @ordered_prizes.size + idx) % tones.length] %>
+                <% tone = tones[(tone_idx + idx) % tones.length] %>
                 <li class="mission-home__prize mission-home__prize--<%= tone %>">
                   <div class="mission-home__prize-tile">
                     <% if shop_unlock.shop_item.respond_to?(:image) && shop_unlock.shop_item.image.respond_to?(:attached?) && shop_unlock.shop_item.image.attached? %>
@@ -247,7 +235,7 @@
                 </li>
               <% end %>
               <% @unlocked_missions.each_with_index do |unlocked, idx| %>
-                <% tone = tones[(tone_idx + @ordered_prizes.size + @shop_unlocks.size + idx) % tones.length] %>
+                <% tone = tones[(tone_idx + @shop_unlocks.size + idx) % tones.length] %>
                 <li class="mission-home__prize mission-home__prize--<%= tone %>">
                   <div class="mission-home__prize-tile">
                     <% if unlocked.icon.attached? %>

--- a/app/views/notifications/hardware/funding_request_reviewed.slack_message.slocks
+++ b/app/views/notifications/hardware/funding_request_reviewed.slack_message.slocks
@@ -1,7 +1,11 @@
 if approved
-  header ":tada: Your funding request was approved!"
+  header ":tada: Your design was approved!"
 
-  section "*<#{project_url}|#{project_title}>* is approved for *$#{amount_dollars}* in funding (#{tier_label}) and has moved to the build phase.", markdown: true
+  if awards_kit
+    section "*<#{project_url}|#{project_title}>* is approved and has moved to the build phase. Head to your project to redeem your kit.", markdown: true
+  else
+    section "*<#{project_url}|#{project_title}>* is approved for *$#{amount_dollars}* in funding (#{tier_label}) and has moved to the build phase.", markdown: true
+  end
 
   section "Log your build hours with a timelapse, then ship when you're ready."
 else

--- a/app/views/notifications/inbox/_funding_request_reviewed.html.erb
+++ b/app/views/notifications/inbox/_funding_request_reviewed.html.erb
@@ -1,7 +1,12 @@
 <% request = notification.record %>
 <% if request&.approved? %>
-  <span class="notifications-item__verb">Your funding request was</span>
-  <strong>approved<%= " for $#{request.final_amount_dollars}" if request.final_amount_dollars.to_i.positive? %></strong>
+  <% if request.awards_design_kit? %>
+    <span class="notifications-item__verb">Your design was</span>
+    <strong>approved</strong>
+  <% else %>
+    <span class="notifications-item__verb">Your funding request was</span>
+    <strong>approved<%= " for $#{request.final_amount_dollars}" if request.final_amount_dollars.to_i.positive? %></strong>
+  <% end %>
 <% else %>
   <span class="notifications-item__verb">Your funding request</span>
   <strong>needs changes</strong>

--- a/app/views/projects/_funding_request_card.html.erb
+++ b/app/views/projects/_funding_request_card.html.erb
@@ -14,11 +14,23 @@
   viewer_is_owner = owner.present? && owner == current_user
   show_feedback = funding_request.feedback.present? && !funding_request.pending? && (viewer_is_owner || current_user&.admin?)
 
+  awards_kit = funding_request.awards_design_kit?
+  kit_prize = awards_kit ? project.current_mission.prizes.after_design.ordered.first : nil
+  kit_redeemed = awards_kit && Mission::PrizeRedemption.exists?(source: funding_request)
+
+  approved_message =
+    if awards_kit && kit_redeemed
+      "Approved! Your kit is on the way. Log your build hours with a timelapse, then ship when you're ready."
+    elsif awards_kit
+      "Approved, and the project has moved to the build stage. Redeem your kit below to get it shipped."
+    else
+      "Approved for $#{funding_request.final_amount_dollars}, and the project has moved to the build stage. Your grant card follows once it has been issued."
+    end
+
   context, message =
     case funding_request.status.to_sym
     when :approved
-      [ "approved your funding request",
-        "Approved for $#{funding_request.final_amount_dollars}, and the project has moved to the build stage. Your grant card follows once it has been issued." ]
+      [ awards_kit ? "approved your design" : "approved your funding request", approved_message ]
     when :returned
       [ "returned your funding request",
         "This needs changes before it can be funded. Take a look at the feedback, then submit your design again." ]
@@ -57,10 +69,12 @@
       </p>
     </div>
 
-    <span class="funding-request-card__amount">
-      $<%= funding_request.requested_amount_dollars %>
-      <span class="funding-request-card__tier"><%= funding_request.tier_label %></span>
-    </span>
+    <% unless awards_kit %>
+      <span class="funding-request-card__amount">
+        $<%= funding_request.requested_amount_dollars %>
+        <span class="funding-request-card__tier"><%= funding_request.tier_label %></span>
+      </span>
+    <% end %>
   </header>
 
   <div class="feed-post-card__body funding-request-card__message">
@@ -82,6 +96,13 @@
               onclick="document.getElementById(<%= resubmit_modal_id.to_json %>).showModal()">
         Submit design again
       </button>
+    </div>
+  <% end %>
+
+  <% if funding_request.approved? && viewer_is_owner && kit_prize && !kit_redeemed %>
+    <div class="funding-request-card__actions">
+      <%= link_to "Redeem your kit", shop_item_path(kit_prize.shop_item, funding_request_id: funding_request.id),
+            class: "action-btn action-btn--small action-btn--primary" %>
     </div>
   <% end %>
 </article>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -642,7 +642,7 @@
                   ) %>
             <% else %>
               <%= render ActionButtonComponent.new(
-                    text: "Submit for funding",
+                    text: @project.awards_design_kit? ? "Submit your design" : "Submit for funding",
                     variant: :primary,
                     type: :button,
                     icon: "icons/rocket.png",
@@ -1161,6 +1161,32 @@
               class="ship-modal ship-modal--post funding-modal"
               data-controller="modal"
               aria-label="Request project funding">
+        <% if @project.awards_design_kit? %>
+        <%= form_with url: project_funding_request_path(@project),
+                      method: :post,
+                      data: { turbo: false },
+                      html: { class: "ship-modal__form" } do |form| %>
+          <div class="ship-modal__panel funding-modal__panel">
+            <header class="funding-modal__header">
+              <h2 class="funding-modal__title">Submit your design</h2>
+              <p class="funding-modal__tagline">Get your design approved and we'll ship you the kit to build with.</p>
+            </header>
+
+            <p class="funding-modal__note">
+              Once a reviewer approves your design, your kit becomes available to redeem and your project moves to the build stage.
+            </p>
+
+            <div class="ship-modal__actions">
+              <button type="button"
+                      class="ship-modal__btn ship-modal__btn--secondary"
+                      onclick="document.getElementById('funding-request-modal-' + <%= @project.id.to_json %>).close()">
+                Cancel
+              </button>
+              <%= form.submit "Submit design", class: "ship-modal__btn ship-modal__btn--primary funding-modal__submit", data: { disable_with: "Submitting…" } %>
+            </div>
+          </div>
+        <% end %>
+        <% else %>
         <%= form_with url: project_funding_request_path(@project),
                       method: :post,
                       data: { turbo: false },
@@ -1214,6 +1240,7 @@
               <%= form.submit "Submit for funding", class: "ship-modal__btn ship-modal__btn--primary funding-modal__submit", data: { disable_with: "Submitting…" } %>
             </div>
           </div>
+        <% end %>
         <% end %>
       </dialog>
       <script>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1169,7 +1169,7 @@
           <div class="ship-modal__panel funding-modal__panel">
             <header class="funding-modal__header">
               <h2 class="funding-modal__title">Submit your design</h2>
-              <p class="funding-modal__tagline">Get your design approved and we'll ship you the kit to build with.</p>
+              <p class="funding-modal__tagline">Get your design approved and we'll ship you the kit to build a <%= @project.current_mission.name %>.</p>
             </header>
 
             <p class="funding-modal__note">

--- a/app/views/shop/items/show.html.erb
+++ b/app/views/shop/items/show.html.erb
@@ -92,12 +92,16 @@
             <div class="shop-order__customs-warning" data-customs-warning-target="warning" style="display: none;"></div>
         </div>
         <% if current_user %>
-        <div class="shop-order__details" data-controller="order-form" data-order-form-has-addresses-value="<%= @user_addresses.any? %>" data-order-form-base-ticket-cost-value="<%= @sale_price || @shop_item.ticket_cost || 0 %>" data-order-form-user-balance-value="<%= @user_balance %>" data-order-form-free-value="<%= @mission_submission.present? %>" data-order-form-addresses-value="<%= @user_addresses.to_json %>" data-order-form-blocked-countries-value="<%= @shop_item.blocked_countries.to_json %>" data-order-form-stardust-icon-url-value="<%= image_path('icons/stardust.png') %>" data-action="address-select:change@document->order-form#addressChanged">
+        <div class="shop-order__details" data-controller="order-form" data-order-form-has-addresses-value="<%= @user_addresses.any? %>" data-order-form-base-ticket-cost-value="<%= @sale_price || @shop_item.ticket_cost || 0 %>" data-order-form-user-balance-value="<%= @user_balance %>" data-order-form-free-value="<%= @redeemable.present? %>" data-order-form-addresses-value="<%= @user_addresses.to_json %>" data-order-form-blocked-countries-value="<%= @shop_item.blocked_countries.to_json %>" data-order-form-stardust-icon-url-value="<%= image_path('icons/stardust.png') %>" data-action="address-select:change@document->order-form#addressChanged">
             <h2>Complete your order:</h2>
             <%= form_with url: shop_orders_path(shop_item_id: @shop_item.id), method: :post, local: true, id: "order-form" do |form| %>
-                <% if @mission_submission %>
+                <% if @redeemable %>
                     <%= form.hidden_field :quantity, value: 1 %>
-                    <%= form.hidden_field :mission_submission_id, value: @mission_submission.id %>
+                    <% if @redeemable.is_a?(Mission::Submission) %>
+                        <%= form.hidden_field :mission_submission_id, value: @redeemable.id %>
+                    <% elsif @redeemable.is_a?(Certification::FundingRequest) %>
+                        <%= form.hidden_field :funding_request_id, value: @redeemable.id %>
+                    <% end %>
                 <% elsif not @shop_item.one_per_person_ever %>
                     <div class="shop-order__quantity">
                         <label class="shop-order__quantity-label" for="shop-order__quantity-input">Quantity</label>
@@ -296,7 +300,7 @@
                     </div>
                 <% end %>
             </div>
-            <div class="shop-order__summary <%= "shop-order__summary--hidden" if @mission_submission %>">
+            <div class="shop-order__summary <%= "shop-order__summary--hidden" if @redeemable %>">
                 <h3 class="shop-order__summary-heading">Order Summary</h3>
                 <p class="shop-order__summary-balance"><%= safe_join([ "Current Balance: ", stardust_icon, " ", @user_balance.to_s ]) %></p>
                 <div class="shop-order__summary-content">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -817,6 +817,16 @@ Rails.application.routes.draw do
           post :undo
         end
       end
+      # A hardware mission's own two-stage review queue (design funding + build
+      # certification), reviewed by the mission's team. Verdicts reuse the global
+      # funding/ship mutation endpoints so PaperTrail stays attached.
+      resources :hardware_reviews, path: "hardware", param: :project_id, only: [ :index, :show ], controller: "missions/hardware_reviews" do
+        collection do
+          get :design
+          get :build
+          get :next
+        end
+      end
     end
     get "mission_reviews", to: "missions/submissions#overview", as: :mission_reviews
 

--- a/db/migrate/20260803195021_add_category_to_mission_prizes.rb
+++ b/db/migrate/20260803195021_add_category_to_mission_prizes.rb
@@ -1,0 +1,5 @@
+class AddCategoryToMissionPrizes < ActiveRecord::Migration[8.1]
+  def change
+    add_column :mission_prizes, :category, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20260803195118_create_mission_prize_redemptions.rb
+++ b/db/migrate/20260803195118_create_mission_prize_redemptions.rb
@@ -1,0 +1,18 @@
+class CreateMissionPrizeRedemptions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :mission_prize_redemptions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :mission, null: false, foreign_key: true
+      t.references :mission_prize, null: false, foreign_key: true
+      t.references :shop_order, null: false, foreign_key: true, index: { unique: true }
+      t.references :source, polymorphic: true, null: false
+
+      t.timestamps
+    end
+
+    add_index :mission_prize_redemptions,
+              [ :source_type, :source_id, :mission_prize_id ],
+              unique: true,
+              name: "index_prize_redemptions_on_source_and_prize"
+  end
+end

--- a/db/migrate/20260803195141_backfill_mission_prize_redemptions.rb
+++ b/db/migrate/20260803195141_backfill_mission_prize_redemptions.rb
@@ -1,0 +1,25 @@
+class BackfillMissionPrizeRedemptions < ActiveRecord::Migration[8.1]
+  # Copies existing inline static-prize redemptions (shop_order_id + chosen_prize_id
+  # on a mission submission) into the new prize_redemptions table. The inline
+  # columns stay in place until the redeem flow is fully cut over.
+  def up
+    safety_assured do
+      execute(<<~SQL)
+        INSERT INTO mission_prize_redemptions
+          (user_id, mission_id, mission_prize_id, shop_order_id, source_type, source_id, created_at, updated_at)
+        SELECT shop_orders.user_id, ms.mission_id, ms.chosen_prize_id, ms.shop_order_id,
+               'Mission::Submission', ms.id, ms.updated_at, ms.updated_at
+        FROM mission_submissions ms
+        JOIN shop_orders ON shop_orders.id = ms.shop_order_id
+        JOIN users ON users.id = shop_orders.user_id
+        WHERE ms.shop_order_id IS NOT NULL
+          AND ms.chosen_prize_id IS NOT NULL
+          AND ms.deleted_at IS NULL
+      SQL
+    end
+  end
+
+  def down
+    execute("DELETE FROM mission_prize_redemptions WHERE source_type = 'Mission::Submission'")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -511,7 +511,25 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_04_004859) do
     t.index ["prerequisite_mission_id"], name: "index_mission_prerequisites_on_prerequisite_mission_id"
   end
 
+  create_table "mission_prize_redemptions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "mission_id", null: false
+    t.bigint "mission_prize_id", null: false
+    t.bigint "shop_order_id", null: false
+    t.bigint "source_id", null: false
+    t.string "source_type", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["mission_id"], name: "index_mission_prize_redemptions_on_mission_id"
+    t.index ["mission_prize_id"], name: "index_mission_prize_redemptions_on_mission_prize_id"
+    t.index ["shop_order_id"], name: "index_mission_prize_redemptions_on_shop_order_id", unique: true
+    t.index ["source_type", "source_id", "mission_prize_id"], name: "index_prize_redemptions_on_source_and_prize", unique: true
+    t.index ["source_type", "source_id"], name: "index_mission_prize_redemptions_on_source"
+    t.index ["user_id"], name: "index_mission_prize_redemptions_on_user_id"
+  end
+
   create_table "mission_prizes", force: :cascade do |t|
+    t.integer "category", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "deleted_at"
     t.bigint "mission_id", null: false
@@ -1649,6 +1667,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_04_004859) do
   add_foreign_key "mission_memberships", "users"
   add_foreign_key "mission_prerequisites", "missions", column: "dependent_mission_id"
   add_foreign_key "mission_prerequisites", "missions", column: "prerequisite_mission_id"
+  add_foreign_key "mission_prize_redemptions", "mission_prizes"
+  add_foreign_key "mission_prize_redemptions", "missions"
+  add_foreign_key "mission_prize_redemptions", "shop_orders"
+  add_foreign_key "mission_prize_redemptions", "users"
   add_foreign_key "mission_prizes", "missions"
   add_foreign_key "mission_prizes", "shop_items"
   add_foreign_key "mission_section_completions", "mission_steps", on_delete: :cascade

--- a/test/controllers/admin/missions/hardware_reviews_controller_test.rb
+++ b/test/controllers/admin/missions/hardware_reviews_controller_test.rb
@@ -1,0 +1,124 @@
+require "test_helper"
+
+class Admin::Missions::HardwareReviewsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    Flipper.enable(:hardware_flow)
+    @owner = create_user(slack_id: "U_MHW_OWNER", display_name: "mhw-owner")
+    @reviewer = create_user(slack_id: "U_MHW_REV", display_name: "mhw-reviewer")
+    @outsider = create_user(slack_id: "U_MHW_OUT", display_name: "mhw-outsider")
+
+    @mission = create_mission
+    @mission.update!(hardware: true)
+    @mission.memberships.create!(user: @reviewer, role: :reviewer)
+
+    @design_project = attach_hardware_project("Kit design bot", "design")
+    add_devlog(@design_project)
+    @funding = @design_project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 2, requested_amount_cents: 4_200, status: :pending
+    )
+
+    @build_project = attach_hardware_project("Kit build bot", "build")
+    @ship = ::Certification::Ship.create!(project: @build_project, status: :pending)
+  end
+
+  teardown { Flipper.disable(:hardware_flow) }
+
+  test "a per-mission reviewer sees the mission's design and build queues" do
+    sign_in @reviewer
+
+    get design_admin_mission_hardware_reviews_path(@mission.slug)
+    assert_response :success
+    assert_select ".ship-queue__project-title", text: /Kit design bot/
+
+    get build_admin_mission_hardware_reviews_path(@mission.slug)
+    assert_response :success
+    assert_select ".ship-queue__project-title", text: /Kit build bot/
+  end
+
+  test "a non-reviewer cannot access the mission hardware dash" do
+    sign_in @outsider
+    get design_admin_mission_hardware_reviews_path(@mission.slug)
+    assert_response :forbidden
+  end
+
+  test "the overview links a hardware mission to its hardware dash with pending funding and ship counts" do
+    sign_in @reviewer
+    get admin_mission_reviews_path
+    assert_response :success
+    assert_select "a[href=?]", design_admin_mission_hardware_reviews_path(@mission.slug)
+    assert_select ".mission-overview__card-pending", text: /2 pending/
+  end
+
+  HCB_GRANT_RESPONSE = { "id" => "test_grant_mhw" }.freeze
+
+  test "a per-mission reviewer can claim a funding request and is returned to the mission dash" do
+    sign_in @reviewer
+    post admin_certification_funding_request_claim_path(@funding)
+    assert_redirected_to admin_mission_hardware_review_path(@mission.slug, @design_project)
+    assert_equal @reviewer.id, @funding.reload.reviewer_id
+  end
+
+  test "a per-mission reviewer can approve a funding request and is returned to the mission dash queue" do
+    ::Certification::FundingRequest.atomic_claim!(@funding.id, @reviewer)
+    sign_in @reviewer
+
+    HCBService.stub(:create_card_grant, HCB_GRANT_RESPONSE) do
+      patch admin_certification_funding_request_path(@funding),
+            params: { redirect_to_hardware: @design_project.id,
+                      certification_funding_request: { status: "approved", feedback: "looks good" } }
+    end
+
+    assert_redirected_to next_admin_mission_hardware_reviews_path(@mission.slug, stage: "design")
+    assert @funding.reload.approved?
+  end
+
+  test "the mission hardware dash renders the per-project review page" do
+    sign_in @reviewer
+    get admin_mission_hardware_review_path(@mission.slug, @design_project)
+    assert_response :success
+  end
+
+  test "the software submission dash for a hardware mission redirects to the hardware dash" do
+    sign_in @reviewer
+    get admin_mission_submissions_path(@mission.slug)
+    assert_redirected_to design_admin_mission_hardware_reviews_path(@mission.slug)
+  end
+
+  test "hardware mission submissions are excluded from the all-missions software queue" do
+    ship_to_mission!(@build_project, @owner, @mission, status: "pending")
+    admin = create_user(slack_id: "U_MHW_ADMIN2", display_name: "mhw-admin2")
+    admin.grant_role!(:admin)
+    sign_in admin
+
+    get admin_mission_submissions_path("all")
+    assert_response :success
+    assert_select ".mission-queue__project-title", text: /Kit build bot/, count: 0
+  end
+
+  test "mission-attached hardware is excluded from the global hardware dash" do
+    admin = create_user(slack_id: "U_MHW_ADMIN", display_name: "mhw-admin")
+    admin.grant_role!(:admin)
+    sign_in admin
+
+    get design_admin_certification_hardware_reviews_path
+    assert_response :success
+    assert_select ".ship-queue__project-title", text: /Kit design bot/, count: 0
+  end
+
+  private
+
+  def attach_hardware_project(title, stage)
+    project = Project.create!(title: title)
+    project.memberships.create!(user: @owner, role: :owner)
+    project.update!(hardware_stage: stage)
+    project.mission_attachments.create!(mission: @mission)
+    project
+  end
+
+  def add_devlog(project)
+    devlog = Post::Devlog.new(body: "log", duration_seconds: 3600, phase: project.hardware_stage)
+    devlog.uploading_attachments = true
+    devlog.save!
+    Post.create!(project: project, user: @owner, postable: devlog)
+  end
+end

--- a/test/controllers/admin/missions/prizes_controller_test.rb
+++ b/test/controllers/admin/missions/prizes_controller_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class Admin::Missions::PrizesControllerTest < ActionDispatch::IntegrationTest
+  PIXEL_PNG = Base64.decode64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=")
+
+  setup do
+    @admin = create_user(slack_id: "U_PRZ_ADMIN", display_name: "prz-admin")
+    @admin.grant_role!(:admin)
+    @mission = create_mission
+    @item = prize_item
+    sign_in @admin
+  end
+
+  test "creating a prize persists the chosen category" do
+    assert_difference -> { @mission.prizes.count }, 1 do
+      post admin_mission_prizes_path(@mission.slug),
+           params: { mission_prize: { shop_item_id: @item.id, category: "after_design" } }
+    end
+    assert_equal "after_design", @mission.prizes.order(:id).last.category
+  end
+
+  test "creating a prize without a category defaults to after_shipping" do
+    post admin_mission_prizes_path(@mission.slug),
+         params: { mission_prize: { shop_item_id: @item.id } }
+    assert_equal "after_shipping", @mission.prizes.order(:id).last.category
+  end
+
+  test "updating a prize changes its category" do
+    prize = @mission.prizes.create!(shop_item: @item, position: 0, category: :after_shipping)
+    patch admin_mission_prize_path(@mission.slug, prize),
+          params: { mission_prize: { category: "after_design" } }
+    assert_equal "after_design", prize.reload.category
+  end
+
+  private
+
+  def prize_item
+    item = ShopItem.new(name: "Kit #{SecureRandom.hex(3)}", description: "d", ticket_cost: 0,
+                        type: "ShopItem::ThirdPartyPhysical", enabled: true, mission_prize_only: true)
+    item.image.attach(io: StringIO.new(PIXEL_PNG), filename: "i.png", content_type: "image/png")
+    item.save!
+    item
+  end
+end

--- a/test/integration/hardware_kit_funding_submission_test.rb
+++ b/test/integration/hardware_kit_funding_submission_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class HardwareKitFundingSubmissionTest < ActionDispatch::IntegrationTest
+  PIXEL_PNG = Base64.decode64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=")
+
+  setup do
+    Flipper.enable(:hardware_flow)
+    @owner = User.create!(email: "owner-#{SecureRandom.hex(6)}@example.com",
+                          display_name: "Owner#{SecureRandom.hex(3)}", slack_id: "U#{SecureRandom.hex(8)}")
+    @project = Project.create!(title: "HW #{SecureRandom.hex(4)}", hardware_stage: "design")
+    Project::Membership.create!(project: @project, user: @owner, role: :owner)
+    @mission = create_mission
+    @mission.update!(hardware: true)
+    @project.mission_attachments.create!(mission: @mission)
+
+    devlog = Post::Devlog.new(body: "log", duration_seconds: 3600, phase: "design")
+    devlog.uploading_attachments = true
+    devlog.save!
+    Post.create!(project: @project, user: @owner, postable: devlog)
+  end
+
+  test "kit mission: submitting a design with no tier or amount creates a valid request" do
+    add_after_design_kit
+
+    sign_in @owner
+    assert_difference -> { @project.certification_funding_requests.count }, 1 do
+      post project_funding_request_path(@project)
+    end
+    assert_redirected_to project_path(@project)
+
+    request = @project.certification_funding_requests.last
+    assert request.awards_design_kit?
+    assert_equal 0, request.requested_amount_cents
+    assert_includes Certification::FundingRequest::TIER_MAX_CENTS.keys, request.complexity_tier
+  end
+
+  test "non-kit mission: submitting without a tier or amount is rejected" do
+    sign_in @owner
+    assert_no_difference -> { @project.certification_funding_requests.count } do
+      post project_funding_request_path(@project)
+    end
+  end
+
+  private
+
+  def add_after_design_kit
+    kit = ShopItem.new(name: "Kit #{SecureRandom.hex(3)}", description: "the kit", ticket_cost: 0,
+                       type: "ShopItem::ThirdPartyPhysical", enabled: true, mission_prize_only: true)
+    kit.image.attach(io: StringIO.new(PIXEL_PNG), filename: "kit.png", content_type: "image/png")
+    kit.save!
+    @mission.prizes.create!(shop_item: kit, position: 0, category: :after_design)
+  end
+end

--- a/test/integration/hardware_kit_redemption_test.rb
+++ b/test/integration/hardware_kit_redemption_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class HardwareKitRedemptionTest < ActionDispatch::IntegrationTest
+  PIXEL_PNG = Base64.decode64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=")
+
+  setup do
+    @owner = User.create!(email: "owner-#{SecureRandom.hex(6)}@example.com",
+                          display_name: "Owner#{SecureRandom.hex(3)}", slack_id: "U#{SecureRandom.hex(8)}")
+    @stranger = User.create!(email: "str-#{SecureRandom.hex(6)}@example.com",
+                             display_name: "Str#{SecureRandom.hex(3)}", slack_id: "U#{SecureRandom.hex(8)}")
+    @project = Project.create!(title: "HW #{SecureRandom.hex(4)}", hardware_stage: "design")
+    Project::Membership.create!(project: @project, user: @owner, role: :owner)
+    @mission = create_mission
+    @mission.update!(hardware: true)
+    @project.mission_attachments.create!(mission: @mission)
+
+    devlog = Post::Devlog.new(body: "log", duration_seconds: 3600, phase: "design")
+    devlog.uploading_attachments = true
+    devlog.save!
+    Post.create!(project: @project, user: @owner, postable: devlog)
+
+    @kit = ShopItem.new(name: "Hackpad Kit #{SecureRandom.hex(3)}", description: "the kit", ticket_cost: 0,
+                        type: "ShopItem::ThirdPartyPhysical", enabled: true, mission_prize_only: true)
+    @kit.image.attach(io: StringIO.new(PIXEL_PNG), filename: "kit.png", content_type: "image/png")
+    @kit.save!
+    @mission.prizes.create!(shop_item: @kit, position: 0, category: :after_design)
+
+    @funding_request = @project.certification_funding_requests.create!(user: @owner, status: :pending)
+    @funding_request.update!(status: :approved)
+  end
+
+  test "the kit page renders a redeem form for the approved request owner" do
+    sign_in @owner
+    get shop_item_path(@kit, funding_request_id: @funding_request.id)
+    assert_response :success
+    assert_select "input[name=?][value=?]", "funding_request_id", @funding_request.id.to_s
+  end
+
+  test "the kit is not redeemable by a non-owner" do
+    sign_in @stranger
+    get shop_item_path(@kit, funding_request_id: @funding_request.id)
+    assert_redirected_to shop_path
+  end
+
+  test "the kit is not redeemable without an approved request" do
+    @funding_request.update!(status: :returned, feedback: "nope")
+    sign_in @owner
+    get shop_item_path(@kit, funding_request_id: @funding_request.id)
+    assert_redirected_to shop_path
+  end
+end

--- a/test/integration/mission_prize_groups_test.rb
+++ b/test/integration/mission_prize_groups_test.rb
@@ -19,7 +19,7 @@ class MissionPrizeGroupsTest < ActionDispatch::IntegrationTest
     assert_select ".mission-home__prize-group-label", count: 0
   end
 
-  test "prizes spanning two categories render group headers" do
+  test "a mission with an after-design kit splits into design and building sections" do
     add_prize(:after_design, "Kit")
     add_prize(:after_shipping, "Sticker")
 
@@ -28,7 +28,29 @@ class MissionPrizeGroupsTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select ".mission-home__prize-group-label", count: 2
     assert_select ".mission-home__prize-group-label", text: "After design"
-    assert_select ".mission-home__prize-group-label", text: "After shipping"
+    assert_select ".mission-home__prize-group-label", text: "After building"
+  end
+
+  test "an after-design kit alone still splits into design and building sections" do
+    add_prize(:after_design, "Kit")
+
+    sign_in @user
+    get mission_path(@mission.slug)
+    assert_response :success
+    assert_select ".mission-home__prize-group-label", text: "After design"
+    assert_select ".mission-home__prize-group-label", text: "After building"
+  end
+
+  test "a hardware mission shows the per-hour stardust payout instead of community rating" do
+    @mission.update!(hardware: true)
+    add_prize(:after_design, "Kit")
+
+    sign_in @user
+    get mission_path(@mission.slug)
+    assert_response :success
+    assert_select ".mission-home__prize-title", text: "Gets stardust"
+    assert_select ".mission-home__prize-blurb", text: /per hour/
+    assert_select ".mission-home__prize-title", text: "Goes into rating", count: 0
   end
 
   private

--- a/test/integration/mission_prize_groups_test.rb
+++ b/test/integration/mission_prize_groups_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class MissionPrizeGroupsTest < ActionDispatch::IntegrationTest
+  PIXEL_PNG = Base64.decode64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=")
+
+  setup do
+    @user = User.create!(email: "u-#{SecureRandom.hex(6)}@example.com",
+                         display_name: "U#{SecureRandom.hex(3)}", slack_id: "U#{SecureRandom.hex(8)}")
+    @mission = create_mission
+  end
+
+  test "single-category prizes render without group headers" do
+    add_prize(:after_shipping, "Sticker")
+    add_prize(:after_shipping, "Patch")
+
+    sign_in @user
+    get mission_path(@mission.slug)
+    assert_response :success
+    assert_select ".mission-home__prize-group-label", count: 0
+  end
+
+  test "prizes spanning two categories render group headers" do
+    add_prize(:after_design, "Kit")
+    add_prize(:after_shipping, "Sticker")
+
+    sign_in @user
+    get mission_path(@mission.slug)
+    assert_response :success
+    assert_select ".mission-home__prize-group-label", count: 2
+    assert_select ".mission-home__prize-group-label", text: "After design"
+    assert_select ".mission-home__prize-group-label", text: "After shipping"
+  end
+
+  private
+
+  def add_prize(category, name)
+    item = ShopItem.new(name: "#{name} #{SecureRandom.hex(3)}", description: "d", ticket_cost: 0,
+                        type: "ShopItem::ThirdPartyPhysical", enabled: true, mission_prize_only: true)
+    item.image.attach(io: StringIO.new(PIXEL_PNG), filename: "i.png", content_type: "image/png")
+    item.save!
+    @mission.prizes.create!(shop_item: item, position: @mission.prizes.count, category: category)
+  end
+end

--- a/test/models/certification/funding_request_test.rb
+++ b/test/models/certification/funding_request_test.rb
@@ -141,6 +141,27 @@ class Certification::FundingRequestTest < ActiveSupport::TestCase
     assert_equal true, fr.notification_locals[:awards_kit]
   end
 
+  test "approving a superseded funding request does not advance the project or issue a grant" do
+    old = @project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 2, requested_amount_cents: 3_000, status: :pending
+    )
+    old.update!(reviewer: @reviewer, status: :returned, feedback: "needs work")
+    # Resubmit: a newer request supersedes the returned one.
+    newer = @project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 2, requested_amount_cents: 3_000, status: :pending
+    )
+
+    assert_not old.latest_for_project?
+    assert newer.latest_for_project?
+
+    HCBService.stub(:create_card_grant, HCB_GRANT_RESPONSE) do
+      old.update!(reviewer: @reviewer, status: :approved)
+    end
+
+    assert_equal "design", @project.reload.hardware_stage, "a superseded request must not advance the project"
+    assert_nil old.reload.hcb_grant_hashid, "a superseded request must not issue a grant"
+  end
+
   private
 
   PIXEL_PNG = Base64.decode64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=")

--- a/test/models/certification/funding_request_test.rb
+++ b/test/models/certification/funding_request_test.rb
@@ -116,7 +116,46 @@ class Certification::FundingRequestTest < ActiveSupport::TestCase
     assert_not_includes @project.ship_blocking_errors, label
   end
 
+  test "kit mission: funding request needs no tier or amount" do
+    attach_kit_mission
+    fr = @project.certification_funding_requests.new(user: @owner)
+    assert fr.valid?, fr.errors.full_messages.to_sentence
+    assert fr.save
+    assert_equal Certification::FundingRequest::TIER_MAX_CENTS.keys.min, fr.complexity_tier
+    assert_equal 0, fr.requested_amount_cents
+    assert fr.awards_design_kit?
+  end
+
+  test "kit mission: approval delivers a kit instead of a cash grant" do
+    attach_kit_mission
+    fr = @project.certification_funding_requests.create!(user: @owner, status: :pending)
+
+    grant_called = false
+    HCBService.stub(:create_card_grant, ->(*) { grant_called = true; HCB_GRANT_RESPONSE }) do
+      fr.update!(reviewer: @reviewer, status: :approved)
+    end
+
+    assert_not grant_called, "kit mission should not issue an HCB grant"
+    assert_nil fr.reload.hcb_grant_hashid
+    assert_equal "build", @project.reload.hardware_stage
+    assert_equal true, fr.notification_locals[:awards_kit]
+  end
+
   private
+
+  PIXEL_PNG = Base64.decode64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=")
+
+  def attach_kit_mission
+    mission = create_mission
+    mission.update!(hardware: true)
+    kit = ShopItem.new(name: "Hackpad Kit #{SecureRandom.hex(3)}", description: "The kit for this mission",
+                       ticket_cost: 0, type: "ShopItem::ThirdPartyPhysical", enabled: true, mission_prize_only: true)
+    kit.image.attach(io: StringIO.new(PIXEL_PNG), filename: "kit.png", content_type: "image/png")
+    kit.save!
+    mission.prizes.create!(shop_item: kit, position: 0, category: :after_design)
+    @project.mission_attachments.create!(mission: mission)
+    mission
+  end
 
   def create_devlog(phase:)
     devlog = Post::Devlog.new(body: "work log", duration_seconds: 3600, phase: phase)

--- a/test/models/certification/ship_mission_collapse_test.rb
+++ b/test/models/certification/ship_mission_collapse_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class Certification::ShipMissionCollapseTest < ActiveSupport::TestCase
+  setup do
+    @owner = create_user(slack_id: "U_HWC_OWNER", display_name: "hwowner")
+    @reviewer = create_user(slack_id: "U_HWC_REV", display_name: "hwrev")
+  end
+
+  test "approving a hardware mission ship cert also approves the mission submission and grants rewards" do
+    project, submission = ship_to_hardware_mission(achievement: true)
+    cert = project.ship_reviews.create!(status: :pending, post_ship_event: submission.ship_event)
+
+    cert.update!(status: :approved, reviewer: @reviewer)
+
+    assert submission.reload.approved?, "hardware mission submission should be auto-approved with the ship cert"
+    assert_equal @reviewer.id, submission.reviewed_by_id
+    assert @owner.achievements.exists?(achievement_slug: submission.mission.achievement_slug),
+           "the mission achievement should be granted"
+  end
+
+  test "approving a software mission ship cert leaves the submission pending for its own review" do
+    project, submission = ship_to_software_mission
+    cert = project.ship_reviews.create!(status: :pending, post_ship_event: submission.ship_event)
+
+    cert.update!(status: :approved, reviewer: @reviewer)
+
+    assert submission.reload.pending?, "software mission submission must still await its own approval"
+  end
+
+  private
+
+  def ship_to_hardware_mission(achievement: false)
+    project = Project.create!(title: "HW #{SecureRandom.hex(4)}", hardware_stage: "build")
+    project.memberships.create!(user: @owner, role: :owner)
+    mission = create_mission
+    mission.update!(hardware: true)
+    mission.update!(achievement_name: "Done") if achievement
+    project.mission_attachments.create!(mission: mission)
+    [ project, ship_to_mission!(project, @owner, mission) ]
+  end
+
+  def ship_to_software_mission
+    project = Project.create!(title: "SW #{SecureRandom.hex(4)}")
+    project.memberships.create!(user: @owner, role: :owner)
+    mission = create_mission
+    project.mission_attachments.create!(mission: mission)
+    [ project, ship_to_mission!(project, @owner, mission) ]
+  end
+end

--- a/test/models/mission/prize_redemption_test.rb
+++ b/test/models/mission/prize_redemption_test.rb
@@ -1,0 +1,113 @@
+require "test_helper"
+
+# == Schema Information
+#
+# Table name: mission_prize_redemptions
+#
+#  id               :bigint           not null, primary key
+#  source_type      :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  mission_id       :bigint           not null
+#  mission_prize_id :bigint           not null
+#  shop_order_id    :bigint           not null
+#  source_id        :bigint           not null
+#  user_id          :bigint           not null
+#
+# Indexes
+#
+#  index_mission_prize_redemptions_on_mission_id        (mission_id)
+#  index_mission_prize_redemptions_on_mission_prize_id  (mission_prize_id)
+#  index_mission_prize_redemptions_on_shop_order_id     (shop_order_id) UNIQUE
+#  index_mission_prize_redemptions_on_source            (source_type,source_id)
+#  index_mission_prize_redemptions_on_user_id           (user_id)
+#  index_prize_redemptions_on_source_and_prize          (source_type,source_id,mission_prize_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (mission_id => missions.id)
+#  fk_rails_...  (mission_prize_id => mission_prizes.id)
+#  fk_rails_...  (shop_order_id => shop_orders.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class Mission::PrizeRedemptionTest < ActiveSupport::TestCase
+  PIXEL_PNG = Base64.decode64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=")
+
+  setup do
+    @owner = User.create!(email: "owner-#{SecureRandom.hex(6)}@example.com",
+                          display_name: "Owner#{SecureRandom.hex(3)}", slack_id: "U#{SecureRandom.hex(8)}")
+    @owner.update!(has_gotten_free_stickers: true) # clears the shop-tutorial gate
+
+    @project = Project.create!(title: "HW #{SecureRandom.hex(4)}", hardware_stage: "design")
+    Project::Membership.create!(project: @project, user: @owner, role: :owner)
+    @mission = create_mission
+    @mission.update!(hardware: true)
+    @project.mission_attachments.create!(mission: @mission)
+
+    devlog = Post::Devlog.new(body: "initial log", duration_seconds: 3600, phase: "design")
+    devlog.uploading_attachments = true
+    devlog.save!
+    Post.create!(project: @project, user: @owner, postable: devlog)
+  end
+
+  test "record! creates a redemption for an after-design funding kit" do
+    kit = prize_item("Kit")
+    design_prize = @mission.prizes.create!(shop_item: kit, position: 0, category: :after_design)
+    funding_request = @project.certification_funding_requests.create!(user: @owner, status: :pending)
+    funding_request.update!(status: :approved)
+
+    order = free_order(kit, funding_request)
+    redemption = Mission::PrizeRedemption.record!(shop_order: order, gate: funding_request)
+
+    assert redemption.persisted?
+    assert_equal funding_request, redemption.source
+    assert_equal design_prize, redemption.mission_prize
+    assert_equal @owner, redemption.user
+    assert_equal @mission, redemption.mission
+  end
+
+  test "record! creates a redemption for an after-ship submission and syncs the inline link" do
+    reward = prize_item("Reward")
+    ship_prize = @mission.prizes.create!(shop_item: reward, position: 0, category: :after_shipping)
+    submission = ship_to_mission!(@project, @owner, @mission, status: "approved")
+
+    order = free_order(reward, submission)
+    redemption = Mission::PrizeRedemption.record!(shop_order: order, gate: submission)
+
+    assert_equal ship_prize, redemption.mission_prize
+    assert_equal submission, redemption.source
+    assert_equal order.id, submission.reload.shop_order_id
+    assert_equal ship_prize.id, submission.chosen_prize_id
+  end
+
+  test "record! ignores an item that is not a prize on the gate's mission" do
+    kit = prize_item("Kit")
+    @mission.prizes.create!(shop_item: kit, position: 0, category: :after_design)
+    funding_request = @project.certification_funding_requests.create!(user: @owner, status: :pending)
+    funding_request.update!(status: :approved)
+
+    stranger = prize_item("Stranger")
+    order = free_order(stranger, funding_request)
+    assert_nil Mission::PrizeRedemption.record!(shop_order: order, gate: funding_request)
+  end
+
+  private
+
+  def prize_item(name)
+    item = ShopItem.new(name: "#{name} #{SecureRandom.hex(3)}", description: "prize item", ticket_cost: 0,
+                        type: "ShopItem::ThirdPartyPhysical", enabled: true, mission_prize_only: true)
+    item.image.attach(io: StringIO.new(PIXEL_PNG), filename: "i.png", content_type: "image/png")
+    item.save!
+    item
+  end
+
+  def free_order(item, gate)
+    order = @owner.shop_orders.new(shop_item: item, quantity: 1,
+                                   frozen_address: { "country" => "US", "phone_number" => "+15555550123" })
+    order.redeeming_funding_request = gate if gate.is_a?(Certification::FundingRequest)
+    order.redeeming_mission_submission = gate if gate.is_a?(Mission::Submission)
+    order.aasm_state = "pending"
+    order.save!
+    order
+  end
+end

--- a/test/models/shop_order_mission_prize_test.rb
+++ b/test/models/shop_order_mission_prize_test.rb
@@ -47,4 +47,17 @@ class ShopOrderMissionPrizeTest < ActiveSupport::TestCase
     order.send(:freeze_item_price)
     assert_operator order.frozen_item_price.to_i, :>, 0, "a normal purchase must keep the real price"
   end
+
+  test "a funding-request kit redemption is free and clears the mission-prize-only guard" do
+    @item.update!(mission_prize_only: true)
+
+    order = @user.shop_orders.new(shop_item: @item, quantity: 1, frozen_address: @address)
+    order.redeeming_funding_request = Certification::FundingRequest.new
+    order.aasm_state = "pending"
+
+    assert order.save, "kit redemption must succeed: #{order.errors.full_messages.to_sentence}"
+    assert_equal 0, order.frozen_item_price, "a kit redemption must freeze the price to 0"
+    assert_equal 0, @user.reload.balance, "redeeming a kit must not debit stardust"
+    assert_empty @user.ledger_entries.where(ledgerable: order), "a free kit must not create a ledger entry"
+  end
 end


### PR DESCRIPTION
## what's this do?

- makes it so when you submit a project for a hardware mission, it goes into the mission's queues
  - hardware missions now have a separate design and build queue
- mission prizes now have a type- can be after design or after ship (all software missions just have after ship still)
  - flow for hackpads is ask for funding -> design approved -> redeem free kit -> build -> ship for mission -> approved for stardust
- all of flow is working and separate from both other missions and regular hardware flow!

## show it works

<img width="2880" height="1637" alt="image" src="https://github.com/user-attachments/assets/a02baf96-f71c-4ae2-8696-806e06d83e8c" />
<img width="621" height="448" alt="image" src="https://github.com/user-attachments/assets/55132347-be6e-4f66-81ae-eb05bfd11de9" />
<img width="1275" height="329" alt="image" src="https://github.com/user-attachments/assets/b8c41073-2588-42fe-a53e-d9ff98b18580" />

## ai?

claude
