### PR TITLE
feat(funding): drop demo URL requirement from funding submission

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -615,6 +615,12 @@ class Project < ApplicationRecord
 
   INFO_REQUIREMENT_KEYS = FIELD_REQUIREMENT_MAP.values.flatten.freeze
 
+  # The subset of project info required to submit a design-stage funding request.
+  # A demo link usually doesn't exist yet while the build is still being
+  # designed, so demo_url is dropped from the funding gate. It stays in
+  # INFO_REQUIREMENT_KEYS, so it's still required to ship.
+  FUNDING_INFO_REQUIREMENT_KEYS = (INFO_REQUIREMENT_KEYS - FIELD_REQUIREMENT_MAP[:demo_url]).freeze
+
   def shipping_requirements
     owner_vote_balance = memberships.owner.first&.user&.vote_balance.to_i
     votes_needed = [ -owner_vote_balance, 0 ].max
@@ -800,22 +806,45 @@ class Project < ApplicationRecord
   # Whether every project-info requirement (see INFO_REQUIREMENT_KEYS) passes,
   # i.e. the editable details are filled in and ship-ready.
   def info_complete?
-    shipping_requirements
-      .select { |r| INFO_REQUIREMENT_KEYS.include?(r[:key]) }
-      .all? { |r| r[:passed] }
+    info_requirements_met?(INFO_REQUIREMENT_KEYS)
   end
 
+  # Whether the info needed to submit a design-stage funding request is complete.
+  # Unlike #info_complete? this doesn't require a demo link, which usually
+  # doesn't exist yet at the design stage (see FUNDING_INFO_REQUIREMENT_KEYS).
+  def funding_info_complete?
+    info_requirements_met?(FUNDING_INFO_REQUIREMENT_KEYS)
+  end
+
+  # Whether the project info needed for the current stage's next action is
+  # complete. At the design stage the next action is a funding request, which
+  # doesn't need a demo link (see #funding_info_complete?); once building, the
+  # next action is shipping, which does (see #info_complete?).
+  def stage_info_complete?
+    design_stage? ? funding_info_complete? : info_complete?
+  end
+
+  # Label of the first unmet info requirement for the current stage, used as the
+  # "Complete project info" tooltip. Mirrors #stage_info_complete? so a
+  # design-stage builder is never nagged about a demo link they don't yet need.
   def info_blocker_message
+    keys = design_stage? ? FUNDING_INFO_REQUIREMENT_KEYS : INFO_REQUIREMENT_KEYS
     req = shipping_requirements
-      .select { |r| INFO_REQUIREMENT_KEYS.include?(r[:key]) }
+      .select { |r| keys.include?(r[:key]) }
       .find { |r| !r[:passed] }
     req&.dig(:label)
   end
 
   # The editable info fields (see FIELD_REQUIREMENT_MAP) that still have an
-  # unmet requirement — used to highlight what's left to fill in on the form.
+  # unmet requirement for the current stage — used to highlight what's left to
+  # fill in on the form. Stage-aware like #stage_info_complete?, so a demo link
+  # isn't flagged red while designing (it isn't needed until shipping).
   def incomplete_info_fields
-    unmet = shipping_requirements.reject { |r| r[:passed] }.map { |r| r[:key] }
+    stage_keys = design_stage? ? FUNDING_INFO_REQUIREMENT_KEYS : INFO_REQUIREMENT_KEYS
+    unmet = shipping_requirements
+      .select { |r| stage_keys.include?(r[:key]) }
+      .reject { |r| r[:passed] }
+      .map { |r| r[:key] }
     FIELD_REQUIREMENT_MAP.select { |_field, keys| (keys & unmet).any? }.keys
   end
 
@@ -941,6 +970,14 @@ class Project < ApplicationRecord
   end
 
   private
+
+  # Whether every shipping requirement in `keys` currently passes. Shared by
+  # #info_complete? (all info keys) and #funding_info_complete? (info minus demo).
+  def info_requirements_met?(keys)
+    shipping_requirements
+      .select { |r| keys.include?(r[:key]) }
+      .all? { |r| r[:passed] }
+  end
 
   def do_url_probe(url)
     response = SafeUrl.safe_get(

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -565,7 +565,7 @@
                   onclick: "document.getElementById('composer-modal-' + #{@project.id.to_json}).showModal()"
                 ) %>
           <% end %>
-          <% unless @project.info_complete? %>
+          <% unless @project.stage_info_complete? %>
             <% if @project.has_devlog_since_last_ship? %>
               <%= render ActionButtonComponent.new(
                     text: "Complete project info",
@@ -592,7 +592,7 @@
                   ) %>
             <% end %>
           <% end %>
-          <% if is_member && current_user && @project.info_complete? %>
+          <% if is_member && current_user && @project.stage_info_complete? %>
             <% unless current_user.identity_verified? %>
               <%= render ActionButtonComponent.new(
                     text: "Verify your identity",
@@ -636,7 +636,7 @@
                       tooltip_position_value: "top"
                     }
                   ) %>
-            <% elsif !@project.info_complete? %>
+            <% elsif !@project.funding_info_complete? %>
               <%= render ActionButtonComponent.new(
                     text: "Submit for funding",
                     variant: :primary,

--- a/test/models/project_funding_info_requirement_test.rb
+++ b/test/models/project_funding_info_requirement_test.rb
@@ -1,0 +1,109 @@
+require "test_helper"
+
+# A demo link often doesn't exist yet at the design/funding stage, so it must
+# NOT gate a funding request - but it stays required to ship. These tests pin
+# that split between #funding_info_complete? and #info_complete?.
+class ProjectFundingInfoRequirementTest < ActiveSupport::TestCase
+  # 1x1 PNG so the banner requirement (banner.attached?) is satisfied with a
+  # real, processable image.
+  PIXEL_PNG = Base64.decode64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=")
+
+  setup do
+    @owner = create_user(slack_id: "U_FUNDING_INFO", display_name: "fundinginfo", verified: true)
+    @project = Project.create!(title: "Design build", hardware_stage: "design")
+    @project.memberships.create!(user: @owner, role: :owner)
+
+    # Everything the project-info gate wants, except a demo link.
+    @project.assign_attributes(
+      description: "A neat hardware build",
+      repo_url: "https://github.com/example/project",
+      readme_url: "https://raw.githubusercontent.com/example/project/main/README.md",
+      ai_declaration: "None"
+    )
+    @project.banner.attach(io: StringIO.new(PIXEL_PNG), filename: "banner.png", content_type: "image/png")
+  end
+
+  # url_reachable? (readme reachability) and GitRepoService.is_cloneable? (repo
+  # cloneable) both hit the network; stub them so the checks stay hermetic.
+  def with_reachable_and_cloneable
+    @project.stub(:url_reachable?, true) do
+      GitRepoService.stub(:is_cloneable?, true) do
+        yield
+      end
+    end
+  end
+
+  test "demo_url is excluded from the funding gate but kept in the ship gate" do
+    assert_includes Project::INFO_REQUIREMENT_KEYS, :demo_url
+    assert_includes Project::INFO_REQUIREMENT_KEYS, :demo_url_reachable
+    refute_includes Project::FUNDING_INFO_REQUIREMENT_KEYS, :demo_url
+    refute_includes Project::FUNDING_INFO_REQUIREMENT_KEYS, :demo_url_reachable
+  end
+
+  test "a project with no demo_url is funding-complete but not info-complete" do
+    assert @project.demo_url.blank?, "guard: demo_url should be blank for this case"
+
+    with_reachable_and_cloneable do
+      assert @project.funding_info_complete?,
+        "funding gate should pass without a demo link"
+      refute @project.info_complete?,
+        "ship info gate should still fail without a demo link"
+
+      demo_req = @project.shipping_requirements.find { |r| r[:key] == :demo_url }
+      refute demo_req[:passed], "demo_url requirement should be unmet"
+
+      assert_empty @project.incomplete_info_fields,
+        "no info fields should be flagged red while designing (demo excluded)"
+    end
+  end
+
+  test "incomplete_info_fields flags the demo link only once building" do
+    assert @project.demo_url.blank?
+
+    with_reachable_and_cloneable do
+      refute_includes @project.incomplete_info_fields, :demo_url,
+        "design-stage form must not flag the demo link red"
+
+      @project.hardware_stage = "build"
+      assert_includes @project.incomplete_info_fields, :demo_url,
+        "build-stage form should flag the missing demo link"
+    end
+  end
+
+  test "adding a demo_url makes the project info-complete too" do
+    @project.demo_url = "https://example.com/demo"
+
+    with_reachable_and_cloneable do
+      assert @project.funding_info_complete?
+      assert @project.info_complete?
+    end
+  end
+
+  test "stage_info_complete? drops the demo requirement only at the design stage" do
+    assert @project.demo_url.blank?, "guard: demo_url should be blank for this case"
+
+    with_reachable_and_cloneable do
+      assert @project.design_stage?, "guard: project starts in the design stage"
+      assert @project.stage_info_complete?,
+        "design-stage info should be complete without a demo link"
+
+      @project.hardware_stage = "build"
+      refute @project.stage_info_complete?,
+        "build-stage info should require a demo link again"
+    end
+  end
+
+  test "info_blocker_message never nags about a demo at the design stage" do
+    assert @project.demo_url.blank?
+    demo_label = @project.shipping_requirements.find { |r| r[:key] == :demo_url }[:label]
+
+    with_reachable_and_cloneable do
+      assert_nil @project.info_blocker_message,
+        "design-stage builder has no outstanding (non-demo) info blocker"
+
+      @project.hardware_stage = "build"
+      assert_equal demo_label, @project.info_blocker_message,
+        "build-stage builder is blocked on the demo link"
+    end
+  end
+end


### PR DESCRIPTION
## what's this do?

Demo links aren't actually used when submitting for a funding request, they just get in the way of things and are a major pain point in submitting. This removes the check when a hardware project is in the design phase.

## show it works

https://github.com/user-attachments/assets/09af4d28-e57c-49e5-8a6e-8182f508e6ff

## ai?

claude opus 4.8
