### PR TITLE
fix(bug): the hackatime notice too long in devlog editor

### DIFF
--- a/app/assets/stylesheets/components/_feed.scss
+++ b/app/assets/stylesheets/components/_feed.scss
@@ -109,6 +109,8 @@
   border-radius: var(--profile-radius, var(--border-radius));
   background: rgba(5, 4, 24, 0.35);
   color: var(--color-space-text);
+  max-width: 100%;
+  overflow-x: clip;
 }
 
 .empty-project-banner {
@@ -227,6 +229,7 @@
     text-decoration: none;
     line-height: 1;
     white-space: nowrap;
+    max-width: 100%;
 
     &:hover,
     &:focus-visible,
@@ -645,9 +648,8 @@
     }
 
     &__info-text {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+      white-space: normal;
+      overflow-wrap: anywhere;
     }
 
     &__submit-group {


### PR DESCRIPTION
## what's this do?

Fixes horizontal overflow on the home feed and project devlog composer mentioned in #1024 . The long Hackatime status line was forced onto a single line (`white-space: nowrap`), which could push the post/composer area wider than the viewport and clip content on the left. Also clamps `.feed-composer` / `.feed-post-card` with `max-width: 100%` and `overflow-x:` clip so they stay inside the reading column.

## show it works

Before the changes:
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/f49c5ffa-acf5-435f-953a-4d1e177552f5" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/82fe7ded-870a-4d57-a082-3532993946e9" />

After the changes:
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/9f3e89f3-2afc-4967-a901-d80a14211de7" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/adfd32c1-2735-49ce-890b-6e9d3d563808" />


## ai?

Yes, I used grok for investigating the bug and css.
