### PR TITLE
fix(bug): overflow bug and update mobile styles for project stats

### DIFF
--- a/app/assets/stylesheets/pages/projects/_show.scss
+++ b/app/assets/stylesheets/pages/projects/_show.scss
@@ -1199,12 +1199,20 @@ turbo-frame#project_hero {
   }
 }
 
+// Fixing the overflow bug on mobile ( issue#1099 )
 .project-show__latest-ship-stats {
   list-style: none;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: var(--space-l);
   opacity: 0.75;
+}
+
+@media (max-width: 720px) {
+  .project-show__latest-ship-stats {
+    gap: var(--space-s);
+  }
 }
 
 .project-show__latest-ship-media {


### PR DESCRIPTION
## what's this do?

This change fixes the bug mentioned in #1099 by adding `flex-wrap`

## show it works

Before the change:
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/db89028b-0518-448c-b16c-1cda15ba1b5f" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/da0a3731-06ef-4dc3-a8d5-eb8a197f25d9" />


After the change:
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/64c249c8-8f4b-4e76-b1ff-2a3d41c27d92" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/be1e7734-e005-4728-8dfe-6b50c2093521" />


## ai?

Used Grok with a GitHub connection to search and investigate the bug.
