### PR TITLE
feat(projects): shortcut to hardware review dashboard from project page

### DIFF
--- a/app/assets/stylesheets/pages/projects/_show.scss
+++ b/app/assets/stylesheets/pages/projects/_show.scss
@@ -709,6 +709,19 @@ turbo-frame#project_hero {
   gap: 6px;
 }
 
+.project-show__pill--review {
+  border-color: var(--color-brand-orange);
+  color: var(--color-brand-orange);
+
+  &:hover:not(:disabled):not([aria-disabled="true"]),
+  &:focus-visible:not(:disabled):not([aria-disabled="true"]) {
+    background: var(--color-brand-orange-soft);
+    border-color: var(--color-brand-orange);
+    color: var(--color-brand-orange);
+    outline: none;
+  }
+}
+
 .project-show__pill-icon {
   width: 16px;
   height: 16px;

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -510,6 +510,12 @@
                               } %>
                 <% end %>
 
+                <% if Flipper.enabled?(:hardware_flow, current_user) && @project.hardware? && !is_member && current_user&.can_review? %>
+                  <%= link_to "Review", admin_certification_hardware_review_path(@project),
+                              class: "project-show__pill project-show__pill--outline project-show__pill--review",
+                              data: { turbo_frame: "_top" } %>
+                <% end %>
+
                 <%= render "projects/report_button", project: @project, is_member: is_member %>
               </div>
             </div>

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -316,4 +316,33 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "button", text: /Record a timelapse/, count: 0
   end
+
+  test "review shortcut shows for a project certifier and no one else" do
+    @project.update!(hardware_stage: "design")
+
+    sign_in certifier
+    get project_path(@project)
+    assert_response :success
+    assert_select "a.project-show__pill--review[href=?]",
+                  admin_certification_hardware_review_path(@project),
+                  text: "Review"
+
+    sign_in @viewer
+    get project_path(@project)
+    assert_select "a.project-show__pill--review", 0
+  end
+
+  private
+
+  def certifier
+    @certifier ||= begin
+      user = User.create!(
+        slack_id: "U_PROJECT_CERTIFIER",
+        display_name: "certifier",
+        email: "certifier@example.test"
+      )
+      user.grant_role!(:project_certifier)
+      user
+    end
+  end
 end


### PR DESCRIPTION
## what's this do?

Hardware projects need their review looked at often. This adds a button for hardware reviewers that redirects directly to the review dashboard for that project.

## show it works

<img width="1170" height="735" alt="image" src="https://github.com/user-attachments/assets/b58a66ea-5cb7-4114-a27d-9a35b3e0bb4a" />

## ai?

opus 5