### PR TITLE
feat(hardware): interleave review history + public_hardware_reviews flag

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -130,13 +130,9 @@ class ProjectsController < ApplicationController
 
     # Shipwright verdicts are rendered straight from the review records —
     # they're private to project members, so they never become Post rows.
-    @timeline_entries = (@posts + visible_ship_decisions + visible_funding_requests).sort_by do |entry|
-      case entry
-      when Certification::Ship then entry.decided_on
-      when Certification::FundingRequest then entry.decided_at || entry.created_at
-      else entry.created_at
-      end
-    end.reverse
+    @timeline_entries = Project.sort_timeline_entries(
+      @posts + visible_ship_decisions + visible_funding_requests
+    )
 
     @show_project_onboarding = @is_member && @timeline_entries.empty?
     @project_onboarding_mission = @project.current_mission
@@ -218,12 +214,27 @@ class ProjectsController < ApplicationController
   end
   private :prepare_project_show_context
 
-  # Decided Shipwright reviews, shown only to project members (and admins)
-  # while the release flag is on.
+  # Who can see a project's hardware review history (funding requests + ship
+  # verdicts) on its page:
+  #   - reviewers always can - they need the history to do their job;
+  #   - the project's own members and admins can while the surface's rollout flag
+  #     is on for them (the amount asked for and the reviewer's feedback are
+  #     otherwise the team's business);
+  #   - and when the +public_hardware_reviews+ flag is on, anyone viewing the
+  #     project can - logged in or not.
+  def hardware_review_history_visible?(rollout_flag)
+    return true if Flipper.enabled?(:public_hardware_reviews)
+    return false unless current_user
+    return true if current_user.can_review?
+    return false unless Flipper.enabled?(rollout_flag, current_user)
+
+    @is_member || current_user.admin?
+  end
+  private :hardware_review_history_visible?
+
+  # Decided Shipwright reviews. Same audience as the funding history below.
   def visible_ship_decisions
-    return [] unless current_user
-    return [] unless @is_member || current_user.admin?
-    return [] unless Flipper.enabled?(:week_1_release, current_user)
+    return [] unless hardware_review_history_visible?(:week_1_release)
 
     @project.ship_reviews
             .decided
@@ -233,16 +244,13 @@ class ProjectsController < ApplicationController
   end
   private :visible_ship_decisions
 
-  # Funding requests, shown only to project members (and admins): the amount
-  # asked for and the reviewer's feedback are the team's business, not public.
-  # Only the most recent request appears on the timeline - a resubmission
-  # supersedes the returned one it replaces.
+  # Funding requests interleaved into the feed (see
+  # Project#timeline_funding_requests), so a returned review keeps its place as
+  # newer devlogs are posted rather than only the latest request showing.
   def visible_funding_requests
-    return [] unless current_user
-    return [] unless @is_member || current_user.admin?
-    return [] unless Flipper.enabled?(:hardware_flow, current_user)
+    return [] unless hardware_review_history_visible?(:hardware_flow)
 
-    @project.certification_funding_requests.includes(:reviewer).order(created_at: :desc).limit(1).to_a
+    @project.timeline_funding_requests.includes(:reviewer).to_a
   end
   private :visible_funding_requests
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -508,6 +508,36 @@ class Project < ApplicationRecord
     @_latest_funding_request = certification_funding_requests.order(created_at: :desc).first
   end
 
+  # Funding reviews to interleave into the project timeline: every request the
+  # owner has a standing outcome for - pending (awaiting a verdict), approved,
+  # or returned. Showing all of them, rather than only the latest, lets an older
+  # returned review keep its chronological place in the feed (see
+  # +timeline_sort_key+) and scroll down as newer devlogs land above it.
+  # Misfiled requests are surfaced by the queue-mismatch card instead, and
+  # withdrawn ones carry no verdict, so both stay off the feed.
+  def timeline_funding_requests
+    certification_funding_requests
+      .where(status: [ :pending, :approved, :returned ])
+      .order(created_at: :desc)
+  end
+
+  # Orders a project's timeline entries (devlog posts, ship decisions, and
+  # funding reviews) newest-first for the project feed.
+  def self.sort_timeline_entries(entries)
+    entries.sort_by { |entry| timeline_sort_key(entry) }.reverse
+  end
+
+  # Where a timeline entry sits in the feed: a review at the moment it was
+  # decided, everything else at its creation. Falling back to +created_at+ keeps
+  # a still-pending review at the point it was submitted.
+  def self.timeline_sort_key(entry)
+    case entry
+    when Certification::Ship then entry.decided_on
+    when Certification::FundingRequest then entry.decided_at || entry.created_at
+    else entry.created_at
+    end
+  end
+
   # Name of the Hackatime project this project's time is filed under (and which
   # Project::EnsureHackatimeProjectsJob seeds for hardware builders to pick in
   # Lapse): the project title, so timelapse time lands under the same Hackatime

--- a/app/views/projects/_funding_request_card.html.erb
+++ b/app/views/projects/_funding_request_card.html.erb
@@ -6,10 +6,10 @@
     status means, what happens next) moves into a "?" tooltip on the byline,
     and only falls back to being the body when there is no feedback to show.
 
-    Reviewer feedback is shown to the project owner only. The card itself is
-    already members-and-admins (see ProjectsController#visible_funding_requests),
-    but feedback names a reviewer and explains a rejection, so it stays with the
-    person who has to act on it.
+    Reviewer feedback names a reviewer and explains a rejection, so it stays with
+    the person who has to act on it: the project owner, plus reviewers who can
+    always see review history. When the public_hardware_reviews flag is on it
+    goes public along with the card (see ProjectsController#visible_funding_requests).
 
     Locals: funding_request, project, owner (required); resubmit_modal_id
     (optional - when present a returned request offers a resubmit button). %>
@@ -17,7 +17,8 @@
   decided_on = funding_request.decided_at || funding_request.created_at
   reviewer = funding_request.reviewer
   viewer_is_owner = owner.present? && owner == current_user
-  show_feedback = funding_request.feedback.present? && !funding_request.pending? && (viewer_is_owner || current_user&.admin?)
+  feedback_visible = viewer_is_owner || current_user&.can_review? || Flipper.enabled?(:public_hardware_reviews)
+  show_feedback = funding_request.feedback.present? && !funding_request.pending? && feedback_visible
 
   kit_mission = funding_request.kit_mission?
   awards_kit = funding_request.awards_design_kit?

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -938,8 +938,11 @@
             <%= render "projects/ship_decision_card", decision: entry, is_member: is_member, project: @project %>
           <% elsif entry.is_a?(Certification::FundingRequest) %>
             <%# The resubmit button reuses the funding modal, which only renders
-                while the project is still in the design stage. %>
-            <% resubmit_id = (Flipper.enabled?(:hardware_flow, current_user) && @project.design_stage?) ? "funding-request-modal-#{@project.id}" : nil %>
+                while the project is still in the design stage. It belongs on the
+                latest review only - older returned reviews are history the
+                builder has already moved past. %>
+            <% resubmit_available = Flipper.enabled?(:hardware_flow, current_user) && @project.design_stage? %>
+            <% resubmit_id = (resubmit_available && entry == @project.latest_funding_request) ? "funding-request-modal-#{@project.id}" : nil %>
             <%= render "projects/funding_request_card",
                        funding_request: entry, project: @project, owner: owner,
                        resubmit_modal_id: resubmit_id %>

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -38,6 +38,7 @@ Rails.application.config.after_initialize do
         gorse_project_recommendations
         week_1_release
         hardware_flow
+        public_hardware_reviews
         ship_event_payouts
         payout_recommendations
         disable_internal_sw_dash_reviews

--- a/test/integration/hardware_review_visibility_test.rb
+++ b/test/integration/hardware_review_visibility_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+# Funding-review feedback is private to a project's members and admins by
+# default. Reviewers can always see it, and the public_hardware_reviews flag
+# opens it up to everyone. These pin who sees the review history on a project
+# page (ProjectsController#hardware_review_history_visible?).
+class HardwareReviewVisibilityTest < ActionDispatch::IntegrationTest
+  FEEDBACK = "Please add a wiring diagram before we fund this.".freeze
+
+  setup do
+    @owner = create_user(slack_id: "U_HRV_OWNER", display_name: "hrv-owner", verified: true)
+    @project = Project.create!(title: "Visible rover", hardware_stage: "design")
+    @project.memberships.create!(user: @owner, role: :owner)
+
+    devlog = Post::Devlog.new(body: "first log", duration_seconds: 3600, phase: "design")
+    devlog.uploading_attachments = true
+    devlog.save!
+    Post.create!(project: @project, user: @owner, postable: devlog)
+
+    review = @project.certification_funding_requests.new(
+      user: @owner, complexity_tier: 2, requested_amount_cents: 5_000,
+      status: :returned, feedback: FEEDBACK
+    )
+    review.save!(validate: false)
+    review.update_columns(decided_at: 1.day.ago)
+
+    # A logged-in non-member who is in the hardware rollout but has no claim on
+    # this project - proves the member gate, not the rollout flag, is what hides
+    # the review by default.
+    @nonmember = create_user(slack_id: "U_HRV_OTHER", display_name: "hrv-other")
+    Flipper.enable_actor(:hardware_flow, @nonmember)
+  end
+
+  teardown do
+    Flipper.disable(:public_hardware_reviews)
+    Flipper.disable_actor(:hardware_flow, @nonmember)
+    Flipper.disable_actor(:hardware_flow, @owner)
+  end
+
+  def review_visible?
+    get project_path(@project)
+    assert_response :success
+    response.body.include?(FEEDBACK)
+  end
+
+  test "a non-member does not see the review by default" do
+    sign_in @nonmember
+    assert_not review_visible?, "a non-member must not see funding-review feedback"
+  end
+
+  test "the project owner sees the review" do
+    Flipper.enable_actor(:hardware_flow, @owner)
+    sign_in @owner
+    assert review_visible?, "the project owner should see the review"
+  end
+
+  test "public_hardware_reviews exposes the review to a non-member" do
+    Flipper.enable(:public_hardware_reviews)
+    sign_in @nonmember
+    assert review_visible?, "the public flag should show the review to a non-member"
+  end
+
+  test "a reviewer always sees the review, even without the rollout flag" do
+    reviewer = create_user(slack_id: "U_HRV_REV", display_name: "hrv-rev")
+    reviewer.grant_role!(:project_certifier)
+    sign_in reviewer
+    assert review_visible?, "a reviewer should always see the review history"
+  end
+end

--- a/test/models/project/timeline_test.rb
+++ b/test/models/project/timeline_test.rb
@@ -1,0 +1,87 @@
+require "test_helper"
+
+# The builder's project feed interleaves devlog posts, ship decisions, and
+# funding reviews. A returned funding review has to keep its chronological place
+# so it scrolls down as newer devlogs are posted, rather than only the latest
+# review ever showing (see Project#timeline_funding_requests and
+# Project.sort_timeline_entries).
+class ProjectTimelineTest < ActiveSupport::TestCase
+  setup do
+    Flipper.enable(:hardware_flow)
+    @owner = create_user(slack_id: "U_PTL_OWNER", display_name: "ptlowner", verified: true)
+    @project = Project.create!(title: "Rover PTL", hardware_stage: "design")
+    @project.memberships.create!(user: @owner, role: :owner)
+
+    devlog = Post::Devlog.new(body: "first log", duration_seconds: 3600, phase: "design")
+    devlog.uploading_attachments = true
+    devlog.save!
+    Post.create!(project: @project, user: @owner, postable: devlog)
+  end
+
+  test "sort_timeline_entries orders a returned review below a later devlog and above an earlier one" do
+    earlier_devlog = Post.new(created_at: 3.days.ago)
+    # Created before the earlier devlog, but decided after it: the decided_at is
+    # what places the review, so it must land between the two devlogs.
+    returned_review = Certification::FundingRequest.new(
+      created_at: 4.days.ago, decided_at: 2.days.ago, status: :returned
+    )
+    later_devlog = Post.new(created_at: 1.day.ago)
+
+    ordered = Project.sort_timeline_entries([ earlier_devlog, returned_review, later_devlog ])
+
+    assert_equal [ later_devlog, returned_review, earlier_devlog ], ordered
+    assert_operator ordered.index(later_devlog), :<, ordered.index(returned_review),
+                    "a later devlog should sit above the returned review"
+    assert_operator ordered.index(returned_review), :<, ordered.index(earlier_devlog),
+                    "the returned review should sit above the devlog that predates its decision"
+  end
+
+  test "timeline_sort_key uses decided_at for a decided review, falling back to created_at while pending" do
+    decided = Certification::FundingRequest.new(created_at: 5.days.ago, decided_at: 1.day.ago)
+    pending = Certification::FundingRequest.new(created_at: 2.days.ago, decided_at: nil)
+
+    assert_equal decided.decided_at, Project.timeline_sort_key(decided)
+    assert_equal pending.created_at, Project.timeline_sort_key(pending)
+  end
+
+  test "timeline_funding_requests keeps older reviews, not just the latest" do
+    older = create_pending_request
+    older.update_column(:status, funding_status(:returned))
+
+    newer = create_pending_request
+    newer.update_column(:status, funding_status(:returned))
+
+    requests = @project.timeline_funding_requests.to_a
+
+    assert_includes requests, older, "an older returned review must stay on the timeline"
+    assert_includes requests, newer
+  end
+
+  test "timeline_funding_requests surfaces pending, approved and returned but omits misfiled and withdrawn" do
+    request = create_pending_request
+
+    %i[pending approved returned].each do |status|
+      request.update_column(:status, funding_status(status))
+      assert_includes @project.timeline_funding_requests.to_a, request,
+                      "a #{status} review belongs on the timeline"
+    end
+
+    %i[misfiled withdrawn].each do |status|
+      request.update_column(:status, funding_status(status))
+      assert_not_includes @project.timeline_funding_requests.to_a, request,
+                          "a #{status} review is surfaced elsewhere, not on the timeline"
+    end
+  end
+
+  private
+
+  def create_pending_request
+    @project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 2, requested_amount_cents: 3_000, status: :pending
+    )
+  end
+
+  def funding_status(name)
+    Certification::FundingRequest.statuses.fetch(name.to_s)
+  end
+end


### PR DESCRIPTION
## what's this do?

Hardware reviews should be shown historically to the user and currently, it just gets overwritten. Additionally, I think they would make a lot more sense if weaved into the devlogs to show actual growth and what things are based on.

Hardware reviews are already public on slack & something I believe are good to learn from and see. The flipper `public_hardware_reviews` makes them public to all users. As-is, they're only public to hardware reviewers & the project creator.

## show it works

<img width="1196" height="1240" alt="image" src="https://github.com/user-attachments/assets/7b1e7dfe-81e0-41bf-b191-25671290fb62" />

## ai?

claude opus 4.8 because opus 5 failed miserably trying to do this.
