### PR TITLE
Count late Hackatime heartbeats in the next devlog

### DIFF
--- a/app/controllers/projects/devlogs_controller.rb
+++ b/app/controllers/projects/devlogs_controller.rb
@@ -248,7 +248,11 @@ class Projects::DevlogsController < ApplicationController
     return apply_test_time_preview if test_time_granted? && hackatime_keys.blank?
     return @preview_time = nil unless hackatime_keys.present?
 
-    seconds = @project.seconds_coded_in_devlog_window(current_user.hackatime_identity&.uid, access_token: current_user.hackatime_identity&.access_token)
+    seconds = @project.unlogged_hackatime_seconds(
+      current_user.hackatime_identity&.uid,
+      user: current_user,
+      access_token: current_user.hackatime_identity&.access_token
+    )
     return apply_test_time_preview if test_time_granted? && seconds.nil?
 
     if seconds.nil?

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -60,7 +60,11 @@ class ProjectsController < ApplicationController
         @hackatime_times = result&.dig(:projects) || {}
         @hackatime_token_stale = current_user.hackatime_token_stale?
         identity = current_user.hackatime_identity
-        @unposted_seconds = @project.seconds_coded_in_devlog_window(identity.uid, access_token: identity.access_token).to_i
+        @unposted_seconds = @project.unlogged_hackatime_seconds(
+          identity.uid,
+          user: current_user,
+          access_token: identity.access_token
+        ).to_i
 
         linked_ids = @linked_hackatime_projects.map(&:id).to_set
         taken_project_ids = @all_hackatime_projects.map(&:project_id).compact.uniq - [ @project.id ]

--- a/app/jobs/devlog_cap_warning_job.rb
+++ b/app/jobs/devlog_cap_warning_job.rb
@@ -38,7 +38,11 @@ class DevlogCapWarningJob < ApplicationJob
     return if Time.current - window_start < Post::ShipEvent::DEVLOG_CAP_WARNING_SECONDS
     return if already_notified?(project, owner, window_start)
 
-    unposted = project.seconds_coded_in_devlog_window(identity.uid, access_token: identity.access_token).to_i
+    unposted = project.unlogged_hackatime_seconds(
+      identity.uid,
+      user: owner,
+      access_token: identity.access_token
+    ).to_i
     sleep API_PAUSE_SECONDS
     return if unposted < Post::ShipEvent::DEVLOG_CAP_WARNING_SECONDS
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -527,14 +527,25 @@ class Project < ApplicationRecord
     (total_seconds / 3600.0).round(1)
   end
 
-  def seconds_coded_in_devlog_window(hackatime_uid, at: Time.current, access_token: nil)
-    HackatimeService.fetch_total_seconds_for_projects(
+  # Query the whole event so heartbeats uploaded after an earlier devlog can
+  # still be claimed, then remove the time this author has already logged.
+  def unlogged_hackatime_seconds(hackatime_uid, user:, at: Time.current, access_token: nil)
+    total_seconds = HackatimeService.fetch_total_seconds_for_projects(
       hackatime_uid,
       hackatime_keys,
-      start_date: devlog_window_start(at).iso8601,
+      start_date: HackatimeService::START_DATE,
       end_date: at.iso8601,
       access_token: access_token
     )
+    return unless total_seconds
+
+    logged_seconds = posts.of_devlogs(join: true)
+      .where(user: user, post_devlogs: { deleted_at: nil })
+      .where("post_devlogs.hackatime_projects_key_snapshot IS DISTINCT FROM ?", "test")
+      .where("post_devlogs.created_at < ?", at)
+      .sum("post_devlogs.duration_seconds")
+
+    [ total_seconds - logged_seconds, 0 ].max
   end
 
   # Where the current devlog window opened: the previous devlog, or for the

--- a/test/models/project/hackatime_unlogged_time_test.rb
+++ b/test/models/project/hackatime_unlogged_time_test.rb
@@ -1,0 +1,90 @@
+require "test_helper"
+
+class Project::HackatimeUnloggedTimeTest < ActiveSupport::TestCase
+  self.fixture_table_names = []
+
+  setup do
+    @owner = create_user(slack_id: "U_UNLOGGED_OWNER", display_name: "unlogged_owner")
+    @collaborator = create_user(slack_id: "U_UNLOGGED_COLLABORATOR", display_name: "unlogged_collaborator")
+    @project = Project.create!(title: "Late heartbeats", description: "Testing cumulative Hackatime totals")
+    @project.memberships.create!(user: @owner, role: :owner)
+    @project.memberships.create!(user: @collaborator, role: :contributor)
+    User::HackatimeProject.insert_all!([
+      { user_id: @owner.id, project_id: @project.id, name: "late-heartbeats", created_at: Time.current, updated_at: Time.current }
+    ])
+  end
+
+  test "fetches time from the event start" do
+    at = Time.zone.parse("2026-06-10 12:00:00")
+    request = nil
+    fetch = lambda do |uid, keys, **options|
+      request = { uid: uid, keys: keys, options: options }
+      2.hours.to_i
+    end
+
+    seconds = HackatimeService.stub(:fetch_total_seconds_for_projects, fetch) do
+      @project.unlogged_hackatime_seconds("ht-owner", user: @owner, at: at, access_token: "secret")
+    end
+
+    assert_equal 2.hours.to_i, seconds
+    assert_equal "ht-owner", request[:uid]
+    assert_equal [ "late-heartbeats" ], request[:keys]
+    assert_equal HackatimeService::START_DATE, request[:options][:start_date]
+    assert_equal at.iso8601, request[:options][:end_date]
+  end
+
+  test "includes late heartbeats in the next devlog without double counting logged time" do
+    create_devlog(user: @owner, duration: 1.hour, at: 1.day.ago)
+
+    seconds = HackatimeService.stub(:fetch_total_seconds_for_projects, 2.5.hours.to_i) do
+      @project.unlogged_hackatime_seconds("ht-owner", user: @owner)
+    end
+
+    assert_equal 1.5.hours.to_i, seconds
+  end
+
+  test "only subtracts devlogs written by the current author" do
+    create_devlog(user: @owner, duration: 1.hour, at: 2.days.ago)
+    create_devlog(user: @collaborator, duration: 3.hours, at: 1.day.ago)
+
+    seconds = HackatimeService.stub(:fetch_total_seconds_for_projects, 2.5.hours.to_i) do
+      @project.unlogged_hackatime_seconds("ht-owner", user: @owner)
+    end
+
+    assert_equal 1.5.hours.to_i, seconds
+  end
+
+  test "does not subtract granted test time" do
+    create_devlog(user: @owner, duration: 15.minutes, at: 1.day.ago, key_snapshot: "test")
+
+    seconds = HackatimeService.stub(:fetch_total_seconds_for_projects, 1.hour.to_i) do
+      @project.unlogged_hackatime_seconds("ht-owner", user: @owner)
+    end
+
+    assert_equal 1.hour.to_i, seconds
+  end
+
+  test "subtracts legacy devlogs without a project key snapshot" do
+    create_devlog(user: @owner, duration: 1.hour, at: 1.day.ago, key_snapshot: nil)
+
+    seconds = HackatimeService.stub(:fetch_total_seconds_for_projects, 2.hours.to_i) do
+      @project.unlogged_hackatime_seconds("ht-owner", user: @owner)
+    end
+
+    assert_equal 1.hour.to_i, seconds
+  end
+
+  private
+
+  def create_devlog(user:, duration:, at:, key_snapshot: "late-heartbeats")
+    devlog = Post::Devlog.new(
+      body: "Progress update",
+      duration_seconds: duration,
+      hackatime_projects_key_snapshot: key_snapshot,
+      created_at: at
+    )
+    devlog.uploading_attachments = true
+    devlog.save!
+    Post.create!(project: @project, user: user, postable: devlog, created_at: at)
+  end
+end

--- a/test/models/project/hackatime_unlogged_time_test.rb
+++ b/test/models/project/hackatime_unlogged_time_test.rb
@@ -4,7 +4,7 @@ class Project::HackatimeUnloggedTimeTest < ActiveSupport::TestCase
   self.fixture_table_names = []
 
   setup do
-    @owner = create_user(slack_id: "U_UNLOGGED_OWNER", display_name: "unlogged_owner")
+    @owner = create_user(slack_id: "U059VC0UDEU", display_name: "mahad")
     @project = Project.create!(title: "Late heartbeats", description: "Testing cumulative Hackatime totals")
     @project.memberships.create!(user: @owner, role: :owner)
     User::HackatimeProject.insert_all!([

--- a/test/models/project/hackatime_unlogged_time_test.rb
+++ b/test/models/project/hackatime_unlogged_time_test.rb
@@ -5,10 +5,8 @@ class Project::HackatimeUnloggedTimeTest < ActiveSupport::TestCase
 
   setup do
     @owner = create_user(slack_id: "U_UNLOGGED_OWNER", display_name: "unlogged_owner")
-    @collaborator = create_user(slack_id: "U_UNLOGGED_COLLABORATOR", display_name: "unlogged_collaborator")
     @project = Project.create!(title: "Late heartbeats", description: "Testing cumulative Hackatime totals")
     @project.memberships.create!(user: @owner, role: :owner)
-    @project.memberships.create!(user: @collaborator, role: :contributor)
     User::HackatimeProject.insert_all!([
       { user_id: @owner.id, project_id: @project.id, name: "late-heartbeats", created_at: Time.current, updated_at: Time.current }
     ])
@@ -35,17 +33,6 @@ class Project::HackatimeUnloggedTimeTest < ActiveSupport::TestCase
 
   test "includes late heartbeats in the next devlog without double counting logged time" do
     create_devlog(user: @owner, duration: 1.hour, at: 1.day.ago)
-
-    seconds = HackatimeService.stub(:fetch_total_seconds_for_projects, 2.5.hours.to_i) do
-      @project.unlogged_hackatime_seconds("ht-owner", user: @owner)
-    end
-
-    assert_equal 1.5.hours.to_i, seconds
-  end
-
-  test "only subtracts devlogs written by the current author" do
-    create_devlog(user: @owner, duration: 1.hour, at: 2.days.ago)
-    create_devlog(user: @collaborator, duration: 3.hours, at: 1.day.ago)
 
     seconds = HackatimeService.stub(:fetch_total_seconds_for_projects, 2.5.hours.to_i) do
       @project.unlogged_hackatime_seconds("ht-owner", user: @owner)


### PR DESCRIPTION
## what's this do?

Fetches cumulative Hackatime time from the event start and subtracts the author's previously logged time.

Why? Because project time from _before_ the last devlog can be uploaded if the user imports time from WakaTime, if time spent coding offline is uploaded, if accounts are merged, that kind of thing!

## show it works

The tests, well, test! More specifically, for a heartbeat appearing after an earlier devlog, and legacy devlogs without project snapshots.

## ai?

Amp was used to investigate the issue and implement the fix.
