### PR TITLE
Fix export job

### DIFF
--- a/app/jobs/user/data_export_job.rb
+++ b/app/jobs/user/data_export_job.rb
@@ -23,19 +23,18 @@ class User::DataExportJob < ApplicationJob
         write_readme(zip, user)
       end
 
-      # Attach first so a failed upload never leaves a completed export
-      # without a downloadable file.
+      # Upload synchronously before entering a transaction.
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: File.open(temp_zip.path),
+        filename: zip_filename,
+        content_type: "application/zip"
+      )
+
       @data_export.with_lock do
         # The user may delete an export while it is being generated.
         return unless @data_export.processing?
 
-        File.open(temp_zip.path) do |file|
-          @data_export.zip_file.attach(
-            io: file,
-            filename: zip_filename,
-            content_type: "application/zip"
-          )
-        end
+        @data_export.zip_file.attach(blob)
         @data_export.update!(status: "completed", zip_filename: zip_filename)
       end
     rescue ActiveRecord::RecordNotFound
@@ -118,12 +117,12 @@ class User::DataExportJob < ApplicationJob
   end
 
   # Streams the blob straight into the ZIP entry instead of loading the whole file into memory
-  def download_attachment(zip, attachment, entry_name)
-    blob = attachment.is_a?(ActiveStorage::Attached) ? attachment.blob : attachment
-    return unless blob
+  def download_attachment(zip, attachable, entry_name)
+    attachment = attachable.try(:attachment) || attachable
+    return unless attachment&.blob
 
     zip.put_next_entry(entry_name)
-    blob.open { |file| IO.copy_stream(file, zip) }
+    attachment.open { |file| IO.copy_stream(file, zip) }
   end
 
   def write_readme(zip, user)

--- a/test/jobs/user/data_export_job_test.rb
+++ b/test/jobs/user/data_export_job_test.rb
@@ -10,9 +10,12 @@ class User::DataExportJobTest < ActiveJob::TestCase
     @project = Project.create!(title: "My Cool Project", description: "desc")
     Project::Membership.create!(user: @user, project: @project)
 
+    # A real (minimal) PNG so content round-trips through Lockbox encryption
+    @png_bytes = Base64.decode64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=")
+
     @devlog = Post::Devlog.new(body: "Devlog body text", duration_seconds: 1.hour)
     @devlog.attachments.attach(
-      io: StringIO.new(Base64.decode64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=")),
+      io: StringIO.new(@png_bytes),
       filename: "progress.png",
       content_type: "image/png"
     )
@@ -37,6 +40,12 @@ class User::DataExportJobTest < ActiveJob::TestCase
     assert_includes entries, "projects/my-cool-project-#{@project.id}/project.json"
     assert_includes entries, "projects/my-cool-project-#{@project.id}/devlogs/devlog-#{@devlog.id}.md"
     assert_includes entries, "projects/my-cool-project-#{@project.id}/devlogs/attachments/#{@devlog.id}-1.png"
+
+    # Attachments must be exported decrypted (Lockbox), byte-for-byte
+    assert_equal @png_bytes, zip_entry_content(@export, "projects/my-cool-project-#{@project.id}/devlogs/attachments/#{@devlog.id}-1.png")
+
+    # The ZIP itself must be downloadable plaintext (not double-encrypted)
+    assert_equal "PK", @export.zip_file.open { |f| f.read(2) }
   end
 
   test "keeps attachments from different devlogs in distinct entries" do


### PR DESCRIPTION
## what's this do?

Upload zip synchronously to avoid closed stream IOError, and stream attachments via Attachment#open so Lockbox decrypts them

<!-- a sentence or two! -->

## show it works

<!-- screen recording, screenshots, test output— whatever makes sense for the change -->

2 succeeded exports are from after fix applied

<img width="875" height="509" alt="image" src="https://github.com/user-attachments/assets/093c135a-7279-4e2a-9adb-c07cbdc0d7a8" />


## ai?

Opencode for finding the issue, and updating the test
