### PR TITLE
chore(deps): bump sentry-ruby and sentry-rails from 6.6.2 to 6.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,8 +124,8 @@ gem "faraday-retry"
 gem "faker", "~> 3.6"
 gem "jsbundling-rails", "~> 1.3"
 gem "stackprof"
-gem "sentry-ruby", "~> 6.6"
-gem "sentry-rails", "~> 6.6"
+gem "sentry-ruby", "~> 6.7"
+gem "sentry-rails", "~> 6.7"
 
 # for pagination
 gem "pagy", "~> 43.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -677,10 +677,10 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
-    sentry-rails (6.6.2)
+    sentry-rails (6.7.0)
       railties (>= 5.2.0)
-      sentry-ruby (~> 6.6.2)
-    sentry-ruby (6.6.2)
+      sentry-ruby (~> 6.7.0)
+    sentry-ruby (6.7.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       logger
@@ -873,8 +873,8 @@ DEPENDENCIES
   rubocop
   rubocop-rails-omakase
   selenium-webdriver
-  sentry-rails (~> 6.6)
-  sentry-ruby (~> 6.6)
+  sentry-rails (~> 6.7)
+  sentry-ruby (~> 6.7)
   skylight
   slack-ruby-client
   slocks


### PR DESCRIPTION
Bumps `sentry-ruby` and `sentry-rails` together from 6.6.2 to 6.7.0.

These gems must be updated in lockstep: `sentry-rails` 6.7.0 requires `sentry-ruby ~> 6.7.0`. Dependabot opened separate PRs that cannot land independently without leaving the pair out of sync.

Supersedes:
- #1057 (`sentry-rails`)
- #1058 (`sentry-ruby`)

## Changelog ([6.7.0](https://github.com/getsentry/sentry-ruby/blob/master/CHANGELOG.md#670))

**New features**
- Active Job tracing
- Solid Queue support
- Client reports for `log_byte` and `trace_metric_byte`
- `config.hub_isolation_level` (`:fiber` / `:thread`) for Fiber-based servers
- New `set_attribute` API

**Bug fixes**
- Guard execution context with `send_default_pii`
- Keep `Rails.error.set_context` from being lost

## Changes

- `Gemfile`: `sentry-ruby` and `sentry-rails` `~> 6.6` → `~> 6.7`
- `Gemfile.lock`: both gems `6.6.2` → `6.7.0`