### PR TITLE
fix(submission): refine the way project submission works

### DIFF
--- a/app/controllers/projects/ships_controller.rb
+++ b/app/controllers/projects/ships_controller.rb
@@ -82,7 +82,8 @@ class Projects::ShipsController < ApplicationController
 
     def require_shippable
       return if @project.shippable?
-      redirect_to project_path(@project), alert: "Finish the remaining requirements before shipping."
+      redirect_to project_path(@project),
+                  alert: @project.mission_review_blocker_message || "Finish the remaining requirements before shipping."
     end
 
     def mission_submission_guide_ack_required?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -570,6 +570,7 @@ class Project < ApplicationRecord
   def shipping_requirements
     owner_vote_balance = memberships.owner.first&.user&.vote_balance.to_i
     votes_needed = [ -owner_vote_balance, 0 ].max
+    mission_review = blocking_mission_submission
     [
       {
         key: :demo_url,
@@ -652,6 +653,17 @@ class Project < ApplicationRecord
         passed: previous_ship_event_has_payout?
       },
       {
+        key: :mission_review,
+        label: "Your mission submission must clear review before you ship again",
+        fail_label: mission_review&.rejected? ?
+          "Your mission submission was returned. Address the feedback and request a re-review" :
+          "Wait for your mission submission to be reviewed before shipping again",
+        tooltip: mission_review&.rejected? ?
+          "A reviewer returned your mission submission. Address their feedback, then request a re-review from the ship on your timeline." :
+          "Your ship is waiting on a mission reviewer. You can ship again once they've made a decision.",
+        passed: mission_review.nil?
+      },
+      {
         key: :vote_balance,
         label: "Maintain a non-negative vote balance",
         fail_label: "Vote at least #{votes_needed} #{'time'.pluralize(votes_needed)} before shipping!",
@@ -707,12 +719,34 @@ class Project < ApplicationRecord
 
   def ship_blocking_errors = shipping_requirements.reject { |r| r[:passed] }.map { |r| r[:label] }
 
+  # The latest ship's mission submission while it still owes a decision:
+  # `pending` waits on a reviewer, `rejected` waits on the builder to address
+  # the feedback and request a re-review. Either way the project can't ship
+  # again. A ship the certifier rejected is left to the re-certification flow.
+  def blocking_mission_submission
+    ship = last_ship_event
+    return nil if ship.nil? || ship.certification_status == "rejected"
+
+    submission = ship.mission_submission
+    submission if submission&.pending? || submission&.rejected?
+  end
+
   # The single most relevant reason the project can't ship yet, as a short
   # actionable message — used for the ship button's disabled tooltip. Returns
   # nil when the project is shippable.
   def ship_blocker_message
     req = shipping_requirements.find { |r| !r[:passed] }
     req && (req[:fail_label] || req[:label])
+  end
+
+  # The mission-review blocker, when that's what's holding the ship button.
+  # Takes precedence over the other blockers in the UI: nothing the builder
+  # fixes on the project itself unblocks a review that hasn't landed yet.
+  def mission_review_blocker_message
+    req = shipping_requirements.find { |r| r[:key] == :mission_review }
+    return nil if req[:passed]
+
+    req[:fail_label] || req[:label]
   end
 
   # Whether every project-info requirement (see INFO_REQUIREMENT_KEYS) passes,

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -659,7 +659,7 @@ class Project < ApplicationRecord
           "Your mission submission was returned. Address the feedback and request a re-review" :
           "Wait for your mission submission to be reviewed before shipping again",
         tooltip: mission_review&.rejected? ?
-          "A reviewer returned your mission submission. Address their feedback, then request a re-review from the ship on your timeline." :
+          "A reviewer returned your mission submission. Address their feedback and request a re-review from the ship on your timeline, or detach the mission to carry on without it." :
           "Your ship is waiting on a mission reviewer. You can ship again once they've made a decision.",
         passed: mission_review.nil?
       },
@@ -884,7 +884,10 @@ class Project < ApplicationRecord
     # a "previous ship awaiting payout" — it's the one currently being
     # (re-)certified, so it must not block re-certification.
     return true unless last_ship_event.certification_status == "approved"
-    sub = last_ship_event.mission_submission
+    # with_deleted so a fixed-prize ship whose mission was detached doesn't
+    # strand the project: Post::ShipEvent.voteable keeps that ship out of the
+    # rating pool either way, so no payout is ever coming for it.
+    sub = Mission::Submission.with_deleted.find_by(ship_event_id: last_ship_event.id)
     return true if sub&.payout_path == "static_prize"
     false
   end

--- a/app/models/project/mission_attachment.rb
+++ b/app/models/project/mission_attachment.rb
@@ -46,10 +46,21 @@ class Project::MissionAttachment < ApplicationRecord
 
   def detach!
     return if detached_at.present?
-    update!(detached_at: Time.current)
+
+    transaction do
+      update!(detached_at: Time.current)
+      discard_rejected_submissions
+    end
   end
 
   private
+
+  # Leaving a mission also clears the reviews it failed: the rejected
+  # submissions come off their ships, so those ships stop blocking the next
+  # one (see Project#blocking_mission_submission) and read as plain ships.
+  def discard_rejected_submissions
+    project.mission_submissions.rejected.where(mission_id: mission_id).find_each(&:soft_delete!)
+  end
 
   def default_attached_at
     self.attached_at ||= Time.current

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -698,7 +698,9 @@
           <% else %>
             <%
               ship_disabled_message =
-                if @project.received_grant? && !@project.has_build_devlog_since_last_ship?
+                if (mission_review_message = @project.mission_review_blocker_message)
+                  mission_review_message
+                elsif @project.received_grant? && !@project.has_build_devlog_since_last_ship?
                   "Post at least one build devlog before you can ship!"
                 elsif !@project.has_devlog_since_last_ship?
                   "Post at least one devlog before shipping!"

--- a/test/controllers/projects/missions_controller_test.rb
+++ b/test/controllers/projects/missions_controller_test.rb
@@ -46,6 +46,17 @@ class Projects::MissionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal @mission, @project.reload.current_mission
   end
 
+  test "detaches a mission whose submission was rejected and clears it off the ship" do
+    submission = ship_to_mission!(@project, @owner, @mission, status: "rejected")
+    sign_in @owner
+
+    delete project_mission_path(@project)
+
+    assert_redirected_to project_path(@project)
+    assert_nil @project.reload.current_mission
+    assert submission.reload.deleted?
+  end
+
   test "follow_up_targets_for classifies ready and awaiting follow-ups" do
     submission = ship_to_mission!(@project, @owner, @mission)
 

--- a/test/models/project_mission_review_requirement_test.rb
+++ b/test/models/project_mission_review_requirement_test.rb
@@ -54,6 +54,36 @@ class ProjectMissionReviewRequirementTest < ActiveSupport::TestCase
     assert mission_review_requirement[:passed]
   end
 
+  test "detaching the mission clears the rejected submission off the latest ship" do
+    submission = ship_to_mission!(@project, @owner, @mission, status: "rejected")
+
+    @project.detach_mission!
+
+    assert submission.reload.deleted?
+    assert_nil @project.last_ship_event.reload.mission_submission
+    assert mission_review_requirement[:passed]
+  end
+
+  test "detaching leaves a pending submission alone" do
+    submission = ship_to_mission!(@project, @owner, @mission, status: "pending")
+
+    @project.detach_mission!
+
+    refute submission.reload.deleted?
+    refute mission_review_requirement[:passed]
+  end
+
+  test "a detached fixed-prize ship does not block the next ship on its missing payout" do
+    submission = ship_to_mission!(@project, @owner, @mission, status: "rejected")
+    submission.update!(payout_path: "static_prize")
+    submission.ship_event.update!(certification_status: "approved")
+
+    @project.detach_mission!
+
+    assert @project.shipping_requirements.find { |r| r[:key] == :payout }[:passed],
+      "a detached fixed-prize ship never enters the rating pool, so it can't wait on a payout forever"
+  end
+
   test "a fixed-prize submission cannot skip the review gate" do
     submission = ship_to_mission!(@project, @owner, @mission, status: "pending")
     submission.update!(payout_path: "static_prize")

--- a/test/models/project_mission_review_requirement_test.rb
+++ b/test/models/project_mission_review_requirement_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class ProjectMissionReviewRequirementTest < ActiveSupport::TestCase
+  setup do
+    @owner = create_user(slack_id: "U_MISSION_REVIEW", display_name: "missionreviewowner")
+    @project = Project.create!(title: "mission review project", description: "d")
+    @project.memberships.create!(user: @owner, role: :owner)
+    @mission = create_mission
+    @project.mission_attachments.create!(mission: @mission)
+  end
+
+  def mission_review_requirement
+    @project.shipping_requirements.find { |r| r[:key] == :mission_review }
+  end
+
+  test "requirement passes when the project has never shipped to a mission" do
+    assert mission_review_requirement[:passed]
+  end
+
+  test "requirement passes while the submission is still awaiting certification" do
+    ship_to_mission!(@project, @owner, @mission)
+
+    assert mission_review_requirement[:passed],
+      "certification is gated separately, so an uncertified ship must not report a mission block"
+  end
+
+  test "requirement blocks shipping while the mission review is pending" do
+    ship_to_mission!(@project, @owner, @mission, status: "pending")
+
+    refute mission_review_requirement[:passed]
+    assert_equal "Wait for your mission submission to be reviewed before shipping again",
+                 @project.mission_review_blocker_message
+  end
+
+  test "requirement blocks shipping while the mission review is rejected" do
+    ship_to_mission!(@project, @owner, @mission, status: "rejected")
+
+    refute mission_review_requirement[:passed]
+    assert_equal "Your mission submission was returned. Address the feedback and request a re-review",
+                 @project.mission_review_blocker_message
+  end
+
+  test "requirement passes once the mission review is approved" do
+    ship_to_mission!(@project, @owner, @mission, status: "approved")
+
+    assert mission_review_requirement[:passed]
+    assert_nil @project.mission_review_blocker_message
+  end
+
+  test "a certifier-rejected ship is left to the re-certification flow" do
+    submission = ship_to_mission!(@project, @owner, @mission, status: "rejected")
+    submission.ship_event.update!(certification_status: "rejected")
+
+    assert mission_review_requirement[:passed]
+  end
+
+  test "a fixed-prize submission cannot skip the review gate" do
+    submission = ship_to_mission!(@project, @owner, @mission, status: "pending")
+    submission.update!(payout_path: "static_prize")
+    submission.ship_event.update!(certification_status: "approved")
+
+    assert @project.shipping_requirements.find { |r| r[:key] == :payout }[:passed],
+      "fixed-prize ships bypass the payout gate, which is why the mission gate has to hold"
+    refute mission_review_requirement[:passed]
+    refute @project.shippable?
+  end
+end


### PR DESCRIPTION
## what's this do?

- block reshipping if mission review is in processing or rejected
- allow people to detach mission if mission is rejected

## ai?

claude
