### PR TITLE
feat(missions): return the mission submission when a ship cert is returned

### DIFF
--- a/app/models/post/ship_event.rb
+++ b/app/models/post/ship_event.rb
@@ -61,6 +61,7 @@ class Post::ShipEvent < ApplicationRecord
   BODY_MAX_LENGTH = Post::Devlog::BODY_MAX_LENGTH
   REVIEW_INSTRUCTIONS_MAX_LENGTH = 2_000
   RETURN_REASON_MAX_LENGTH = 1_000
+  UNCERTIFIED_SUBMISSION_MESSAGE = "Your ship was not certified. See the ship feedback for what to change."
   MAX_ATTACHMENTS = 2
   ACCEPTED_CONTENT_TYPES = %w[image/jpeg image/png image/webp image/heic image/heif image/gif].freeze
   LIFECYCLE_DATA_QUALITIES = %w[live backfilled_exact backfilled_estimated].freeze
@@ -226,18 +227,32 @@ class Post::ShipEvent < ApplicationRecord
 
   # Drives the Mission::Submission state machine off ship cert transitions.
   # See docs/missions-design.md "Certification interaction" for the spec.
+  # "returned" is the verdict the ship queue actually writes; "rejected" only
+  # comes from an admin forcing the project state.
   def sync_mission_submission_status
     submission = mission_submission
     return unless submission
 
     case certification_status
     when "approved"
-      submission.certify! if submission.may_certify?
-    when "rejected"
+      if submission.may_certify?
+        submission.certify!
+      elsif failed_certification?(submission)
+        submission.update_columns(rejection_message: nil)
+        submission.undo!
+      end
+    when "returned", "rejected"
       if submission.may_fail_certification?
-        submission.update_columns(rejection_message: "Ship was not certified — see ship feedback for details.")
+        submission.update_columns(rejection_message: UNCERTIFIED_SUBMISSION_MESSAGE)
         submission.fail_certification!
       end
     end
+  end
+
+  # A submission certification knocked back, as opposed to one a mission
+  # reviewer judged: only the reviewer path stamps reviewed_by, and their
+  # verdict has to survive a later re-certification.
+  def failed_certification?(submission)
+    submission.rejected? && submission.reviewed_by_id.nil?
   end
 end

--- a/test/models/post/ship_event_test.rb
+++ b/test/models/post/ship_event_test.rb
@@ -216,7 +216,61 @@ class Post::ShipEventTest < ActiveSupport::TestCase
     assert_nil ship.reload.payout
   end
 
+  test "returning a ship cert returns the mission submission with it" do
+    ship, submission = create_uncertified_mission_ship
+
+    ship.update!(certification_status: "returned")
+
+    assert submission.reload.rejected?
+    assert_equal Post::ShipEvent::UNCERTIFIED_SUBMISSION_MESSAGE, submission.rejection_message
+  end
+
+  test "approving a ship cert certifies a submission still awaiting certification" do
+    ship, submission = create_uncertified_mission_ship
+
+    ship.update!(certification_status: "approved")
+
+    assert submission.reload.pending?
+    assert_not_nil submission.pending_at
+  end
+
+  test "re-certifying a returned ship puts its submission back in the mission queue" do
+    ship, submission = create_uncertified_mission_ship
+    ship.update!(certification_status: "returned")
+
+    ship.reload.update!(certification_status: "approved")
+
+    assert submission.reload.pending?
+    assert_nil submission.rejection_message
+    assert_not_nil submission.pending_at
+  end
+
+  test "re-certifying a ship does not overturn a mission reviewer's rejection" do
+    ship, submission = create_uncertified_mission_ship
+    ship.update!(certification_status: "approved")
+    submission.reload.update!(reviewed_by: @owner, reviewed_at: Time.current, rejection_message: "Missing the write-up")
+    submission.reject!
+
+    ship.reload.update!(certification_status: "returned")
+    ship.reload.update!(certification_status: "approved")
+
+    assert submission.reload.rejected?
+    assert_equal "Missing the write-up", submission.rejection_message
+  end
+
   private
+
+  # A ship still waiting on certification, with the mission submission its
+  # builder filed alongside it.
+  def create_uncertified_mission_ship
+    project = Project.create!(title: "Project #{SecureRandom.hex(4)}", created_at: 3.days.ago)
+    Project::Membership.create!(project: project, user: @owner, role: :owner)
+    ship = Post::ShipEvent.create!(body: "Ship it", uploading_attachments: true)
+    Post.create!(project: project, user: @owner, postable: ship)
+    submission = Mission::Submission.create!(ship_event: ship, mission: create_mission, payout_path: "voting")
+
+    [ ship.reload, submission ]
+  end
 
   def create_ship_event(hours:, vote_count: 1, scores: [ 6, 6, 6, 6 ], project: nil)
     project ||= Project.create!(title: "Project #{SecureRandom.hex(4)}", created_at: 3.days.ago)


### PR DESCRIPTION
## what's this do?

- a lot of mission submissions ended up in weird states when the ship cert was rejected. this makes the mission submission automatically rejected when that happens

## show it works

test passes green

## ai?

claude
