### PR TITLE
fix: render devlog detail cards without navigation

### DIFF
--- a/app/components/posts/card_component.html.erb
+++ b/app/components/posts/card_component.html.erb
@@ -6,7 +6,7 @@
 <article id="<%= dom_id(post) %>" class="<%= card_classes %>"
   <%= tag.attributes(data: card_data) %>>
 <% end %>
-  <% if card_link_url.present? && !on_card_link_target %>
+  <% if clickable && card_link_url.present? && !on_card_link_target %>
     <%= link_to card_link_url,
           class: "feed-post-card__overlay-link",
           aria: { label: "Open comments for this post" } do %>

--- a/app/components/posts/card_component.rb
+++ b/app/components/posts/card_component.rb
@@ -4,9 +4,9 @@ module Posts
   class CardComponent < ViewComponent::Base
     delegate :inline_svg_tag, to: :helpers
 
-    attr_reader :post, :current_user, :theme, :compact, :show_likes, :show_comments, :show_reposts, :show_actions, :source, :position, :page, :feed_request_id, :track_engagement, :current_user_reposted_post_ids, :show_views, :media_variant, :lazy_media
+    attr_reader :post, :current_user, :theme, :compact, :show_likes, :show_comments, :show_reposts, :show_actions, :source, :position, :page, :feed_request_id, :track_engagement, :current_user_reposted_post_ids, :show_views, :media_variant, :lazy_media, :clickable
 
-    def initialize(post:, current_user: nil, theme: :feed, compact: false, show_likes: true, show_comments: true, show_reposts: true, show_actions: true, source: nil, position: nil, page: nil, feed_request_id: nil, track_engagement: true, current_user_reposted_post_ids: nil, show_views: nil, media_variant: :large, lazy_media: false)
+    def initialize(post:, current_user: nil, theme: :feed, compact: false, show_likes: true, show_comments: true, show_reposts: true, show_actions: true, source: nil, position: nil, page: nil, feed_request_id: nil, track_engagement: true, current_user_reposted_post_ids: nil, show_views: nil, media_variant: :large, lazy_media: false, clickable: true)
       @post = post
       @current_user = current_user
       @theme = theme
@@ -24,6 +24,7 @@ module Posts
       @show_views = show_views
       @media_variant = media_variant
       @lazy_media = lazy_media
+      @clickable = clickable
     end
 
     def render?
@@ -60,7 +61,7 @@ module Posts
     def card_classes
       class_names(
         "feed-post-card",
-        "feed-post-card--linked": card_link_url.present? && request.path != card_link_url,
+        "feed-post-card--linked": card_link_url.present? && request.path != card_link_url && clickable,
         "feed-post-card--compact": compact,
         "feed-post-card--quote-repost": quote_repost?,
         "feed-post-card--fire": fire_event?,
@@ -74,7 +75,9 @@ module Posts
       return data if url.blank?
 
       controllers = [ data[:controller], "card-link" ].compact.join(" ")
-      actions = [ data[:action], "click->card-link#navigate auxclick->card-link#navigate" ].compact.join(" ")
+      if clickable
+        actions = [ data[:action], "click->card-link#navigate auxclick->card-link#navigate" ].compact.join(" ")
+      end
 
       data.merge(
         controller: controllers,

--- a/app/components/posts/card_component.rb
+++ b/app/components/posts/card_component.rb
@@ -72,12 +72,10 @@ module Posts
     def card_data
       url = card_link_url
       data = engagement_data
-      return data if url.blank?
+      return data if url.blank? || !clickable
 
       controllers = [ data[:controller], "card-link" ].compact.join(" ")
-      if clickable
-        actions = [ data[:action], "click->card-link#navigate auxclick->card-link#navigate" ].compact.join(" ")
-      end
+      actions = [ data[:action], "click->card-link#navigate auxclick->card-link#navigate" ].compact.join(" ")
 
       data.merge(
         controller: controllers,

--- a/app/views/projects/devlogs/show.html.erb
+++ b/app/views/projects/devlogs/show.html.erb
@@ -25,7 +25,8 @@
               post: @post,
               current_user: current_user,
               show_comments: false,
-              show_actions: current_user.present?
+              show_actions: current_user.present?,
+              clickable: false
             ) %>
       </article>
 

--- a/test/components/feed_presentation_components_test.rb
+++ b/test/components/feed_presentation_components_test.rb
@@ -101,6 +101,17 @@ class FeedPresentationComponentsTest < ViewComponent::TestCase
     assert_selector "a.feed-post-card__overlay-link[href='#{href}']", visible: :all
   end
 
+  test "post card can render without navigation data" do
+    render_inline Posts::CardComponent.new(post: @post, current_user: @user, clickable: false)
+
+    assert_selector ".feed-post-card[data-controller~='feed-engagement']"
+    assert_no_selector ".feed-post-card--linked"
+    assert_no_selector ".feed-post-card[data-controller~='card-link']"
+    assert_no_selector ".feed-post-card[data-card-link-url-value]"
+    assert_no_selector ".feed-post-card[data-action*='card-link#navigate']"
+    assert_no_selector ".feed-post-card__overlay-link", visible: :all
+  end
+
   test "post card can render without passive feed engagement tracking" do
     render_inline Posts::CardComponent.new(post: @post, current_user: @user, track_engagement: false)
 


### PR DESCRIPTION
## What

Prevents the devlog card on its own detail page from linking back to itself.

This cherry-picks the original change from #682, updates it for the current post-card panel/navigation implementation, and applies the outstanding review feedback: when clickable is false, the card now renders without the card-link controller, URL/action data, linked styling, or overlay link. Passive feed-engagement data remains independent.

Supersedes and links back to #682.

## Attribution

The original cherry-picked commit retains @ultravioletasdf as its author. The follow-up feedback commit also includes ultraviolet as a co-author.

## Validation

- git diff --check origin/main...HEAD
- Added ViewComponent coverage for the static-card navigation contract
- Rails test not run locally because Docker/local execution mode is awaiting confirmation; CI will run on this PR