### PR TITLE
fix(hardware): Use real links in hardware cert table

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -74,7 +74,7 @@ body.admin-page {
 
   a:not(.action-btn):not([class*="btn-"]):not(.ysws-queue__view-btn):not(
       .ysws-dashboard__reviewer-link--on-pace
-    ) {
+    ):not(.ship-queue__row-link) {
     color: var(--color-brand-highlight);
     text-decoration: none;
 

--- a/app/assets/stylesheets/pages/certification/ships/_index.scss
+++ b/app/assets/stylesheets/pages/certification/ships/_index.scss
@@ -411,9 +411,6 @@
     }
   }
 
-  // Stretches the anchor over its whole row, so the row is clickable without
-  // giving up link semantics. Anything interactive added to a row later needs
-  // its own stacking context to stay above it.
   &__row-link {
     &::after {
       content: "";
@@ -421,7 +418,6 @@
       inset: 0;
     }
 
-    // Ring traces the row rather than just the title text.
     &:focus-visible {
       outline: none;
 

--- a/app/assets/stylesheets/pages/certification/ships/_index.scss
+++ b/app/assets/stylesheets/pages/certification/ships/_index.scss
@@ -397,11 +397,37 @@
       background: rgba(255, 255, 255, 0.03);
     }
 
-    tbody tr.ship-queue__row--link {
+    tbody tr.ship-queue__row--link,
+    tbody tr.ship-queue__row--anchored {
       cursor: pointer;
 
       &:hover {
         background: rgba(255, 255, 255, 0.06);
+      }
+    }
+
+    tbody tr.ship-queue__row--anchored {
+      position: relative;
+    }
+  }
+
+  // Stretches the anchor over its whole row, so the row is clickable without
+  // giving up link semantics. Anything interactive added to a row later needs
+  // its own stacking context to stay above it.
+  &__row-link {
+    &::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+    }
+
+    // Ring traces the row rather than just the title text.
+    &:focus-visible {
+      outline: none;
+
+      &::after {
+        outline: 2px solid var(--accent);
+        outline-offset: -2px;
       }
     }
   }

--- a/app/views/admin/certification/hardware_reviews/queue.html.erb
+++ b/app/views/admin/certification/hardware_reviews/queue.html.erb
@@ -144,11 +144,11 @@
           <tbody>
             <% @review_items.each do |item| %>
               <% wait_days = ((Time.current - item[:submitted_at]) / 1.day).floor %>
-              <tr class="ship-queue__row ship-queue__row--link"
-                  onclick="window.location = <%= hardware_review_path(item[:project]).to_json %>">
+              <tr class="ship-queue__row ship-queue__row--anchored">
                 <td class="ship-queue__cell-project">
                   <div class="ship-queue__project-head">
-                    <span class="ship-queue__project-title"><%= item[:project].title %></span>
+                    <%= link_to item[:project].title, hardware_review_path(item[:project]),
+                          class: "ship-queue__project-title ship-queue__row-link" %>
                     <span class="ship-queue__project-id">#<%= item[:project].id %></span>
                     <%= render "admin/certification/hardware_reviews/hackpad_tag", project: item[:project], hackpad_project_ids: @hackpad_project_ids %>
                   </div>


### PR DESCRIPTION
## what's this do?

on `admin/certification/hardware/`, the existing projects do not count as hrefs and therefore couldn't be opened in a new tab. this makes them into actual links. Lets people ctrl+click, or hit the "copy link address" button for sending in a DM, etc. This change only affects the hardware queue.

## show it works

https://github.com/user-attachments/assets/7d50ea47-94c0-4a78-8baf-951ece1b9bad

## ai?

claude opus 5