### PR TITLE
fix(admin): count hardware mission reviews correctly

### DIFF
--- a/app/controllers/admin/missions/submissions_controller.rb
+++ b/app/controllers/admin/missions/submissions_controller.rb
@@ -203,10 +203,15 @@ module Admin
                                .pluck(:project_id, :mission_id).to_h
         return {} if project_to_mission.empty?
 
-        project_ids = project_to_mission.keys
+        # Scoped the same way the mission's own hardware dash builds its queue,
+        # so this badge cannot drift from the page it sends reviewers to. A
+        # review on a soft-deleted or non-hardware project is unreachable from
+        # every queue, so counting it reports a backlog nobody can work.
         counts = Hash.new(0)
         [ ::Certification::FundingRequest, ::Certification::Ship ].each do |model|
-          model.where(project_id: project_ids, status: :pending).pluck(:project_id).each do |pid|
+          model.in_hardware_mission_queue.pending
+               .where(project_id: project_to_mission.keys)
+               .pluck(:project_id).each do |pid|
             counts[project_to_mission[pid]] += 1
           end
         end

--- a/test/controllers/admin/missions/submissions_controller_test.rb
+++ b/test/controllers/admin/missions/submissions_controller_test.rb
@@ -74,6 +74,24 @@ class Admin::Missions::SubmissionsControllerTest < ActionDispatch::IntegrationTe
     assert_response :success
   end
 
+  test "overview counts only hardware reviews the mission dash can hand out" do
+    mission = create_mission
+    mission.update!(hardware: true)
+    live = hardware_project_for(mission)
+    deleted = hardware_project_for(mission)
+    Certification::Ship.create!(project: live, status: :pending)
+    Certification::Ship.create!(project: deleted, status: :pending)
+    deleted.soft_delete!
+
+    sign_in @reviewer
+    get admin_mission_reviews_path
+
+    assert_response :success
+    # The review on the soft-deleted project is unreachable from every queue.
+    assert_includes response.body, "1 pending"
+    assert_not_includes response.body, "2 pending"
+  end
+
   test "overview only lists missions the user can review" do
     member = create_member
     other_mission = create_mission
@@ -117,5 +135,13 @@ class Admin::Missions::SubmissionsControllerTest < ActionDispatch::IntegrationTe
                  display_name: "member-#{SecureRandom.hex(4)}",
                  slack_id: "U#{SecureRandom.hex(8)}",
                  granted_roles: granted_roles)
+  end
+
+  def hardware_project_for(mission)
+    project = Project.create!(title: "HW #{SecureRandom.hex(4)}")
+    project.memberships.create!(user: @builder, role: :owner)
+    project.update!(hardware_stage: "build")
+    project.mission_attachments.create!(mission: mission)
+    project
   end
 end


### PR DESCRIPTION
## what's this do?

previously, the mega dash was overcounting the number of hardware mission reviews to be done, this makes it exactly like the hardware dashboard

## show it works

test passes green

## ai?

claude
