### PR TITLE
feat(hardware): add approve-without-grant verdict to design review

### DIFF
--- a/app/assets/stylesheets/components/_feed.scss
+++ b/app/assets/stylesheets/components/_feed.scss
@@ -2284,6 +2284,12 @@
     --funding-accent: var(--color-brand-salmon);
   }
 
+  // The byline is a single line but the avatar is 39px, so the shared
+  // flex-start header would leave a dead strip under it before the body.
+  &__header {
+    align-items: center;
+  }
+
   &__amount {
     margin-left: auto;
     display: flex;
@@ -2301,28 +2307,17 @@
   }
 
   &__message {
+    color: var(--color-space-text);
+    line-height: 1.45;
+    overflow-wrap: anywhere;
+
     p {
       margin: 0;
     }
-  }
 
-  &__feedback {
-    padding-left: var(--space-s);
-    border-left: 3px solid var(--funding-accent);
-  }
-
-  &__feedback-label {
-    margin: 0 0 var(--space-xxs);
-    color: var(--funding-accent);
-    font-size: var(--font-size-s);
-    font-weight: 700;
-  }
-
-  &__feedback-body {
-    color: var(--color-space-text);
-    font-size: var(--font-size-m);
-    line-height: 1.45;
-    overflow-wrap: anywhere;
+    p + p {
+      margin-top: var(--space-xs);
+    }
   }
 
   &__actions {

--- a/app/assets/stylesheets/components/_feed.scss
+++ b/app/assets/stylesheets/components/_feed.scss
@@ -2327,6 +2327,8 @@
 
   &__actions {
     display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-s);
     justify-content: flex-start;
   }
 }

--- a/app/assets/stylesheets/components/_tooltip.scss
+++ b/app/assets/stylesheets/components/_tooltip.scss
@@ -63,3 +63,17 @@
   border-left-color: var(--color-space-bg-2);
   border-right: 0;
 }
+
+// The "?" trigger rendered by shared/_help_tooltip.
+.help-badge {
+  display: inline-grid;
+  place-items: center;
+  width: 16px;
+  height: 16px;
+  border: 2px solid currentColor;
+  border-radius: 50%;
+  font-size: 0.5rem;
+  font-weight: 700;
+  opacity: 0.4;
+  vertical-align: middle;
+}

--- a/app/assets/stylesheets/pages/mission_submissions/_redeem.scss
+++ b/app/assets/stylesheets/pages/mission_submissions/_redeem.scss
@@ -1,5 +1,5 @@
-// Mission prize redeem picker (shown when a mission has 0 or ≥2 prizes;
-// a single prize redirects straight to its shop item).
+// Mission prize claim page (shown while 0 or ≥2 prizes are left to claim;
+// a single remaining prize redirects straight to its shop item).
 
 .submission-redeem__breadcrumb {
   margin: var(--space-l) 0 var(--space-xs);
@@ -62,4 +62,16 @@
     align-self: flex-start;
     margin-top: auto;
   }
+}
+
+.submission-redeem__prizes--claimed {
+  margin-top: var(--space-m);
+}
+
+.submission-redeem__prize--claimed {
+  opacity: 0.6;
+}
+
+.submission-redeem__claimed-label {
+  font-weight: 600;
 }

--- a/app/assets/stylesheets/pages/projects/_show.scss
+++ b/app/assets/stylesheets/pages/projects/_show.scss
@@ -617,19 +617,6 @@ turbo-frame#project_hero {
   background: transparent;
 }
 
-.project-show__help {
-  display: inline-grid;
-  place-items: center;
-  width: 16px;
-  height: 16px;
-  border: 2px solid currentColor;
-  border-radius: 50%;
-  font-size: 0.5rem;
-  font-weight: 700;
-  opacity: 0.4;
-  vertical-align: middle;
-}
-
 .project-show__panel-actions {
   display: flex;
   justify-content: flex-end;

--- a/app/controllers/admin/certification/funding_requests_controller.rb
+++ b/app/controllers/admin/certification/funding_requests_controller.rb
@@ -6,9 +6,8 @@ class Admin::Certification::FundingRequestsController < Admin::Certification::Ap
   def update
     authorize @funding_request
     if @funding_request.update(funding_request_params)
-      verb = @funding_request.approved? ? "Approved" : "Returned"
       count = ::Certification::FundingRequest.reviewed_today(current_user)
-      notice = "#{verb} funding for “#{@funding_request.project.title}.” That's #{count} reviewed today. Keep going!"
+      notice = "#{verdict_sentence} That's #{count} reviewed today. Keep going!"
       # Straight on to the next design review; `next` claims it, and falls back
       # to the queue when there's nothing left.
       redirect_to hardware_review_next_path_for(@funding_request.project, "design"), notice: notice
@@ -19,6 +18,19 @@ class Admin::Certification::FundingRequestsController < Admin::Certification::Ap
   end
 
   private
+
+  # Names the verdict back to the reviewer, since "approved" now covers a grant,
+  # a kit, and no funding at all.
+  def verdict_sentence
+    title = @funding_request.project.title
+    if !@funding_request.approved?
+      "Returned funding for “#{title}.”"
+    elsif @funding_request.issues_grant?
+      "Approved funding for “#{title}.”"
+    else
+      "Approved “#{title}” with no grant."
+    end
+  end
 
   def set_funding_request
     @funding_request = ::Certification::FundingRequest.find(params[:id])
@@ -75,6 +87,6 @@ class Admin::Certification::FundingRequestsController < Admin::Certification::Ap
   end
 
   def funding_request_params
-    params.require(:certification_funding_request).permit(:status, :feedback, :approved_amount_dollars)
+    params.require(:certification_funding_request).permit(:verdict, :feedback, :approved_amount_dollars)
   end
 end

--- a/app/controllers/mission_submissions_controller.rb
+++ b/app/controllers/mission_submissions_controller.rb
@@ -4,13 +4,12 @@ class MissionSubmissionsController < ApplicationController
 
   def redeem
     authorize @submission
-    prizes = @submission.mission.prizes.after_shipping.ordered.includes(:shop_item).to_a
+    @prizes = @submission.unredeemed_prizes.to_a
+    @claimed_prizes = @submission.redeemable_prizes
+      .where(id: @submission.prize_redemptions.select(:mission_prize_id))
 
-    if prizes.size == 1
-      redirect_to shop_item_path(prizes.first.shop_item, mission_submission_id: @submission.id)
-    else
-      @prizes = prizes
-    end
+    # Nothing left to choose between, so skip the picker.
+    redirect_to shop_item_path(@prizes.first.shop_item, mission_submission_id: @submission.id) if @prizes.one?
   end
 
   private

--- a/app/controllers/shop/base_controller.rb
+++ b/app/controllers/shop/base_controller.rb
@@ -86,9 +86,9 @@ class Shop::BaseController < ApplicationController
       .find_by(id: submission_id)
     return nil unless submission
     return nil unless submission.approved?
-    return nil unless submission.shop_order_id.nil?
     return nil unless submission.ship_event&.post&.user_id == current_user.id
-    return nil unless submission.mission.prizes.after_shipping.exists?(shop_item_id: shop_item.id)
+    # Each after-ship prize is claimable once per submission.
+    return nil unless submission.redeemable_prize_for(shop_item)
 
     submission
   end
@@ -103,11 +103,8 @@ class Shop::BaseController < ApplicationController
       .find_by(id: funding_request_id)
     return nil unless funding_request&.approved?
     return nil unless funding_request.owner == current_user
-
-    mission = funding_request.project.current_mission
-    return nil unless mission&.prizes&.after_design&.exists?(shop_item_id: shop_item.id)
-    # One design kit per approved request.
-    return nil if Mission::PrizeRedemption.exists?(source: funding_request)
+    # Each design kit is claimable once per approved request.
+    return nil unless funding_request.redeemable_prize_for(shop_item)
 
     funding_request
   end

--- a/app/models/certification/funding_request.rb
+++ b/app/models/certification/funding_request.rb
@@ -48,6 +48,10 @@ module Certification
   # approval delivers that kit for redemption instead of a cash grant: no HCB
   # grant is issued and the tier/amount fields are vestigial (defaulted, hidden
   # in the request form).
+  #
+  # A reviewer can also approve without any funding at all (the builder already
+  # has the parts, or is covered some other way). That is an ordinary approval
+  # recorded as an approved amount of $0, which issues no grant.
   class FundingRequest < ApplicationRecord
     self.table_name = "certification_funding_requests"
 
@@ -89,7 +93,13 @@ module Certification
     # Stardust a reviewer earns per completed funding review.
     REVIEW_BOUNTY = 1
 
+    # The three choices a reviewer picks from on the design review form.
+    VERDICTS = %w[approved approved_without_grant returned].freeze
+
     before_validation :default_kit_request_fields, on: :create, if: :awards_design_kit?
+    # Zeroed here rather than in the writer so it wins regardless of the order
+    # the verdict and the approved amount arrive in from the form.
+    before_validation :zero_approved_amount, if: -> { @verdict == "approved_without_grant" }
 
     validates :complexity_tier, inclusion: { in: TIER_MAX_CENTS.keys }
     validates :requested_amount_cents,
@@ -97,6 +107,7 @@ module Certification
     validates :approved_amount_cents,
               numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
     validates :feedback, length: { maximum: 10_000 }, allow_blank: true
+    validates :verdict, inclusion: { in: VERDICTS }, allow_nil: true
     validate :requested_within_tier_max
     validate :approved_within_tier_max
     validate :project_in_design_stage, on: :create
@@ -195,6 +206,35 @@ module Certification
       project&.current_mission&.prizes&.after_design&.exists? || false
     end
 
+    # True when approving this request pays out an HCB card grant, as opposed to
+    # shipping a kit or approving the build with no funding at all.
+    def issues_grant?
+      approved? && !awards_design_kit? && final_amount_cents.to_i.positive?
+    end
+
+    # An approval that funds nothing: the project moves to the build stage, but
+    # no grant is issued and no kit is owed.
+    def approved_without_grant?
+      approved? && !awards_design_kit? && !issues_grant?
+    end
+
+    # The review form's verdict radio. Collapses the status and the "no grant"
+    # approval into one choice; the amount is zeroed before validation.
+    def verdict
+      @verdict ||= if approved_without_grant?
+        "approved_without_grant"
+      elsif status.present? && !pending?
+        status
+      end
+    end
+
+    def verdict=(value)
+      @verdict = value.presence
+      return unless VERDICTS.include?(@verdict)
+
+      self.status = @verdict == "approved_without_grant" ? "approved" : @verdict
+    end
+
     # True unless a newer funding request has superseded this one (a resubmit
     # after a return). A superseded request's verdict is inert: it must not
     # advance the project or issue a grant/kit, so approving the wrong one can't
@@ -229,6 +269,7 @@ module Certification
         project_url: routes.project_url(project, **url_opts),
         approved: approved?,
         awards_kit: awards_design_kit?,
+        issues_grant: issues_grant?,
         amount_dollars: final_amount_dollars,
         tier_label: tier_label,
         reviewer_name: reviewer&.display_name,
@@ -264,7 +305,7 @@ module Certification
     # retries the next time the request is saved instead of being stranded.
     # issue_hcb_grant! already returns early when a grant exists.
     after_save_commit :notify_owner!, if: -> { saved_change_to_status? && !pending? }
-    after_save_commit :issue_hcb_grant!, if: -> { approved? && hcb_grant_hashid.blank? && !awards_design_kit? && latest_for_project? }
+    after_save_commit :issue_hcb_grant!, if: -> { issues_grant? && hcb_grant_hashid.blank? && latest_for_project? }
 
     private
 
@@ -301,6 +342,10 @@ module Certification
 
     def default_approved_amount
       self.approved_amount_cents ||= requested_amount_cents
+    end
+
+    def zero_approved_amount
+      self.approved_amount_cents = 0
     end
 
     # Kit missions have no cash amount, but the columns are NOT NULL. Seed the

--- a/app/models/certification/funding_request.rb
+++ b/app/models/certification/funding_request.rb
@@ -56,6 +56,7 @@ module Certification
     self.table_name = "certification_funding_requests"
 
     include Certification::Reviewable
+    include Mission::PrizeRedeemable
 
     belongs_to :project
     belongs_to :user
@@ -203,7 +204,7 @@ module Certification
     # True when the project's active mission delivers a physical kit at design
     # approval (an after_design prize) rather than a cash grant.
     def awards_design_kit?
-      project&.current_mission&.prizes&.after_design&.exists? || false
+      redeemable_prizes.exists?
     end
 
     # True when approving this request pays out an HCB card grant, as opposed to
@@ -244,16 +245,15 @@ module Certification
       !project.certification_funding_requests.where("id > ?", id).exists?
     end
 
-    # The after-design kit this request can redeem for `shop_item`, if any.
-    # Part of the redemption-gate interface (see Mission::PrizeRedemption.record!).
-    def redeemable_prize_for(shop_item)
-      project&.current_mission&.prizes&.after_design&.find_by(shop_item_id: shop_item.id)
-    end
+    # Redemption-gate interface (see Mission::PrizeRedeemable): an approved
+    # design claims the mission's after-design kits.
+    def redemption_mission = project&.current_mission
+    def redemption_prize_category = :after_design
 
     # The kit shipped when this design is approved (the mission's first
     # after_design prize), for reviewer-facing copy.
     def design_kit_shop_item
-      project&.current_mission&.prizes&.after_design&.ordered&.first&.shop_item
+      redeemable_prizes.first&.shop_item
     end
 
     # Locals for the verdict notification's Slack template.

--- a/app/models/certification/funding_request.rb
+++ b/app/models/certification/funding_request.rb
@@ -15,7 +15,7 @@
 #  lock_version              :integer          default(0), not null
 #  requested_amount_cents    :integer          not null
 #  stardust_earned           :integer
-#  status                    :integer          default("pending"), not null
+#  status                    :integer          default(0), not null
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  project_id                :bigint           not null

--- a/app/models/certification/integrity.rb
+++ b/app/models/certification/integrity.rb
@@ -9,7 +9,7 @@
 #  flags                  :integer          default(0), not null
 #  fraud_detection_data   :jsonb
 #  reviewed_at            :datetime
-#  status                 :integer          default("auto_passed"), not null
+#  status                 :integer          default(0), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  claimed_by_id          :bigint

--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -13,7 +13,7 @@
 #  proof_video_url           :string
 #  recert_reason             :text
 #  stardust_earned           :float
-#  status                    :integer          default("pending"), not null
+#  status                    :integer          default(0), not null
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  external_certification_id :string

--- a/app/models/concerns/mission/prize_redeemable.rb
+++ b/app/models/concerns/mission/prize_redeemable.rb
@@ -1,0 +1,40 @@
+# The redemption-gate interface shared by the two records that unlock mission
+# prizes: a Mission::Submission (after shipping) and a
+# Certification::FundingRequest (after design). A gate unlocks every prize in
+# its category, one order each, so the claim stays open until they are all
+# redeemed.
+#
+# Includers define `redemption_mission` and `redemption_prize_category`.
+module Mission::PrizeRedeemable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :prize_redemptions, class_name: "Mission::PrizeRedemption",
+             as: :source, dependent: :destroy, inverse_of: :source
+  end
+
+  # Every prize this gate unlocks, in display order.
+  def redeemable_prizes
+    return Mission::Prize.none unless redemption_mission
+
+    redemption_mission.prizes
+      .where(category: redemption_prize_category)
+      .ordered
+      .includes(:shop_item)
+  end
+
+  # The ones still to claim.
+  def unredeemed_prizes
+    redeemable_prizes.where.not(id: prize_redemptions.select(:mission_prize_id))
+  end
+
+  def prizes_to_claim?
+    unredeemed_prizes.exists?
+  end
+
+  # The prize this gate can still redeem for `shop_item`, if any. Drives both
+  # the free-price gate in the shop and Mission::PrizeRedemption.record!.
+  def redeemable_prize_for(shop_item)
+    unredeemed_prizes.find_by(shop_item_id: shop_item.id)
+  end
+end

--- a/app/models/mission/prize.rb
+++ b/app/models/mission/prize.rb
@@ -3,7 +3,7 @@
 # Table name: mission_prizes
 #
 #  id           :bigint           not null, primary key
-#  category     :integer          default("after_shipping"), not null
+#  category     :integer          default(0), not null
 #  deleted_at   :datetime
 #  position     :integer          default(0), not null
 #  created_at   :datetime         not null

--- a/app/models/mission/prize_redemption.rb
+++ b/app/models/mission/prize_redemption.rb
@@ -47,8 +47,9 @@ class Mission::PrizeRedemption < ApplicationRecord
   # Records a redemption for a freshly-placed free order. `gate` is the approval
   # that unlocked it (a Mission::Submission or Certification::FundingRequest) and
   # answers `redeemable_prize_for`. Submissions keep their inline link populated
-  # until that column is retired. Returns the redemption, or nil if the item is
-  # not actually a prize on the gate's mission.
+  # until that column is retired; it points at the first claim, since a gate can
+  # now redeem every prize in its category. Returns the redemption, or nil if the
+  # item is not a claimable prize on the gate's mission.
   def self.record!(shop_order:, gate:)
     prize = gate.redeemable_prize_for(shop_order.shop_item)
     return unless prize
@@ -60,7 +61,9 @@ class Mission::PrizeRedemption < ApplicationRecord
       shop_order: shop_order,
       source: gate
     )
-    gate.update!(shop_order_id: shop_order.id, chosen_prize_id: prize.id) if gate.is_a?(Mission::Submission)
+    if gate.is_a?(Mission::Submission) && gate.shop_order_id.nil?
+      gate.update!(shop_order_id: shop_order.id, chosen_prize_id: prize.id)
+    end
     redemption
   end
 end

--- a/app/models/mission/submission.rb
+++ b/app/models/mission/submission.rb
@@ -50,6 +50,7 @@ class Mission::Submission < ApplicationRecord
   include Ledgerable
   include AASM
   include MissionReviewable
+  include Mission::PrizeRedeemable
 
   has_paper_trail
 
@@ -103,7 +104,6 @@ class Mission::Submission < ApplicationRecord
   scope :in_review, -> { where.not(status: %w[approved rejected]) }
 
   scope :reviewable,  -> { pending }
-  scope :unredeemed,  -> { approved.where(shop_order_id: nil) }
   scope :stale_pending, ->(days: 7) {
     pending.where("pending_at < ?", days.days.ago)
   }
@@ -114,11 +114,10 @@ class Mission::Submission < ApplicationRecord
     pending_at || created_at
   end
 
-  # The after-ship prize this submission can redeem for `shop_item`, if any.
-  # Part of the redemption-gate interface (see Mission::PrizeRedemption.record!).
-  def redeemable_prize_for(shop_item)
-    mission.prizes.after_shipping.find_by(shop_item_id: shop_item.id)
-  end
+  # Redemption-gate interface (see Mission::PrizeRedeemable): an approved
+  # submission claims the mission's after-shipping prizes.
+  def redemption_mission = mission
+  def redemption_prize_category = :after_shipping
 
   # Rewards granted when a submission is approved: the mission achievement and
   # any fixed stardust. Idempotent. reviewer_id is recorded on the ledger entry.

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -7,7 +7,7 @@
 #  group_count        :integer          default(1), not null
 #  group_key          :string
 #  params             :jsonb            not null
-#  priority           :integer          default(NULL), not null
+#  priority           :integer          default(0), not null
 #  read_at            :datetime
 #  record_type        :string
 #  seen_at            :datetime

--- a/app/models/notifications/hardware/funding_request_reviewed.rb
+++ b/app/models/notifications/hardware/funding_request_reviewed.rb
@@ -24,7 +24,8 @@ module Notifications
       def email_subject
         title = record&.project&.title
         if record&.approved?
-          title.present? ? "#{title} was approved for funding" : "Your funding request was approved"
+          approval = record.issues_grant? ? "approved for funding" : "approved"
+          title.present? ? "#{title} was #{approval}" : "Your funding request was approved"
         else
           title.present? ? "#{title} needs changes before funding" : "Your funding request needs changes"
         end

--- a/app/models/project/report.rb
+++ b/app/models/project/report.rb
@@ -5,7 +5,7 @@
 #  id          :bigint           not null, primary key
 #  details     :text             not null
 #  reason      :string           not null
-#  status      :integer          default("pending"), not null
+#  status      :integer          default(0), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  project_id  :bigint           not null

--- a/app/models/project_language.rb
+++ b/app/models/project_language.rb
@@ -6,7 +6,7 @@
 #  error_message  :text
 #  language_stats :jsonb
 #  last_synced_at :datetime
-#  status         :integer          default("pending"), not null
+#  status         :integer          default(0), not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  project_id     :bigint           not null

--- a/app/models/rsvp/game.rb
+++ b/app/models/rsvp/game.rb
@@ -5,7 +5,7 @@
 #  id         :bigint           not null, primary key
 #  board      :string           default("---------"), not null
 #  move_count :integer          default(0), not null
-#  status     :integer          default("in_progress"), not null
+#  status     :integer          default(0), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  rsvp_id    :bigint           not null

--- a/app/policies/mission/submission_policy.rb
+++ b/app/policies/mission/submission_policy.rb
@@ -39,7 +39,7 @@ class Mission::SubmissionPolicy < ApplicationPolicy
 
   def redeem?
     return false unless user.present?
-    submitter? && record.approved? && record.shop_order_id.nil?
+    submitter? && record.approved? && record.prizes_to_claim?
   end
 
   private

--- a/app/views/admin/certification/funding_requests/_form.html.erb
+++ b/app/views/admin/certification/funding_requests/_form.html.erb
@@ -34,11 +34,17 @@
   <fieldset class="review-form__fieldset">
     <legend>Verdict</legend>
     <label class="review-form__option">
-      <%= f.radio_button :status, "approved", required: true %>
-      <span>Approve</span>
+      <%= f.radio_button :verdict, "approved", required: true %>
+      <span><%= funding_request.awards_design_kit? ? "Approve" : "Approve and issue a grant" %></span>
     </label>
+    <% unless funding_request.awards_design_kit? %>
+      <label class="review-form__option">
+        <%= f.radio_button :verdict, "approved_without_grant", required: true %>
+        <span>Approve without a grant</span>
+      </label>
+    <% end %>
     <label class="review-form__option">
-      <%= f.radio_button :status, "returned", required: true %>
+      <%= f.radio_button :verdict, "returned", required: true %>
       <span>Return for changes</span>
     </label>
   </fieldset>
@@ -48,6 +54,9 @@
       Approving ships the <%= funding_request.design_kit_shop_item&.name || "design kit" %> and moves the project to the build stage. No grant is issued.
     </p>
   <% else %>
+    <p class="review-form__hint">
+      Approving without a grant still moves the project to the build stage and pays out for build hours as usual. The amount below is ignored.
+    </p>
     <div class="review-form__field">
       <%= f.label :approved_amount_dollars, "Approved amount ($) — up to the #{funding_request.tier_label} max of $#{funding_request.tier_max_dollars}" %>
       <%= f.number_field :approved_amount_dollars,

--- a/app/views/admin/certification/hardware_reviews/show.html.erb
+++ b/app/views/admin/certification/hardware_reviews/show.html.erb
@@ -75,6 +75,8 @@
                   <span class="hardware-review__timeline-meta">
                     <% if @funding_request.awards_design_kit? %>
                       <%= @funding_request.design_kit_shop_item&.name || "Kit" %>
+                    <% elsif @funding_request.approved_without_grant? %>
+                      Approved, no grant
                     <% else %>
                       $<%= @funding_request.final_amount_dollars %>
                       <% if @funding_request.approved? %> approved<% elsif @funding_request.pending? %> requested<% end %>
@@ -112,7 +114,13 @@
                       <span class="status-pill status-pill--<%= review.status %>"><%= review.status.capitalize %></span>
                       <% if is_funding %>
                         <span class="hardware-review__timeline-meta">
-                          <%= review.awards_design_kit? ? (review.design_kit_shop_item&.name || "Kit") : "$#{review.final_amount_dollars} · #{review.tier_label}" %>
+                          <% if review.awards_design_kit? %>
+                            <%= review.design_kit_shop_item&.name || "Kit" %>
+                          <% elsif review.approved_without_grant? %>
+                            No grant
+                          <% else %>
+                            $<%= review.final_amount_dollars %> · <%= review.tier_label %>
+                          <% end %>
                         </span>
                       <% end %>
                       <% if review.decided_at %>

--- a/app/views/mission_submissions/redeem.html.erb
+++ b/app/views/mission_submissions/redeem.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Redeem prize — #{@submission.mission.name}" %>
+<% content_for :title, "Claim prizes — #{@submission.mission.name}" %>
 
 <div class="app-layout">
   <div class="app-layout__main">
@@ -6,8 +6,8 @@
       <p class="submission-redeem__breadcrumb">
         <%= link_to @submission.mission.name, mission_path(@submission.mission.slug) %>
       </p>
-      <h1>Pick a prize</h1>
-      <p>Approved submission for <strong><%= @submission.mission.name %></strong>. Pick which prize you'd like to redeem.</p>
+      <h1>Claim your prizes</h1>
+      <p>Approved submission for <strong><%= @submission.mission.name %></strong>. Every prize below is yours, and each one is claimed on its own.</p>
     </header>
 
     <% if @prizes.any? %>
@@ -18,7 +18,7 @@
             <% if prize.shop_item.description.present? %>
               <p><%= prize.shop_item.description %></p>
             <% end %>
-            <%= link_to "Redeem this prize",
+            <%= link_to "Claim this prize",
                         shop_item_path(prize.shop_item, mission_submission_id: @submission.id),
                         class: "action-btn action-btn--large action-btn--primary" %>
           </li>
@@ -26,6 +26,17 @@
       </ul>
     <% else %>
       <p>This mission has no prizes configured. Contact an admin if you believe this is wrong.</p>
+    <% end %>
+
+    <% if @claimed_prizes.any? %>
+      <ul class="submission-redeem__prizes submission-redeem__prizes--claimed">
+        <% @claimed_prizes.each do |prize| %>
+          <li class="submission-redeem__prize submission-redeem__prize--claimed">
+            <h3><%= prize.shop_item.name %></h3>
+            <p class="submission-redeem__claimed-label">Already claimed</p>
+          </li>
+        <% end %>
+      </ul>
     <% end %>
   </div>
 </div>

--- a/app/views/notification_mailer/funding_request_reviewed.html.erb
+++ b/app/views/notification_mailer/funding_request_reviewed.html.erb
@@ -8,8 +8,10 @@
 
 <% if approved %>
   <p style="margin:0 0 16px;font-size:15px;line-height:1.55;color:#3a3a4a;">
-    <% if project %>
+    <% if project && @record.issues_grant? %>
       <strong><%= project.title %></strong> is approved for <strong>$<%= @record.final_amount_dollars %></strong> in funding<% if @actor %>, reviewed by <strong>@<%= @actor.display_name %></strong><% end %>.
+    <% elsif project %>
+      <strong><%= project.title %></strong> is approved<% if @actor %>, reviewed by <strong>@<%= @actor.display_name %></strong><% end %>.
     <% else %>
       Your hardware funding request was approved.
     <% end %>

--- a/app/views/notification_mailer/funding_request_reviewed.text.erb
+++ b/app/views/notification_mailer/funding_request_reviewed.text.erb
@@ -5,8 +5,10 @@
 <% if approved %>
 Your funding request was approved!
 
-<% if project %>
+<% if project && @record.issues_grant? %>
 "<%= project.title %>" is approved for $<%= @record.final_amount_dollars %> in funding<% if @actor %>, reviewed by @<%= @actor.display_name %><% end %>.
+<% elsif project %>
+"<%= project.title %>" is approved<% if @actor %>, reviewed by @<%= @actor.display_name %><% end %>.
 <% else %>
 Your hardware funding request was approved.
 <% end %>

--- a/app/views/notifications/hardware/funding_request_reviewed.slack_message.slocks
+++ b/app/views/notifications/hardware/funding_request_reviewed.slack_message.slocks
@@ -3,8 +3,10 @@ if approved
 
   if awards_kit
     section "*<#{project_url}|#{project_title}>* is approved and has moved to the build phase. Head to your project to redeem your kit.", markdown: true
-  else
+  elsif issues_grant
     section "*<#{project_url}|#{project_title}>* is approved for *$#{amount_dollars}* in funding (#{tier_label}) and has moved to the build phase.", markdown: true
+  else
+    section "*<#{project_url}|#{project_title}>* is approved and has moved to the build phase. This approval doesn't come with a grant.", markdown: true
   end
 
   section "Log your build hours with a timelapse, then ship when you're ready."

--- a/app/views/projects/_funding_request_card.html.erb
+++ b/app/views/projects/_funding_request_card.html.erb
@@ -1,6 +1,11 @@
 <%# A funding request on the project timeline. Deliberately short: the whole
     point is the amount and, once decided, the verdict.
 
+    The reviewer's feedback is the card's body text, since that is the part
+    written for this project. The verdict's standing explanation (what the
+    status means, what happens next) moves into a "?" tooltip on the byline,
+    and only falls back to being the body when there is no feedback to show.
+
     Reviewer feedback is shown to the project owner only. The card itself is
     already members-and-admins (see ProjectsController#visible_funding_requests),
     but feedback names a reviewer and explains a rejection, so it stays with the
@@ -44,7 +49,7 @@
 <article id="<%= dom_id(funding_request) %>"
          class="<%= class_names("feed-post-card", "funding-request-card",
                                 "funding-request-card--#{funding_request.status}") %>">
-  <header class="feed-post-card__header">
+  <header class="feed-post-card__header funding-request-card__header">
     <% if reviewer && !funding_request.pending? %>
       <%= link_to profile_path(reviewer.display_name), class: "feed-post-card__avatar-link",
             aria: { label: "@#{reviewer.display_name}" } do %>
@@ -63,6 +68,9 @@
           <span class="feed-post-card__author"><%= owner&.display_name || "Someone" %></span>
         <% end %>
         <span class="feed-post-card__context"><%= context %></span>
+        <% if show_feedback %>
+          <%= render "shared/help_tooltip", text: message %>
+        <% end %>
         <time class="feed-post-card__time" datetime="<%= decided_on.iso8601 %>"
               title="<%= l(decided_on, format: :long) %>">
           · <%= time_ago_in_words(decided_on) %> ago
@@ -79,17 +87,12 @@
   </header>
 
   <div class="feed-post-card__body funding-request-card__message">
-    <p><%= message %></p>
+    <% if show_feedback %>
+      <%= simple_format(funding_request.feedback, {}, sanitize: true) %>
+    <% else %>
+      <p><%= message %></p>
+    <% end %>
   </div>
-
-  <% if show_feedback %>
-    <section class="feed-post-card__body funding-request-card__feedback" aria-label="Reviewer feedback">
-      <p class="funding-request-card__feedback-label">Feedback</p>
-      <div class="funding-request-card__feedback-body">
-        <%= simple_format(funding_request.feedback, {}, sanitize: true) %>
-      </div>
-    </section>
-  <% end %>
 
   <% if funding_request.returned? && viewer_is_owner && resubmit_modal_id.present? %>
     <div class="funding-request-card__actions">

--- a/app/views/projects/_funding_request_card.html.erb
+++ b/app/views/projects/_funding_request_card.html.erb
@@ -23,6 +23,8 @@
       "Approved! Your kit is on the way. Log your build hours with a timelapse, then ship when you're ready."
     elsif awards_kit
       "Approved, and the project has moved to the build stage. Redeem your kit below to get it shipped."
+    elsif funding_request.approved_without_grant?
+      "Approved, and the project has moved to the build stage. This one comes without a grant, so keep logging your build hours and ship when you're ready."
     else
       "Approved for $#{funding_request.final_amount_dollars}, and the project has moved to the build stage. Your grant card follows once it has been issued."
     end

--- a/app/views/projects/_funding_request_card.html.erb
+++ b/app/views/projects/_funding_request_card.html.erb
@@ -15,14 +15,13 @@
   show_feedback = funding_request.feedback.present? && !funding_request.pending? && (viewer_is_owner || current_user&.admin?)
 
   awards_kit = funding_request.awards_design_kit?
-  kit_prize = awards_kit ? project.current_mission.prizes.after_design.ordered.first : nil
-  kit_redeemed = awards_kit && Mission::PrizeRedemption.exists?(source: funding_request)
+  unclaimed_kits = awards_kit ? funding_request.unredeemed_prizes.to_a : []
 
   approved_message =
-    if awards_kit && kit_redeemed
-      "Approved! Your kit is on the way. Log your build hours with a timelapse, then ship when you're ready."
+    if awards_kit && unclaimed_kits.none?
+      "Approved! Everything you claimed is on the way. Log your build hours with a timelapse, then ship when you're ready."
     elsif awards_kit
-      "Approved, and the project has moved to the build stage. Redeem your kit below to get it shipped."
+      "Approved, and the project has moved to the build stage. Claim your #{"kit".pluralize(unclaimed_kits.size)} below to get shipped."
     elsif funding_request.approved_without_grant?
       "Approved, and the project has moved to the build stage. This one comes without a grant, so keep logging your build hours and ship when you're ready."
     else
@@ -101,10 +100,13 @@
     </div>
   <% end %>
 
-  <% if funding_request.approved? && viewer_is_owner && kit_prize && !kit_redeemed %>
+  <% if funding_request.approved? && viewer_is_owner && unclaimed_kits.any? %>
     <div class="funding-request-card__actions">
-      <%= link_to "Redeem your kit", shop_item_path(kit_prize.shop_item, funding_request_id: funding_request.id),
-            class: "action-btn action-btn--small action-btn--primary" %>
+      <% unclaimed_kits.each do |prize| %>
+        <%= link_to "Claim #{prize.shop_item.name}",
+              shop_item_path(prize.shop_item, funding_request_id: funding_request.id),
+              class: "action-btn action-btn--small action-btn--primary" %>
+      <% end %>
     </div>
   <% end %>
 </article>

--- a/app/views/projects/_ship_card.html.erb
+++ b/app/views/projects/_ship_card.html.erb
@@ -66,10 +66,10 @@
         <% else %>
           <span class="project-show__latest-ship-status project-show__latest-ship-status--returned">Mission returned</span>
         <% end %>
-      <% elsif mission_sub&.approved? && mission_sub.shop_order_id.nil? && mission_sub.mission.prizes_count > 0 %>
+      <% elsif mission_sub&.approved? && (unclaimed_prizes = mission_sub.unredeemed_prizes.count) > 0 %>
         <%= link_to redeem_mission_submission_path(mission_sub),
                     class: "project-show__latest-ship-status project-show__latest-ship-status--approved project-show__latest-ship-status--clickable" do %>
-          Claim prize ↗
+          <%= "Claim #{"prize".pluralize(unclaimed_prizes)} ↗" %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -150,7 +150,7 @@
 
             <div class="project-show__edit-grid" data-controller="project-type">
               <div class="project-show__field project-show__field--inline">
-                <span>Project type <%= render "projects/help_tooltip", text: "Software projects track coding time with Hackatime. Hardware projects (electronics, 3D printing, robotics, etc.) record a screen/build timelapse instead." %></span>
+                <span>Project type <%= render "shared/help_tooltip", text: "Software projects track coding time with Hackatime. Hardware projects (electronics, 3D printing, robotics, etc.) record a screen/build timelapse instead." %></span>
                 <%# Locked once the project has asked for funding or shipped: the
                     stage decides how the ship is paid, so the model refuses the
                     change and a live control here would only fail validation. %>
@@ -188,7 +188,7 @@
               <div class="project-show__field project-show__field--inline"
                    data-project-type-target="stageSection"
                    <%= "hidden" unless @project.hardware? %>>
-                <span>Project stage <%= render "projects/help_tooltip", text: "\"I need Funding\" means you're still designing and need a grant to buy parts. Submit your design for funding to move to building. \"I don't need Funding\" means you already have your parts and are building." %></span>
+                <span>Project stage <%= render "shared/help_tooltip", text: "\"I need Funding\" means you're still designing and need a grant to buy parts. Submit your design for funding to move to building. \"I don't need Funding\" means you already have your parts and are building." %></span>
                 <% if @project.hardware_stage_locked? %>
                   <% fr = @project.latest_funding_request %>
                   <div class="project-show__stage-toggle project-show__stage-toggle--locked" aria-label="Project stage (locked)">
@@ -298,7 +298,7 @@
               </div>
 
               <label class="project-show__field project-show__field--inline">
-                <span>AI usage declaration <%= render "projects/help_tooltip", text: "Describe how you used AI in this project (e.g. \"Used ChatGPT for debugging\", \"GitHub Copilot for code completion\"). AI use is OK, but it should feel like your own work! If you didn't use AI, write \"None\"." %></span>
+                <span>AI usage declaration <%= render "shared/help_tooltip", text: "Describe how you used AI in this project (e.g. \"Used ChatGPT for debugging\", \"GitHub Copilot for code completion\"). AI use is OK, but it should feel like your own work! If you didn't use AI, write \"None\"." %></span>
                 <%= form.text_area :ai_declaration,
                                    rows: 2,
                                    maxlength: 1000,
@@ -321,7 +321,7 @@
               <label class="project-show__field project-show__field--inline"
                      data-project-form-target="updateDescriptionContainer"
                      <%= "hidden" if @project.update_description.blank? %>>
-                <span>Update Description <%= render "projects/help_tooltip", text: "Describe the features you've added or updated, and the impact these changes have had on your project overall. Please be specific." %></span>
+                <span>Update Description <%= render "shared/help_tooltip", text: "Describe the features you've added or updated, and the impact these changes have had on your project overall. Please be specific." %></span>
                 <%= form.text_area :update_description,
                                    rows: 3,
                                    maxlength: 1000,
@@ -334,7 +334,7 @@
               <div class="project-show__sparkle" aria-hidden="true"></div>
 
               <label class="project-show__field project-show__field--inline">
-                <span>Demo URL <%= render "projects/help_tooltip", text: @project.hardware? ? "An IRL video of your project working." : "A live URL where anyone can try your project." %></span>
+                <span>Demo URL <%= render "shared/help_tooltip", text: @project.hardware? ? "An IRL video of your project working." : "A live URL where anyone can try your project." %></span>
                 <%= form.url_field :demo_url,
                                    class: "project-show__control",
                                    placeholder: "https://example.com",
@@ -346,7 +346,7 @@
               </label>
 
               <label class="project-show__field project-show__field--inline">
-                <span>Github URL <%= render "projects/help_tooltip", text: "A public repository URL." %></span>
+                <span>Github URL <%= render "shared/help_tooltip", text: "A public repository URL." %></span>
                 <%= form.url_field :repo_url,
                                    class: "project-show__control",
                                    placeholder: "https://github.com/user/repo",
@@ -360,7 +360,7 @@
               <label class="project-show__field project-show__field--inline"
                      data-project-form-target="readmeContainer"
                      <%= "hidden" if @project.readme_url.blank? %>>
-                <span>Readme URL <%= render "projects/help_tooltip", text: "A raw README URL for your project page." %></span>
+                <span>Readme URL <%= render "shared/help_tooltip", text: "A raw README URL for your project page." %></span>
                 <%= form.url_field :readme_url,
                                    class: "project-show__control",
                                    placeholder: "https://raw.githubusercontent.com/user/repo/main/README.md",

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -195,8 +195,10 @@
                     <span class="project-show__stage-choice-label project-show__stage-choice-label--locked">
                       <% if fr.nil? %>
                         Design Stage
-                      <% elsif fr.approved? %>
+                      <% elsif fr.issues_grant? %>
                         Design Stage — $<%= fr.final_amount_dollars %> approved
+                      <% elsif fr.approved? %>
+                        Design Stage — approved
                       <% elsif fr.pending? %>
                         Design Stage — $<%= fr.requested_amount_dollars %> under review
                       <% else %>

--- a/app/views/shared/_help_tooltip.html.erb
+++ b/app/views/shared/_help_tooltip.html.erb
@@ -1,7 +1,7 @@
 <%# Themed hover/focus tooltip for the little "?" help badges next to form
-    fields. Uses the standard tooltip controller.
+    fields and post bylines. Uses the standard tooltip controller.
     Locals: text (tooltip body), position (default "top"). %>
-<span class="project-show__help"
+<span class="help-badge"
       tabindex="0"
       aria-label="<%= text %>"
       data-controller="tooltip"

--- a/test/controllers/admin/certification/hardware_reviews_controller_test.rb
+++ b/test/controllers/admin/certification/hardware_reviews_controller_test.rb
@@ -170,10 +170,26 @@ class Admin::Certification::HardwareReviewsControllerTest < ActionDispatch::Inte
     HCBService.stub(:create_card_grant, HCB_GRANT_RESPONSE) do
       patch admin_certification_funding_request_path(@funding),
             params: { redirect_to_hardware: @design_project.id,
-                      certification_funding_request: { status: "approved", feedback: "looks good" } }
+                      certification_funding_request: { verdict: "approved", feedback: "looks good" } }
     end
 
     assert_redirected_to next_admin_certification_hardware_reviews_path(stage: "design")
+  end
+
+  test "a reviewer can approve a design without issuing a grant" do
+    ::Certification::FundingRequest.atomic_claim!(@funding.id, @reviewer)
+
+    grant_called = false
+    HCBService.stub(:create_card_grant, ->(*) { grant_called = true; HCB_GRANT_RESPONSE }) do
+      patch admin_certification_funding_request_path(@funding),
+            params: { redirect_to_hardware: @design_project.id,
+                      certification_funding_request: { verdict: "approved_without_grant", feedback: "you're covered" } }
+    end
+
+    assert_not grant_called
+    assert @funding.reload.approved_without_grant?
+    assert_nil @funding.hcb_grant_hashid
+    assert_equal "build", @design_project.reload.hardware_stage
   end
 
   test "an emptied design queue lands back on the design queue, not a dead end" do
@@ -181,7 +197,7 @@ class Admin::Certification::HardwareReviewsControllerTest < ActionDispatch::Inte
     HCBService.stub(:create_card_grant, HCB_GRANT_RESPONSE) do
       patch admin_certification_funding_request_path(@funding),
             params: { redirect_to_hardware: @design_project.id,
-                      certification_funding_request: { status: "approved", feedback: "looks good" } }
+                      certification_funding_request: { verdict: "approved", feedback: "looks good" } }
     end
     follow_redirect!
 

--- a/test/controllers/admin/missions/hardware_reviews_controller_test.rb
+++ b/test/controllers/admin/missions/hardware_reviews_controller_test.rb
@@ -65,7 +65,7 @@ class Admin::Missions::HardwareReviewsControllerTest < ActionDispatch::Integrati
     HCBService.stub(:create_card_grant, HCB_GRANT_RESPONSE) do
       patch admin_certification_funding_request_path(@funding),
             params: { redirect_to_hardware: @design_project.id,
-                      certification_funding_request: { status: "approved", feedback: "looks good" } }
+                      certification_funding_request: { verdict: "approved", feedback: "looks good" } }
     end
 
     assert_redirected_to next_admin_mission_hardware_reviews_path(@mission.slug, stage: "design")

--- a/test/controllers/projects/funding_requests_controller_test.rb
+++ b/test/controllers/projects/funding_requests_controller_test.rb
@@ -102,7 +102,8 @@ class Projects::FundingRequestsControllerTest < ActionDispatch::IntegrationTest
     get project_path(@project)
 
     assert_select ".funding-request-card--returned"
-    assert_select ".funding-request-card__feedback-body", text: /bill of materials/
+    assert_select ".funding-request-card__message", text: /bill of materials/
+    assert_select ".funding-request-card .help-badge"
   end
 
   test "a returned request offers the owner a resubmit button" do
@@ -126,16 +127,17 @@ class Projects::FundingRequestsControllerTest < ActionDispatch::IntegrationTest
     assert_select ".funding-request-card__actions button", count: 0
   end
 
-  # A pending request has nothing decided to explain yet.
-  test "a pending request shows no feedback section" do
+  # A pending request has nothing decided to explain yet, so the standing copy
+  # stays in the body instead of collapsing into the tooltip.
+  test "a pending request shows the standing message and no help tooltip" do
     @project.certification_funding_requests.create!(
       user: @owner, complexity_tier: 2, requested_amount_cents: 4_000, status: :pending
     )
 
     get project_path(@project)
 
-    assert_select ".funding-request-card"
-    assert_select ".funding-request-card__feedback", count: 0
+    assert_select ".funding-request-card__message", text: /Waiting on a reviewer/
+    assert_select ".funding-request-card .help-badge", count: 0
   end
 
   private

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -9,7 +9,7 @@
 #  group_count        :integer          default(1), not null
 #  group_key          :string
 #  params             :jsonb            not null
-#  priority           :integer          default(NULL), not null
+#  priority           :integer          default(0), not null
 #  read_at            :datetime
 #  record_type        :string
 #  seen_at            :datetime

--- a/test/integration/hardware_kit_redemption_test.rb
+++ b/test/integration/hardware_kit_redemption_test.rb
@@ -42,6 +42,29 @@ class HardwareKitRedemptionTest < ActionDispatch::IntegrationTest
     assert_redirected_to shop_path
   end
 
+  test "a second kit on the same mission stays claimable after the first is claimed" do
+    second_kit = ShopItem.new(name: "Extra Kit #{SecureRandom.hex(3)}", description: "the other kit", ticket_cost: 0,
+                              type: "ShopItem::ThirdPartyPhysical", enabled: true, mission_prize_only: true)
+    second_kit.image.attach(io: StringIO.new(PIXEL_PNG), filename: "kit2.png", content_type: "image/png")
+    second_kit.save!
+    @mission.prizes.create!(shop_item: second_kit, position: 1, category: :after_design)
+
+    @owner.update!(has_gotten_free_stickers: true) # clears the shop-tutorial gate
+    order = @owner.shop_orders.new(shop_item: @kit, quantity: 1,
+                                   frozen_address: { "country" => "US", "phone_number" => "+15555550123" })
+    order.redeeming_funding_request = @funding_request
+    order.aasm_state = "pending"
+    order.save!
+    Mission::PrizeRedemption.record!(shop_order: order, gate: @funding_request)
+
+    sign_in @owner
+    get shop_item_path(second_kit, funding_request_id: @funding_request.id)
+    assert_response :success
+
+    get shop_item_path(@kit, funding_request_id: @funding_request.id)
+    assert_redirected_to shop_path, "an already-claimed kit stops being redeemable"
+  end
+
   test "the kit is not redeemable without an approved request" do
     @funding_request.update!(status: :returned, feedback: "nope")
     sign_in @owner

--- a/test/models/certification/funding_request_test.rb
+++ b/test/models/certification/funding_request_test.rb
@@ -141,6 +141,40 @@ class Certification::FundingRequestTest < ActiveSupport::TestCase
     assert_equal true, fr.notification_locals[:awards_kit]
   end
 
+  test "approving without a grant advances the project but issues no grant" do
+    fr = @project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 3, requested_amount_cents: 6_000, status: :pending
+    )
+
+    grant_called = false
+    HCBService.stub(:create_card_grant, ->(*) { grant_called = true; HCB_GRANT_RESPONSE }) do
+      fr.update!(reviewer: @reviewer, verdict: "approved_without_grant", approved_amount_dollars: 60)
+    end
+
+    assert_not grant_called, "approving without a grant should not issue an HCB grant"
+    fr.reload
+    assert fr.approved?
+    assert fr.approved_without_grant?
+    assert_not fr.issues_grant?
+    assert_equal 0, fr.approved_amount_cents, "the submitted amount is ignored"
+    assert_nil fr.hcb_grant_hashid
+    assert_equal "build", @project.reload.hardware_stage
+    assert_equal Certification::FundingRequest::REVIEW_BOUNTY, fr.stardust_earned
+  end
+
+  test "the verdict reader reflects how an approval was funded" do
+    fr = @project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 2, requested_amount_cents: 3_000, status: :pending
+    )
+    assert_nil fr.verdict
+
+    HCBService.stub(:create_card_grant, HCB_GRANT_RESPONSE) do
+      fr.update!(reviewer: @reviewer, status: :approved)
+    end
+
+    assert_equal "approved", Certification::FundingRequest.find(fr.id).verdict
+  end
+
   test "approving a superseded funding request does not advance the project or issue a grant" do
     old = @project.certification_funding_requests.create!(
       user: @owner, complexity_tier: 2, requested_amount_cents: 3_000, status: :pending

--- a/test/models/certification/funding_request_test.rb
+++ b/test/models/certification/funding_request_test.rb
@@ -15,7 +15,7 @@
 #  lock_version              :integer          default(0), not null
 #  requested_amount_cents    :integer          not null
 #  stardust_earned           :integer
-#  status                    :integer          default("pending"), not null
+#  status                    :integer          default(0), not null
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  project_id                :bigint           not null

--- a/test/models/certification/ship_test.rb
+++ b/test/models/certification/ship_test.rb
@@ -15,7 +15,7 @@
 #  proof_video_url           :string
 #  recert_reason             :text
 #  stardust_earned           :float
-#  status                    :integer          default("pending"), not null
+#  status                    :integer          default(0), not null
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  external_certification_id :string

--- a/test/models/mission/prize_redemption_test.rb
+++ b/test/models/mission/prize_redemption_test.rb
@@ -80,6 +80,47 @@ class Mission::PrizeRedemptionTest < ActiveSupport::TestCase
     assert_equal ship_prize.id, submission.chosen_prize_id
   end
 
+  test "an approved design claims every after-design kit, once each" do
+    kits = [ prize_item("Kit A"), prize_item("Kit B") ]
+    kits.each_with_index { |kit, i| @mission.prizes.create!(shop_item: kit, position: i, category: :after_design) }
+    other = prize_item("After ship")
+    @mission.prizes.create!(shop_item: other, position: 0, category: :after_shipping)
+
+    funding_request = @project.certification_funding_requests.create!(user: @owner, status: :pending)
+    funding_request.update!(status: :approved)
+
+    assert_equal 2, funding_request.unredeemed_prizes.count
+    assert_nil funding_request.redeemable_prize_for(other), "an after-ship prize is not claimable at design"
+
+    kits.each do |kit|
+      Mission::PrizeRedemption.record!(shop_order: free_order(kit, funding_request), gate: funding_request)
+    end
+
+    assert_equal 2, funding_request.prize_redemptions.count
+    assert_empty funding_request.unredeemed_prizes
+    assert_not funding_request.prizes_to_claim?
+    # A second go at a kit already claimed is no longer redeemable.
+    assert_nil funding_request.redeemable_prize_for(kits.first)
+  end
+
+  test "an approved submission claims every after-ship prize, once each" do
+    rewards = [ prize_item("Reward A"), prize_item("Reward B") ]
+    rewards.each_with_index { |item, i| @mission.prizes.create!(shop_item: item, position: i, category: :after_shipping) }
+    submission = ship_to_mission!(@project, @owner, @mission, status: "approved")
+
+    first_order = free_order(rewards.first, submission)
+    Mission::PrizeRedemption.record!(shop_order: first_order, gate: submission)
+
+    assert submission.prizes_to_claim?, "the second prize is still claimable"
+
+    Mission::PrizeRedemption.record!(shop_order: free_order(rewards.second, submission), gate: submission)
+
+    assert_equal 2, submission.prize_redemptions.count
+    assert_not submission.prizes_to_claim?
+    # The legacy inline link keeps pointing at the first claim.
+    assert_equal first_order.id, submission.reload.shop_order_id
+  end
+
   test "record! ignores an item that is not a prize on the gate's mission" do
     kit = prize_item("Kit")
     @mission.prizes.create!(shop_item: kit, position: 0, category: :after_design)

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -7,7 +7,7 @@
 #  group_count        :integer          default(1), not null
 #  group_key          :string
 #  params             :jsonb            not null
-#  priority           :integer          default(NULL), not null
+#  priority           :integer          default(0), not null
 #  read_at            :datetime
 #  record_type        :string
 #  seen_at            :datetime

--- a/test/models/rsvp/game_test.rb
+++ b/test/models/rsvp/game_test.rb
@@ -5,7 +5,7 @@
 #  id         :bigint           not null, primary key
 #  board      :string           default("---------"), not null
 #  move_count :integer          default(0), not null
-#  status     :integer          default("in_progress"), not null
+#  status     :integer          default(0), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  rsvp_id    :bigint           not null


### PR DESCRIPTION
## what's this do?

- adds an option to approve a funding request without a grant, allowing things already funded for outpost to get through the system
- claim every prize in the prize list
- fix funding req post

## show it works

<img width="1286" height="189" alt="image" src="https://github.com/user-attachments/assets/5cf6fe06-f729-441d-82e1-deb390ea8417" />
<img width="717" height="1338" alt="image" src="https://github.com/user-attachments/assets/e14cbaa9-aa30-415a-90bc-ea29b5a21b1a" />


## ai?

claude
