### PR TITLE
feat(hardware): Add design review feedback image support

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -41,6 +41,7 @@
 @use "components/mission_panel";
 @use "components/status_pill";
 @use "components/review_history";
+@use "components/feedback_images";
 @use "components/feed";
 @use "components/mentions";
 @use "components/star_border";

--- a/app/assets/stylesheets/components/_feed.scss
+++ b/app/assets/stylesheets/components/_feed.scss
@@ -2361,6 +2361,7 @@
   // project story. Only a returned request breaks out of it.
   --funding-accent: var(--color-brand-highlight);
 
+  position: relative;
   background: var(--color-set-4-bg);
   border-color: var(--funding-accent);
   gap: var(--space-xxs);
@@ -2402,6 +2403,51 @@
 
     p + p {
       margin-top: var(--space-xs);
+    }
+
+    // Reviewer feedback with photos: the whole block opens the feedback modal.
+    &--openable {
+      cursor: pointer;
+    }
+  }
+
+  // One "expand" control for the whole review, anchored bottom-right. Opens the
+  // same feedback modal as clicking the review body. `!important` overrides the
+  // broad `.feed-post-card button { position: relative }` reset, which would
+  // otherwise keep this in flow and stretch it across the flex column.
+  &__expand {
+    position: absolute !important;
+    right: var(--space-m);
+    bottom: var(--space-m);
+    z-index: 3;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xxs);
+    padding: var(--space-xxs) var(--space-s);
+    border: 1px solid var(--color-space-border);
+    border-radius: 999px;
+    background: rgba(5, 4, 24, 0.35);
+    color: var(--color-space-text-muted);
+    font-size: var(--font-size-s);
+    font-weight: 600;
+    line-height: 1;
+    cursor: pointer;
+    transition:
+      background 0.15s ease,
+      color 0.15s ease,
+      border-color 0.15s ease;
+
+    svg {
+      width: 15px;
+      height: 15px;
+    }
+
+    &:hover,
+    &:focus-visible {
+      background: var(--color-brand-mint-soft);
+      border-color: var(--color-brand-mint);
+      color: var(--color-space-text);
+      outline: none;
     }
   }
 

--- a/app/assets/stylesheets/components/_feedback_images.scss
+++ b/app/assets/stylesheets/components/_feedback_images.scss
@@ -1,12 +1,11 @@
-// Thumbnail gallery for reviewer-attached funding-feedback photos. Rendered
-// beside the feedback text on both the reviewer review view and the
-// builder-facing funding request card (partial:
-// admin/certification/funding_requests/_feedback_images).
+// Reviewer-attached funding-feedback photos: a thumbnail gallery beside the
+// feedback text (partial: admin/certification/funding_requests/_feedback_images).
+// Each thumbnail opens the full image in a modal, like project photos elsewhere.
 .feedback-images {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-xs);
-  margin: var(--space-xs) 0 0;
+  margin: var(--space-s) 0 0;
   padding: 0;
   list-style: none;
 
@@ -14,9 +13,13 @@
     margin: 0;
   }
 
-  &__link {
+  &__trigger {
     display: block;
+    padding: 0;
+    border: 0;
+    background: none;
     border-radius: calc(var(--border-radius) * 0.5);
+    cursor: pointer;
     overflow: hidden;
 
     &:focus-visible {
@@ -27,16 +30,153 @@
 
   &__media {
     display: block;
-    width: 84px;
-    height: 84px;
+    width: 112px;
+    height: 112px;
     object-fit: cover;
     border: 1px solid var(--color-space-border);
     border-radius: calc(var(--border-radius) * 0.5);
     background: var(--color-space-card);
-    transition: filter 0.15s ease;
+    transition:
+      filter 0.15s ease,
+      transform 0.15s ease;
 
-    &:hover {
+    .feedback-images__trigger:hover & {
       filter: brightness(1.08);
+      transform: scale(1.02);
+    }
+  }
+
+  // Expanded view: the whole review the way a devlog reads. A large, transparent,
+  // centred <dialog> holding a surface panel on a dimmed backdrop — the same
+  // shape as .ship-modal / .payout-review-modal.
+  &__modal {
+    position: fixed;
+    inset: auto;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    margin: 0;
+    width: min(860px, 94vw);
+    max-height: 90vh;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--color-space-text);
+    overflow: visible;
+
+    &::backdrop {
+      background: rgba(0, 0, 0, 0.55);
+      backdrop-filter: blur(2px);
+    }
+  }
+
+  &__panel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-m);
+    max-height: 90vh;
+    padding: var(--space-l);
+    overflow-y: auto;
+    // Match the funding-request card's surface (set-4 + the cream funding accent)
+    // so the expanded view reads as the same review.
+    background: var(--color-set-4-bg);
+    border: 2px solid var(--color-brand-highlight);
+    border-radius: var(--border-radius);
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+  }
+
+  &__panel-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-m);
+  }
+
+  &__panel-title {
+    margin: 0;
+    font-family: "Playfair Display", serif;
+    font-style: italic;
+    font-size: var(--font-size-l);
+    font-weight: 700;
+    color: var(--color-space-text);
+  }
+
+  &__close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 34px;
+    height: 34px;
+    padding: 0;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--color-space-text-muted);
+    font-size: 1.25rem;
+    line-height: 1;
+    cursor: pointer;
+    transition:
+      background 120ms ease,
+      color 120ms ease;
+
+    &:hover,
+    &:focus-visible {
+      background: rgba(255, 255, 255, 0.12);
+      color: var(--color-space-text);
+      outline: none;
+    }
+  }
+
+  // The review rendered as a feed-post-card, but seamless inside the panel: no
+  // card border/background of its own (the panel is the surface). Keeping the
+  // .feed-post-card class means its byline/body offset and post-media styles
+  // still apply. Compound selector so this beats the base .feed-post-card.
+  &__panel &__card {
+    border: 0;
+    background: transparent;
+    overflow: visible;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-s);
+
+    // Show each photo whole (not cover-cropped) and keep the modal compact so it
+    // stays comfortably centred rather than running off-screen.
+    .feed-post-card__media-viewport {
+      background: transparent;
+    }
+
+    .feed-post-card__image {
+      width: auto;
+      max-width: 100%;
+      height: auto;
+      max-height: 56vh;
+      margin: 0 auto;
+      object-fit: contain;
+    }
+
+    // Carousel controls as a compact pair at the media's bottom-right, always
+    // visible (the feed hides its full-height gradient arrows until hover).
+    .feed-post-card__media-arrow {
+      top: auto;
+      bottom: var(--space-xs);
+      width: 34px;
+      height: 34px;
+      padding: 0;
+      justify-content: center;
+      border-radius: 999px;
+      background: rgba(5, 4, 24, 0.6);
+      color: #fff;
+      opacity: 1;
+    }
+
+    .feed-post-card__media-arrow--prev {
+      left: auto;
+      right: calc(var(--space-xs) + 42px);
+    }
+
+    .feed-post-card__media-arrow--next {
+      right: var(--space-xs);
     }
   }
 }

--- a/app/assets/stylesheets/components/_feedback_images.scss
+++ b/app/assets/stylesheets/components/_feedback_images.scss
@@ -1,0 +1,42 @@
+// Thumbnail gallery for reviewer-attached funding-feedback photos. Rendered
+// beside the feedback text on both the reviewer review view and the
+// builder-facing funding request card (partial:
+// admin/certification/funding_requests/_feedback_images).
+.feedback-images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  margin: var(--space-xs) 0 0;
+  padding: 0;
+  list-style: none;
+
+  &__item {
+    margin: 0;
+  }
+
+  &__link {
+    display: block;
+    border-radius: calc(var(--border-radius) * 0.5);
+    overflow: hidden;
+
+    &:focus-visible {
+      outline: 2px solid var(--color-brand-mint);
+      outline-offset: 2px;
+    }
+  }
+
+  &__media {
+    display: block;
+    width: 84px;
+    height: 84px;
+    object-fit: cover;
+    border: 1px solid var(--color-space-border);
+    border-radius: calc(var(--border-radius) * 0.5);
+    background: var(--color-space-card);
+    transition: filter 0.15s ease;
+
+    &:hover {
+      filter: brightness(1.08);
+    }
+  }
+}

--- a/app/assets/stylesheets/pages/_hardware_funding.scss
+++ b/app/assets/stylesheets/pages/_hardware_funding.scss
@@ -248,6 +248,103 @@
   opacity: 0.75;
 }
 
+// Reviewer feedback-image upload: a dashed drop target plus a client-side
+// preview grid of the files queued for this verdict (controller:
+// review_feedback_images_controller.js).
+.review-form__images-heading {
+  margin: var(--space-s) 0 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  opacity: 0.75;
+}
+
+.review-form__image-drop {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: var(--space-xs);
+  padding: var(--space-m);
+  border: 2px dashed var(--color-space-border);
+  border-radius: var(--border-radius);
+  text-align: center;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+
+  &:hover,
+  &:focus-within {
+    border-color: var(--color-space-accent);
+  }
+
+  &--dragover {
+    border-color: var(--color-brand-mint);
+    background: var(--color-space-card);
+  }
+}
+
+.review-form__image-input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.review-form__image-drop-text {
+  font-size: 0.85rem;
+  color: var(--color-space-text-muted);
+  pointer-events: none;
+}
+
+.review-form__image-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  margin: var(--space-xs) 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.review-form__image-preview {
+  position: relative;
+  width: 84px;
+  height: 84px;
+  border-radius: calc(var(--border-radius) * 0.5);
+  overflow: hidden;
+  border: 1px solid var(--color-space-border);
+}
+
+.review-form__image-preview-media {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.review-form__image-preview-remove {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 20px;
+  height: 20px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-size: 0.9rem;
+  line-height: 1;
+  cursor: pointer;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.85);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // /guides/tiers — tier table.
 // ---------------------------------------------------------------------------

--- a/app/controllers/admin/certification/funding_requests_controller.rb
+++ b/app/controllers/admin/certification/funding_requests_controller.rb
@@ -5,7 +5,9 @@ class Admin::Certification::FundingRequestsController < Admin::Certification::Ap
 
   def update
     authorize @funding_request
-    if @funding_request.update(funding_request_params)
+    @funding_request.assign_attributes(funding_request_params)
+    attach_feedback_images
+    if @funding_request.save
       count = ::Certification::FundingRequest.reviewed_today(current_user)
       notice = "#{verdict_sentence} That's #{count} reviewed today. Keep going!"
       # Straight on to the next design review; `next` claims it, and falls back
@@ -106,5 +108,13 @@ class Admin::Certification::FundingRequestsController < Admin::Certification::Ap
 
   def funding_request_params
     params.require(:certification_funding_request).permit(:verdict, :feedback, :approved_amount_dollars)
+  end
+
+  # Reviewer-attached feedback photos. Mirrors ships_controller's attach guard:
+  # only touch the association when files are actually present, so submitting a
+  # verdict without picking any images leaves the request's images untouched.
+  def attach_feedback_images
+    images = params.dig(:certification_funding_request, :feedback_images)&.reject(&:blank?)
+    @funding_request.feedback_images.attach(images) if images.present?
   end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -322,6 +322,9 @@ application.register("readme-image", ReadmeImageController);
 import RerollPollController from "./reroll_poll_controller";
 application.register("reroll-poll", RerollPollController);
 
+import ReviewFeedbackImagesController from "./review_feedback_images_controller";
+application.register("review-feedback-images", ReviewFeedbackImagesController);
+
 import RevealOnScrollController from "./reveal_on_scroll_controller";
 application.register("reveal-on-scroll", RevealOnScrollController);
 

--- a/app/javascript/controllers/review_feedback_images_controller.js
+++ b/app/javascript/controllers/review_feedback_images_controller.js
@@ -1,0 +1,116 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Multi-image picker for the hardware funding review form. Previews the
+// reviewer's selected feedback photos, lets them drop or remove files, and
+// keeps the file input in sync so the current selection submits with the
+// verdict. Server-side validation (image type / size / count) is the source of
+// truth; this only mirrors the accepted types and max count for a nicer UI.
+export default class extends Controller {
+  static targets = ["input", "grid", "dropZone"];
+  static values = { max: { type: Number, default: 6 } };
+
+  #files = [];
+  #urls = [];
+
+  disconnect() {
+    this.#revokeUrls();
+  }
+
+  select() {
+    this.#addFiles(this.inputTarget.files);
+  }
+
+  drop(event) {
+    event.preventDefault();
+    this.#toggleDragover(false);
+    this.#addFiles(event.dataTransfer.files);
+  }
+
+  dragover(event) {
+    event.preventDefault();
+    this.#toggleDragover(true);
+  }
+
+  dragleave() {
+    this.#toggleDragover(false);
+  }
+
+  removeFile({ params: { index } }) {
+    this.#files.splice(index, 1);
+    this.#render();
+  }
+
+  #toggleDragover(on) {
+    if (this.hasDropZoneTarget)
+      this.dropZoneTarget.classList.toggle(
+        "review-form__image-drop--dragover",
+        on,
+      );
+  }
+
+  #acceptedTypes() {
+    return (this.inputTarget.accept || "")
+      .split(",")
+      .map((type) => type.trim())
+      .filter(Boolean);
+  }
+
+  #addFiles(fileList) {
+    const accepted = this.#acceptedTypes();
+    const incoming = Array.from(fileList).filter(
+      (file) => accepted.length === 0 || accepted.includes(file.type),
+    );
+    const room = this.maxValue - this.#files.length;
+    this.#files.push(...incoming.slice(0, Math.max(0, room)));
+    this.#render();
+  }
+
+  #render() {
+    this.#revokeUrls();
+    this.gridTarget.innerHTML = "";
+
+    if (this.#files.length === 0) {
+      this.gridTarget.hidden = true;
+      this.#syncInput();
+      return;
+    }
+
+    this.gridTarget.hidden = false;
+    this.#files.forEach((file, index) => {
+      const item = document.createElement("li");
+      item.className = "review-form__image-preview";
+
+      const url = URL.createObjectURL(file);
+      this.#urls.push(url);
+      const img = document.createElement("img");
+      img.src = url;
+      img.alt = file.name;
+      img.className = "review-form__image-preview-media";
+      item.appendChild(img);
+
+      const remove = document.createElement("button");
+      remove.type = "button";
+      remove.className = "review-form__image-preview-remove";
+      remove.setAttribute("aria-label", "Remove image");
+      remove.textContent = "×";
+      remove.dataset.action = "review-feedback-images#removeFile";
+      remove.dataset.reviewFeedbackImagesIndexParam = String(index);
+      item.appendChild(remove);
+
+      this.gridTarget.appendChild(item);
+    });
+
+    this.#syncInput();
+  }
+
+  #syncInput() {
+    const data = new DataTransfer();
+    this.#files.forEach((file) => data.items.add(file));
+    this.inputTarget.files = data.files;
+  }
+
+  #revokeUrls() {
+    this.#urls.forEach((url) => URL.revokeObjectURL(url));
+    this.#urls = [];
+  }
+}

--- a/app/models/certification/funding_request.rb
+++ b/app/models/certification/funding_request.rb
@@ -67,6 +67,46 @@ module Certification
 
     has_paper_trail
 
+    # Reviewers can attach annotated photos (wiring shots, schematics) to their
+    # written feedback, shown to the builder beside the feedback text. Images
+    # only, and always optional: mirrors HasPostAttachments' webp variants and
+    # content-type/size validations without its "at least one attachment" rule.
+    MAX_FEEDBACK_IMAGES = 6
+    FEEDBACK_IMAGE_CONTENT_TYPES = %w[
+      image/jpeg
+      image/png
+      image/webp
+      image/heic
+      image/heif
+      image/gif
+    ].freeze
+
+    has_many_attached :feedback_images do |attachable|
+      attachable.variant :large,
+                         resize_to_limit: [ 1600, 900 ],
+                         format: :webp,
+                         preprocessed: true,
+                         saver: { strip: true, quality: 75 }
+
+      attachable.variant :medium,
+                         resize_to_limit: [ 800, 800 ],
+                         format: :webp,
+                         preprocessed: false,
+                         saver: { strip: true, quality: 75 }
+
+      attachable.variant :thumb,
+                         resize_to_limit: [ 400, 400 ],
+                         format: :webp,
+                         preprocessed: false,
+                         saver: { strip: true, quality: 75 }
+    end
+
+    validates :feedback_images,
+              content_type: { in: FEEDBACK_IMAGE_CONTENT_TYPES, spoofing_protection: true },
+              size: { less_than: 15.megabytes, message: "is too large (max 15 MB)" },
+              processable_file: true
+    validate :feedback_images_within_limit
+
     # misfiled: a reviewer says this belongs in the build queue and the builder
     # hasn't answered yet. withdrawn: the builder agreed, so the request is done
     # with and the project moves on to the build stage. Neither is a verdict, so
@@ -389,6 +429,14 @@ module Certification
         errors.add(:base, "Verify your identity before requesting funding.")
       elsif !owner.ysws_eligible?
         errors.add(:base, "You're not eligible for YSWS prizes yet, so we can't fund this build. Check the Hack Club portal for details.")
+      end
+    end
+
+    def feedback_images_within_limit
+      return unless feedback_images.attached?
+
+      if feedback_images.size > MAX_FEEDBACK_IMAGES
+        errors.add(:feedback_images, "can't exceed #{MAX_FEEDBACK_IMAGES} images")
       end
     end
 

--- a/app/models/concerns/certification/reviewable.rb
+++ b/app/models/concerns/certification/reviewable.rb
@@ -112,6 +112,7 @@ module Certification
       locals[:review_type] = is_a?(Certification::FundingRequest) ? "design" : "build"
       locals[:owner_slack_id] = owner&.slack_id
       locals[:reviewer_slack_id] = reviewer&.slack_id
+      locals[:feedback_image_urls] = feedback_image_slack_urls
       SendSlackDmJob.perform_later(
         HARDWARE_REVIEW_CHANNEL,
         nil,
@@ -120,6 +121,29 @@ module Certification
       )
     rescue StandardError => e
       Rails.logger.error("#{self.class.name} ##{id} post_verdict_to_hardware_review_channel! failed: #{e.message}")
+    end
+
+    # Public, Slack-renderable URLs for the reviewer's attached feedback photos so
+    # the verdict channel post can show them inline. Only funding requests carry
+    # feedback images; Slack won't render our webp variants, so this serves a PNG
+    # one. A bad image never takes down the verdict post - it just drops out.
+    def feedback_image_slack_urls
+      return [] unless respond_to?(:feedback_images) && feedback_images.attached?
+
+      routes = Rails.application.routes.url_helpers
+      url_opts = (Rails.application.config.action_controller.default_url_options || {})
+                   .reverse_merge(host: "stardance.hackclub.com", protocol: "https")
+
+      feedback_images.filter_map do |image|
+        next unless image.persisted?
+
+        routes.rails_representation_url(
+          image.variant(resize_to_limit: [ 1600, 1600 ], format: :png), **url_opts
+        )
+      rescue StandardError => e
+        Rails.logger.error("feedback_image_slack_urls (##{id}) failed: #{e.message}")
+        nil
+      end
     end
 
     def decided?

--- a/app/views/admin/certification/funding_requests/_feedback_images.html.erb
+++ b/app/views/admin/certification/funding_requests/_feedback_images.html.erb
@@ -1,0 +1,21 @@
+<%# Reviewer-attached feedback photos for a funding request, shown beside the
+    feedback text on both the reviewer review view and the builder-facing card.
+
+    Only persisted attachments render: after a failed verdict submit the form
+    re-shows the request with the reviewer's picks still staged (unsaved), and
+    those must not appear as though they were already attached.
+
+    Locals: funding_request (required). %>
+<% saved_feedback_images = funding_request.feedback_images.select(&:persisted?) %>
+<% if saved_feedback_images.any? %>
+  <ul class="feedback-images">
+    <% saved_feedback_images.each do |image| %>
+      <li class="feedback-images__item">
+        <%= link_to url_for(image), target: "_blank", rel: "noopener noreferrer", class: "feedback-images__link" do %>
+          <%= image_tag image.variant(:thumb), alt: "Reviewer feedback image",
+                loading: "lazy", class: "feedback-images__media" %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/admin/certification/funding_requests/_feedback_images.html.erb
+++ b/app/views/admin/certification/funding_requests/_feedback_images.html.erb
@@ -1,6 +1,11 @@
 <%# Reviewer-attached feedback photos for a funding request, shown beside the
     feedback text on both the reviewer review view and the builder-facing card.
 
+    Inline: a small thumbnail gallery. Clicking any thumbnail opens one large
+    modal that shows the whole review the way a devlog reads - reviewer byline,
+    the feedback text, and the photos in the shared post-media gallery. The modal
+    closes via the button, Esc, or a backdrop click (modal controller).
+
     Only persisted attachments render: after a failed verdict submit the form
     re-shows the request with the reviewer's picks still staged (unsaved), and
     those must not appear as though they were already attached.
@@ -8,14 +13,70 @@
     Locals: funding_request (required). %>
 <% saved_feedback_images = funding_request.feedback_images.select(&:persisted?) %>
 <% if saved_feedback_images.any? %>
+  <% dialog_id = "feedback-images-#{funding_request.id}" %>
+  <% reviewer = funding_request.reviewer %>
+  <% decided_on = funding_request.decided_at || funding_request.created_at %>
+
   <ul class="feedback-images">
     <% saved_feedback_images.each do |image| %>
       <li class="feedback-images__item">
-        <%= link_to url_for(image), target: "_blank", rel: "noopener noreferrer", class: "feedback-images__link" do %>
-          <%= image_tag image.variant(:thumb), alt: "Reviewer feedback image",
+        <button type="button" class="feedback-images__trigger"
+                onclick="document.getElementById(<%= dialog_id.to_json %>).showModal()"
+                aria-label="Open reviewer feedback">
+          <%= image_tag image.variant(:medium), alt: "Reviewer feedback image",
                 loading: "lazy", class: "feedback-images__media" %>
-        <% end %>
+        </button>
       </li>
     <% end %>
   </ul>
+
+  <%# stopPropagation so a click inside the modal (backdrop, ×, content) doesn't
+      bubble to the review body's open handler, which would reopen it. %>
+  <dialog id="<%= dialog_id %>" class="feedback-images__modal" data-controller="modal"
+          aria-label="Reviewer feedback" onclick="event.stopPropagation()">
+    <div class="feedback-images__panel">
+      <header class="feedback-images__panel-head">
+        <p class="feedback-images__panel-title">Reviewer feedback</p>
+        <button type="button" class="feedback-images__close"
+                data-action="modal#close" aria-label="Close">&times;</button>
+      </header>
+
+      <article class="feed-post-card feedback-images__card">
+        <header class="feed-post-card__header">
+          <% if reviewer %>
+            <%= link_to profile_path(reviewer.display_name), class: "feed-post-card__avatar-link",
+                  aria: { label: "@#{reviewer.display_name}" } do %>
+              <%= image_tag reviewer.avatar, alt: "", class: "feed-post-card__avatar" %>
+            <% end %>
+          <% else %>
+            <span class="feed-post-card__avatar feed-post-card__avatar--placeholder" aria-hidden="true">$</span>
+          <% end %>
+          <div class="feed-post-card__meta">
+            <p class="feed-post-card__byline">
+              <% if reviewer %>
+                <%= render "shared/username_link", user: reviewer,
+                      link_class: "feed-post-card__author", badge: false %>
+              <% else %>
+                <span class="feed-post-card__author">A reviewer</span>
+              <% end %>
+              <span class="feed-post-card__context">left feedback</span>
+              <time class="feed-post-card__time" datetime="<%= decided_on.iso8601 %>"
+                    title="<%= l(decided_on, format: :long) %>">
+                · <%= time_ago_in_words(decided_on) %> ago
+              </time>
+            </p>
+          </div>
+        </header>
+
+        <% if funding_request.feedback.present? %>
+          <div class="feed-post-card__body markdown-content">
+            <%= simple_format(funding_request.feedback, {}, sanitize: true) %>
+          </div>
+        <% end %>
+
+        <%= render "shared/post_media",
+              attachments: saved_feedback_images, variant: :large, lazy: false %>
+      </article>
+    </div>
+  </dialog>
 <% end %>

--- a/app/views/admin/certification/funding_requests/_form.html.erb
+++ b/app/views/admin/certification/funding_requests/_form.html.erb
@@ -8,7 +8,7 @@
   <% end %>
 <% end %>
 
-<%= form_with model: funding_request, url: admin_certification_funding_request_path(funding_request), method: :patch, class: "review-form" do |f| %>
+<%= form_with model: funding_request, url: admin_certification_funding_request_path(funding_request), method: :patch, class: "review-form", multipart: true do |f| %>
 <% if local_assigns[:redirect_to_hardware] %>
   <%# Sends the verdict back to the combined hardware review page. %>
   <%= hidden_field_tag :redirect_to_hardware, funding_request.project_id %>
@@ -71,6 +71,33 @@
   <div class="review-form__field">
     <%= f.label :feedback, "Feedback for the user (visible to the project owner)" %>
     <%= f.text_area :feedback, rows: 6, maxlength: 10_000 %>
+  </div>
+
+  <div class="review-form__field review-form__images"
+       data-controller="review-feedback-images"
+       data-review-feedback-images-max-value="<%= Certification::FundingRequest::MAX_FEEDBACK_IMAGES %>">
+    <%= f.label :feedback_images, "Attach images (optional)" %>
+    <p class="review-form__hint">
+      Add annotated photos — wiring shots, schematics — to go with your feedback. Up to <%= Certification::FundingRequest::MAX_FEEDBACK_IMAGES %> images, shown to the builder.
+    </p>
+
+    <% if funding_request.feedback_images.any?(&:persisted?) %>
+      <p class="review-form__images-heading">Already attached</p>
+      <%= render "admin/certification/funding_requests/feedback_images", funding_request: funding_request %>
+    <% end %>
+
+    <label class="review-form__image-drop"
+           data-review-feedback-images-target="dropZone"
+           data-action="dragover->review-feedback-images#dragover dragleave->review-feedback-images#dragleave drop->review-feedback-images#drop">
+      <%= f.file_field :feedback_images,
+            multiple: true,
+            accept: Certification::FundingRequest::FEEDBACK_IMAGE_CONTENT_TYPES.join(","),
+            class: "review-form__image-input",
+            data: { review_feedback_images_target: "input", action: "change->review-feedback-images#select" } %>
+      <span class="review-form__image-drop-text">Drag images here, or click to choose</span>
+    </label>
+
+    <ul class="review-form__image-grid" data-review-feedback-images-target="grid" hidden></ul>
   </div>
 
   <div class="review-form__actions">

--- a/app/views/admin/certification/hardware_reviews/show.html.erb
+++ b/app/views/admin/certification/hardware_reviews/show.html.erb
@@ -120,6 +120,9 @@
                   <% if review.feedback.present? %>
                     <p class="hardware-review__history-feedback"><%= review.feedback %></p>
                   <% end %>
+                  <% if is_funding %>
+                    <%= render "admin/certification/funding_requests/feedback_images", funding_request: review %>
+                  <% end %>
                   <% if review.internal_reason.present? %>
                     <p class="hardware-review__history-feedback hardware-review__history-feedback--internal">
                       Reviewer note: <%= review.internal_reason %>
@@ -288,6 +291,7 @@
               <div class="ship-review__verdict-feedback">
                 <h3>Funding feedback</h3>
                 <p><%= @funding_request.feedback %></p>
+                <%= render "admin/certification/funding_requests/feedback_images", funding_request: @funding_request %>
               </div>
             <% end %>
             <% if @ship&.feedback.present? %>

--- a/app/views/notifications/hardware/review_decided_channel.slack_message.slocks
+++ b/app/views/notifications/hardware/review_decided_channel.slack_message.slocks
@@ -9,3 +9,10 @@ section ":yay: brand new #{review_type} review!! #{emoji}
  *#{verdict}:* *<#{project_url}|#{project_title}>* by #{owner_mention}", markdown: true
 
 section "*feedback from #{reviewer_mention}:* #{feedback}", markdown: true if feedback.present?
+
+# Reviewer-attached feedback photos (funding reviews only), one image block each.
+if defined?(feedback_image_urls)
+  Array(feedback_image_urls).each do |feedback_image_url|
+    image(feedback_image_url, "Reviewer feedback photo")
+  end
+end

--- a/app/views/projects/_funding_request_card.html.erb
+++ b/app/views/projects/_funding_request_card.html.erb
@@ -92,6 +92,7 @@
   <div class="feed-post-card__body funding-request-card__message">
     <% if show_feedback %>
       <%= simple_format(funding_request.feedback, {}, sanitize: true) %>
+      <%= render "admin/certification/funding_requests/feedback_images", funding_request: funding_request %>
     <% else %>
       <p><%= message %></p>
     <% end %>

--- a/app/views/projects/_funding_request_card.html.erb
+++ b/app/views/projects/_funding_request_card.html.erb
@@ -89,14 +89,25 @@
     <% end %>
   </header>
 
-  <div class="feed-post-card__body funding-request-card__message">
+  <%
+    has_feedback_photos = show_feedback && funding_request.feedback_images.any?(&:persisted?)
+    message_class = class_names("feed-post-card__body", "funding-request-card__message",
+                                "funding-request-card__message--openable" => has_feedback_photos)
+    # The whole review opens the feedback modal; guarded so a thumbnail click
+    # (which opens it too) doesn't re-call showModal on an already-open dialog.
+    open_modal_js =
+      if has_feedback_photos
+        "var d=document.getElementById('feedback-images-#{funding_request.id}'); if (d && !d.open) d.showModal()"
+      end
+  %>
+  <%= tag.div class: message_class, onclick: open_modal_js do %>
     <% if show_feedback %>
       <%= simple_format(funding_request.feedback, {}, sanitize: true) %>
       <%= render "admin/certification/funding_requests/feedback_images", funding_request: funding_request %>
     <% else %>
       <p><%= message %></p>
     <% end %>
-  </div>
+  <% end %>
 
   <% if funding_request.returned? && viewer_is_owner && resubmit_modal_id.present? %>
     <div class="funding-request-card__actions">
@@ -115,5 +126,16 @@
               class: "action-btn action-btn--small action-btn--primary" %>
       <% end %>
     </div>
+  <% end %>
+
+  <% if has_feedback_photos %>
+    <%= tag.button type: "button", class: "funding-request-card__expand",
+          onclick: open_modal_js, aria: { label: "Expand reviewer feedback" } do %>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+           stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M15 3h6v6" /><path d="M9 21H3v-6" /><path d="M21 3l-7 7" /><path d="M3 21l7-7" />
+      </svg>
+      <span>Expand</span>
+    <% end %>
   <% end %>
 </article>

--- a/test/models/certification/funding_request_slack_feedback_test.rb
+++ b/test/models/certification/funding_request_slack_feedback_test.rb
@@ -1,0 +1,100 @@
+require "test_helper"
+
+# The verdict channel post ("brand new review!!") carries the reviewer's attached
+# feedback photos as Slack image blocks. These pin
+# Certification::FundingRequest#feedback_image_slack_urls and the image rendering
+# in notifications/hardware/review_decided_channel.
+class FundingRequestSlackFeedbackTest < ActiveSupport::TestCase
+  # 1x1 PNG so attaching produces a real, identifiable image blob.
+  PIXEL_PNG = Base64.decode64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=")
+
+  setup do
+    Flipper.enable(:hardware_flow)
+    @owner = User.create!(
+      email: "owner-#{SecureRandom.hex(6)}@example.com",
+      display_name: "Owner#{SecureRandom.hex(3)}",
+      slack_id: "U#{SecureRandom.hex(8)}",
+      verification_status: :verified, ysws_eligible: true
+    )
+    @reviewer = User.create!(
+      email: "rev-#{SecureRandom.hex(6)}@example.com",
+      display_name: "Rev#{SecureRandom.hex(3)}",
+      slack_id: "U#{SecureRandom.hex(8)}"
+    )
+    @project = Project.create!(title: "HW #{SecureRandom.hex(4)}", hardware_stage: "design")
+    Project::Membership.create!(project: @project, user: @owner, role: :owner)
+    devlog = Post::Devlog.new(body: "initial log", duration_seconds: 3600, phase: "design")
+    devlog.uploading_attachments = true
+    devlog.save!
+    Post.create!(project: @project, user: @owner, postable: devlog)
+    @request = @project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 2, requested_amount_cents: 5_000, status: :pending
+    )
+  end
+
+  def attach_image(name)
+    @request.feedback_images.attach(io: StringIO.new(PIXEL_PNG), filename: name, content_type: "image/png")
+  end
+
+  test "returns one absolute publicly fetchable url per attached photo" do
+    attach_image("a.png")
+    attach_image("b.png")
+
+    urls = @request.feedback_image_slack_urls
+
+    assert_equal 2, urls.size
+    urls.each do |url|
+      assert_match %r{\Ahttps://stardance\.hackclub\.com/rails/active_storage/}, url,
+        "Slack fetches the image over the internet, so the url must be absolute + public"
+    end
+  end
+
+  test "feedback_image_slack_urls is empty when no photos are attached" do
+    assert_empty @request.feedback_image_slack_urls
+  end
+
+  test "a build review has no feedback image urls" do
+    # Ship shares the Reviewable concern but carries no feedback_images
+    # association, so the helper must degrade to [] rather than raise.
+    assert_empty Certification::Ship.new.feedback_image_slack_urls
+  end
+
+  test "the verdict channel post renders one image block per photo" do
+    attach_image("a.png")
+    attach_image("b.png")
+
+    images = channel_blocks(@request.feedback_image_slack_urls).select { |b| b["type"] == "image" }
+
+    assert_equal 2, images.size
+    assert(images.all? { |block| block["image_url"].present? }, "each image block needs an image_url")
+  end
+
+  test "the verdict channel post has no image blocks when there are no photos" do
+    images = channel_blocks([]).select { |b| b["type"] == "image" }
+    assert_empty images
+  end
+
+  private
+
+  # Render the review_decided_channel slocks template the way SendSlackDmJob does
+  # and return its Slack blocks.
+  def channel_blocks(feedback_image_urls)
+    rendered = ApplicationController.renderer.new.render(
+      template: "notifications/hardware/review_decided_channel",
+      formats: [ :slack_message ],
+      locals: {
+        project_title: @project.title,
+        project_url: "https://stardance.hackclub.com/projects/#{@project.id}",
+        approved: false,
+        reviewer_name: @reviewer.display_name,
+        feedback: "Nice work",
+        review_type: "design",
+        owner_slack_id: @owner.slack_id,
+        reviewer_slack_id: @reviewer.slack_id,
+        feedback_image_urls: feedback_image_urls
+      }
+    )
+    parsed = JSON.parse(rendered)
+    parsed["blocks"] || parsed.values.find { |value| value.is_a?(Array) } || []
+  end
+end

--- a/test/models/certification/funding_request_test.rb
+++ b/test/models/certification/funding_request_test.rb
@@ -198,6 +198,50 @@ class Certification::FundingRequestTest < ActiveSupport::TestCase
     assert_nil old.reload.hcb_grant_hashid, "a superseded request must not issue a grant"
   end
 
+  test "a reviewer can attach feedback images, which persist" do
+    fr = @project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 2, requested_amount_cents: 3_000, status: :pending
+    )
+    fr.feedback_images.attach(io: StringIO.new(PIXEL_PNG), filename: "wiring.png", content_type: "image/png")
+
+    assert fr.valid?
+    assert fr.save
+    assert_equal 1, fr.reload.feedback_images.count
+  end
+
+  test "feedback images reject a non-image file" do
+    fr = @project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 2, requested_amount_cents: 3_000, status: :pending
+    )
+    fr.feedback_images.attach(io: StringIO.new("just notes, not an image"), filename: "notes.txt", content_type: "text/plain")
+
+    assert_not fr.valid?
+    assert fr.errors[:feedback_images].any?
+  end
+
+  test "feedback images reject a file over the size limit" do
+    fr = @project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 2, requested_amount_cents: 3_000, status: :pending
+    )
+    oversized = PIXEL_PNG + ("\0" * 16.megabytes)
+    fr.feedback_images.attach(io: StringIO.new(oversized), filename: "huge.png", content_type: "image/png")
+
+    assert_not fr.valid?
+    assert fr.errors[:feedback_images].any?
+  end
+
+  test "feedback images reject more than the max count" do
+    fr = @project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 2, requested_amount_cents: 3_000, status: :pending
+    )
+    (Certification::FundingRequest::MAX_FEEDBACK_IMAGES + 1).times do |i|
+      fr.feedback_images.attach(io: StringIO.new(PIXEL_PNG), filename: "img#{i}.png", content_type: "image/png")
+    end
+
+    assert_not fr.valid?
+    assert fr.errors[:feedback_images].any?
+  end
+
   private
 
   PIXEL_PNG = Base64.decode64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=")


### PR DESCRIPTION
## what's this do?

images are a great way to help out a user with their design, this adds native support for them

## show it works

<img width="1186" height="485" alt="image" src="https://github.com/user-attachments/assets/0477f117-f5e0-49b1-b9f2-da2978373b5a" />
<img width="2557" height="1533" alt="image" src="https://github.com/user-attachments/assets/6162c871-d419-4995-8782-110699d78c22" />
<img width="575" height="1278" alt="image" src="https://github.com/user-attachments/assets/136d40d4-c99d-4dc4-b00f-d4c757dcfcdd" />

## ai?

opus 4.8