### PR TITLE
fix(hardware): skip timelapses whose project was deleted (STARDANCE-GR)

### DIFF
--- a/app/controllers/my/timelapses_controller.rb
+++ b/app/controllers/my/timelapses_controller.rb
@@ -8,8 +8,13 @@ class My::TimelapsesController < ApplicationController
   def index
     @deadline = LookoutSession::FINALIZE_DEADLINE
     @window_open = Time.current <= @deadline
+    # Only sessions whose project still exists: Project's default_scope hides
+    # soft-deleted rows, so an orphaned session's `project` is nil and the view
+    # (and forward path) would blow up. A deleted project can't be recovered to
+    # anyway.
     @sessions = LookoutSession.where(user: current_user)
                               .recoverable
+                              .where(project_id: Project.select(:id))
                               .includes(:project)
                               .order(Arel.sql("COALESCE(started_at, created_at) DESC"))
     # Which sessions Hackatime already has, matched exactly by heartbeat entity

--- a/test/integration/timelapses_recovery_test.rb
+++ b/test/integration/timelapses_recovery_test.rb
@@ -26,6 +26,23 @@ class TimelapsesRecoveryTest < ActionDispatch::IntegrationTest
     assert_select "form[action=?]", forward_heartbeats_project_lookout_session_path(@project, @pushed), count: 0
   end
 
+  test "skips sessions whose project was soft-deleted instead of crashing the page" do
+    orphan_project = projects(:two)
+    orphan = LookoutSession.create!(user: @user, project: orphan_project, token: "tok-orphan",
+                                    status: "complete", duration_seconds: 600,
+                                    started_at: Time.utc(2026, 7, 17, 12))
+    orphan_project.update_column(:deleted_at, Time.current)
+    assert_nil orphan.reload.project, "guard assumes a soft-deleted project reads back as nil"
+
+    LookoutPushStatus.stub(:pushed_tokens, Set.new) do
+      get my_timelapses_path
+    end
+
+    assert_response :success
+    assert_select "form[action=?]", forward_heartbeats_project_lookout_session_path(orphan_project, orphan), count: 0
+    assert_select "form[action=?]", forward_heartbeats_project_lookout_session_path(@project, @pending)
+  end
+
   test "one-click send forwards the session to Hackatime and returns to the list" do
     forwarded = nil
     ok = Struct.new(:ok, :error, :count) { def ok? = ok }.new(true, nil, 3)


### PR DESCRIPTION
## what's this do?

- skips trying to recover timelapses for projects that were deleted

## ai?

claude
