### PR TITLE
Allow embedding Stardance in an iframe

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -79,6 +79,9 @@ module Battlemage
 
     config.exceptions_app = self.routes
 
+    # Allow the app to be embedded in an iframe from any origin.
+    config.action_dispatch.default_headers.delete("X-Frame-Options")
+
     config.middleware.insert_after ActionDispatch::RemoteIp, Rack::Attack
     config.middleware.insert_before ActionDispatch::Static, ServeAvif
     config.middleware.insert_before ActionDispatch::Static, NoCacheErrors


### PR DESCRIPTION
- Removes the default `X-Frame-Options: SAMEORIGIN` header so the app can be embedded in an iframe from any origin.
- No CSP `frame-ancestors` policy is set (CSP is currently disabled app-wide in `config/initializers/content_security_policy.rb`), so no restriction is applied there either.