### PR TITLE
feat(hardware): add a reviewer-only internal notes ledger to projects

### DIFF
--- a/app/assets/stylesheets/pages/certification/_hardware_review.scss
+++ b/app/assets/stylesheets/pages/certification/_hardware_review.scss
@@ -577,3 +577,97 @@
     color: var(--color-brand-mint);
   }
 }
+
+// Internal notes ledger for reviewers, kept across a project's funding and ship
+// reviews. It lives on the already staff-only /admin review page, so it needs no
+// per-element admin marker (branding §1.5).
+.reviewer-notes {
+  display: grid;
+  gap: var(--space-m);
+
+  &__header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-s);
+  }
+
+  &__title {
+    margin: 0;
+  }
+
+  &__list {
+    display: grid;
+    gap: var(--space-s);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  &__item {
+    padding: var(--space-s);
+    background: rgba(255, 255, 255, 0.035);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 8px;
+  }
+
+  &__meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.35rem;
+    margin: 0 0 var(--space-xs);
+    font-size: var(--font-size-s);
+  }
+
+  &__author {
+    font-weight: 700;
+    color: var(--color-space-text);
+
+    &:hover,
+    &:focus-visible {
+      text-decoration: underline;
+    }
+  }
+
+  &__time {
+    color: var(--color-space-text-muted);
+  }
+
+  &__body {
+    margin: 0;
+    color: var(--color-space-text);
+    white-space: pre-wrap;
+  }
+
+  &__empty {
+    margin: 0;
+  }
+
+  &__form {
+    display: grid;
+    gap: var(--space-xs);
+    justify-items: start;
+  }
+
+  &__label {
+    font-weight: 600;
+  }
+
+  &__input {
+    width: 100%;
+    padding: var(--space-s);
+    font-family: inherit;
+    font-size: var(--font-size-m);
+    color: var(--color-space-text);
+    background: var(--color-space-surface, rgba(255, 255, 255, 0.04));
+    border: 1px solid var(--color-space-border, rgba(255, 255, 255, 0.18));
+    border-radius: 8px;
+    resize: vertical;
+
+    &:focus-visible {
+      outline: 2px solid var(--color-brand-highlight);
+      outline-offset: 1px;
+    }
+  }
+}

--- a/app/controllers/admin/certification/review_notes_controller.rb
+++ b/app/controllers/admin/certification/review_notes_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Reviewer-only internal notes about a hardware project, written for the next
+# reviewer. Append-only and shared across the project's funding and ship
+# reviews. PaperTrail whodunnit is set by Admin::ApplicationController, so every
+# note is attributable in the audit log.
+class Admin::Certification::ReviewNotesController < Admin::Certification::ApplicationController
+  before_action -> { head :not_found unless Flipper.enabled?(:hardware_flow, current_user) }
+  before_action :set_project
+
+  def create
+    @note = @project.review_notes.new(review_note_params.merge(author: current_user))
+    authorize @note, policy_class: Admin::Certification::ReviewNotePolicy
+
+    if @note.save
+      redirect_to hardware_review_path_for(@project), notice: "Reviewer note added."
+    else
+      redirect_to hardware_review_path_for(@project),
+                  alert: @note.errors.full_messages.to_sentence.presence || "Couldn't add that note."
+    end
+  end
+
+  private
+
+  def set_project
+    @project = Project.find(params[:project_id])
+  end
+
+  def review_note_params
+    params.require(:certification_review_note).permit(:body)
+  end
+end

--- a/app/controllers/concerns/hardware_review_queue.rb
+++ b/app/controllers/concerns/hardware_review_queue.rb
@@ -215,6 +215,7 @@ module HardwareReviewQueue
       when ::Certification::Ship then :ship
       end
     @past_reviews = past_reviews
+    @review_notes = @project.review_notes.includes(:author).newest_first
     @lapse_timelapses = lapse_timelapses_for_review
     @lookout_recordings = lookout_recordings_for_review
   end

--- a/app/models/certification/review_note.rb
+++ b/app/models/certification/review_note.rb
@@ -1,0 +1,39 @@
+# == Schema Information
+#
+# Table name: certification_review_notes
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  author_id  :bigint           not null
+#  project_id :bigint           not null
+#
+# Indexes
+#
+#  index_certification_review_notes_on_author_id   (author_id)
+#  index_certification_review_notes_on_project_id  (project_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (author_id => users.id)
+#  fk_rails_...  (project_id => projects.id)
+#
+module Certification
+  # An internal, reviewer-only note about a project, written for the next
+  # reviewer. Append-only and timestamped, it persists across the project's
+  # funding and ship reviews so context carries between the two hardware stages.
+  # Never shown to the builder.
+  class ReviewNote < ApplicationRecord
+    self.table_name = "certification_review_notes"
+
+    belongs_to :project
+    belongs_to :author, class_name: "User"
+
+    has_paper_trail
+
+    validates :body, presence: true
+
+    scope :newest_first, -> { order(created_at: :desc) }
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -153,6 +153,7 @@ class Project < ApplicationRecord
   has_many :reports, class_name: "Project::Report", dependent: :destroy
   has_many :ship_reviews, class_name: "Certification::Ship", dependent: :restrict_with_exception
   has_many :certification_funding_requests, class_name: "Certification::FundingRequest", dependent: :destroy
+  has_many :review_notes, class_name: "Certification::ReviewNote", dependent: :destroy
   has_many :integrity_checks, through: :ship_events, source: :integrity_check
   has_many :skips, class_name: "Project::Skip", dependent: :destroy
   has_many :project_follows, dependent: :destroy

--- a/app/policies/admin/certification/review_note_policy.rb
+++ b/app/policies/admin/certification/review_note_policy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Admin::Certification::ReviewNotePolicy < ApplicationPolicy
+  # Same bar as leaving a verdict: a hardware reviewer may add an internal note,
+  # but never on a project they're a member of.
+  def create? = can_review_hardware? && not_own_project?
+
+  private
+
+  def not_own_project?
+    return true unless record.respond_to?(:project_id)
+    !user.memberships.where(project_id: record.project_id).exists?
+  end
+end

--- a/app/views/admin/certification/hardware_reviews/show.html.erb
+++ b/app/views/admin/certification/hardware_reviews/show.html.erb
@@ -136,6 +136,42 @@
           <% end %>
         </div>
 
+        <%# Internal notes ledger: context for the next reviewer, kept across
+            this project's funding and ship reviews and never shown to the
+            builder. The whole /admin review page is already staff-only. %>
+        <div class="ship-review__panel reviewer-notes">
+          <header class="reviewer-notes__header">
+            <h2 class="ship-review__panel-title reviewer-notes__title">Reviewer notes</h2>
+          </header>
+
+          <% if @review_notes.any? %>
+            <ul class="reviewer-notes__list">
+              <% @review_notes.each do |note| %>
+                <li class="reviewer-notes__item">
+                  <p class="reviewer-notes__meta">
+                    <%= render "shared/username_link", user: note.author, link_class: "reviewer-notes__author", text: note.author.display_name, badge: false %>
+                    <time class="reviewer-notes__time" datetime="<%= note.created_at.iso8601 %>"
+                          title="<%= l(note.created_at, format: :long) %>">
+                      · <%= l(note.created_at, format: :short) %>
+                    </time>
+                  </p>
+                  <p class="reviewer-notes__body"><%= note.body %></p>
+                </li>
+              <% end %>
+            </ul>
+          <% else %>
+            <p class="ship-review__description reviewer-notes__empty">No reviewer notes yet.</p>
+          <% end %>
+
+          <%= form_with url: admin_certification_project_review_notes_path(@project),
+                scope: :certification_review_note, method: :post, class: "reviewer-notes__form" do |form| %>
+            <%= form.label :body, "Add a note for the next reviewer", class: "reviewer-notes__label" %>
+            <%= form.text_area :body, rows: 3, class: "reviewer-notes__input",
+                  placeholder: "Context the next reviewer should know (not shown to the builder)" %>
+            <%= form.submit "Add note", class: "action-btn action-btn--small action-btn--secondary" %>
+          <% end %>
+        </div>
+
         <%# Secondary context: useful when a verdict is borderline, not needed to
             start reviewing, so it sits below the evidence and the form. %>
         <details class="hardware-review__more">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -897,6 +897,12 @@ Rails.application.routes.draw do
         post :flag_for_fraud, on: :member
       end
 
+      # Reviewer-only internal notes about a project, shared across its funding
+      # and ship reviews and shown on the hardware review page. Append-only.
+      resources :projects, only: [] do
+        resources :review_notes, only: [ :create ]
+      end
+
       resources :devlog_reviews, only: [ :update ]
 
       get "devlogs/:devlog_id/commits", to: "devlog_commits#index", as: "devlog_commits"

--- a/db/migrate/20260824173339_create_certification_review_notes.rb
+++ b/db/migrate/20260824173339_create_certification_review_notes.rb
@@ -1,0 +1,11 @@
+class CreateCertificationReviewNotes < ActiveRecord::Migration[8.1]
+  def change
+    create_table :certification_review_notes do |t|
+      t.references :project, null: false, foreign_key: true
+      t.references :author, null: false, foreign_key: { to_table: :users }
+      t.text :body
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -234,6 +234,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_25_002911) do
     t.index ["ysws_review_id"], name: "index_certification_mac_analyses_on_ysws_review_id", unique: true
   end
 
+  create_table "certification_review_notes", force: :cascade do |t|
+    t.bigint "author_id", null: false
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.bigint "project_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["author_id"], name: "index_certification_review_notes_on_author_id"
+    t.index ["project_id"], name: "index_certification_review_notes_on_project_id"
+  end
+
   create_table "certification_review_skips", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "reviewable_id", null: false
@@ -1700,6 +1710,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_25_002911) do
   add_foreign_key "certification_integrities", "users", column: "claimed_by_id"
   add_foreign_key "certification_integrities", "users", column: "reviewer_id"
   add_foreign_key "certification_mac_analyses", "certification_ysws_reviews", column: "ysws_review_id"
+  add_foreign_key "certification_review_notes", "projects"
+  add_foreign_key "certification_review_notes", "users", column: "author_id"
   add_foreign_key "certification_review_skips", "users"
   add_foreign_key "certification_ship_reviews", "post_ship_events", on_delete: :nullify
   add_foreign_key "certification_ship_reviews", "projects"

--- a/test/controllers/admin/certification/review_notes_controller_test.rb
+++ b/test/controllers/admin/certification/review_notes_controller_test.rb
@@ -1,0 +1,98 @@
+require "test_helper"
+
+class Admin::Certification::ReviewNotesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    Flipper.enable(:hardware_flow)
+
+    @reviewer = create_user(slack_id: "U_RN_REV", display_name: "rn-reviewer")
+    @reviewer.grant_role!(:admin)
+
+    @owner = create_user(slack_id: "U_RN_OWNER", display_name: "rn-owner", verified: true)
+    @project = hardware_project("Note bot", "design")
+
+    sign_in @reviewer
+  end
+
+  teardown { Flipper.disable(:hardware_flow) }
+
+  test "a reviewer can add an internal note" do
+    assert_difference -> { @project.review_notes.count }, 1 do
+      post admin_certification_project_review_notes_path(@project),
+           params: { certification_review_note: { body: "Watch the power budget on this one." } }
+    end
+
+    note = @project.review_notes.order(:created_at).last
+    assert_equal "Watch the power budget on this one.", note.body
+    assert_equal @reviewer, note.author
+    assert_redirected_to admin_certification_hardware_review_path(@project)
+  end
+
+  test "a blank note is not created" do
+    assert_no_difference -> { @project.review_notes.count } do
+      post admin_certification_project_review_notes_path(@project),
+           params: { certification_review_note: { body: "" } }
+    end
+
+    assert_redirected_to admin_certification_hardware_review_path(@project)
+  end
+
+  test "a note is recorded in paper_trail with the reviewer as whodunnit" do
+    post admin_certification_project_review_notes_path(@project),
+         params: { certification_review_note: { body: "Auditable note." } }
+
+    version = @project.review_notes.order(:created_at).last.versions.last
+    assert_equal @reviewer.id.to_s, version.whodunnit
+  end
+
+  test "a reviewer cannot add a note to their own project" do
+    @project.memberships.create!(user: @reviewer, role: :contributor)
+
+    assert_no_difference -> { @project.review_notes.count } do
+      post admin_certification_project_review_notes_path(@project),
+           params: { certification_review_note: { body: "Can't note my own project." } }
+    end
+
+    assert_response :forbidden
+  end
+
+  test "a non-reviewer cannot add a note" do
+    sign_in @owner
+
+    assert_no_difference -> { @project.review_notes.count } do
+      post admin_certification_project_review_notes_path(@project),
+           params: { certification_review_note: { body: "Not allowed." } }
+    end
+
+    assert_response :forbidden
+  end
+
+  test "existing notes render on the review page, newest first" do
+    @project.review_notes.create!(author: @reviewer, body: "First note", created_at: 2.days.ago)
+    @project.review_notes.create!(author: @reviewer, body: "Second note", created_at: 1.hour.ago)
+
+    get admin_certification_hardware_review_path(@project)
+
+    assert_response :success
+    assert_select ".reviewer-notes__item:first-child .reviewer-notes__body", text: /Second note/
+    assert_select ".reviewer-notes__item:last-child .reviewer-notes__body", text: /First note/
+    # The add-note form is present for a reviewer viewing the page.
+    assert_select ".reviewer-notes__form textarea[name=?]", "certification_review_note[body]"
+  end
+
+  test "the panel shows an empty state when there are no notes" do
+    get admin_certification_hardware_review_path(@project)
+
+    assert_response :success
+    assert_select ".reviewer-notes__empty"
+    assert_select ".reviewer-notes__item", count: 0
+  end
+
+  private
+
+  def hardware_project(title, stage)
+    project = Project.create!(title: title)
+    project.memberships.create!(user: @owner, role: :owner)
+    project.update!(hardware_stage: stage)
+    project
+  end
+end

--- a/test/fixtures/certification/review_notes.yml
+++ b/test/fixtures/certification/review_notes.yml
@@ -1,0 +1,27 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# == Schema Information
+#
+# Table name: certification_review_notes
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  author_id  :bigint           not null
+#  project_id :bigint           not null
+#
+# Indexes
+#
+#  index_certification_review_notes_on_author_id   (author_id)
+#  index_certification_review_notes_on_project_id  (project_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (author_id => users.id)
+#  fk_rails_...  (project_id => projects.id)
+#
+reviewer_note_one:
+  project: one
+  author: one
+  body: "Checked the BOM against the repo; parts list looks complete."

--- a/test/models/certification/review_note_test.rb
+++ b/test/models/certification/review_note_test.rb
@@ -1,0 +1,72 @@
+require "test_helper"
+
+# == Schema Information
+#
+# Table name: certification_review_notes
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  author_id  :bigint           not null
+#  project_id :bigint           not null
+#
+# Indexes
+#
+#  index_certification_review_notes_on_author_id   (author_id)
+#  index_certification_review_notes_on_project_id  (project_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (author_id => users.id)
+#  fk_rails_...  (project_id => projects.id)
+#
+class Certification::ReviewNoteTest < ActiveSupport::TestCase
+  def setup
+    @project = Project.create!(title: "HW #{SecureRandom.hex(4)}", hardware_stage: "design")
+    @author = User.create!(
+      email: "rev-#{SecureRandom.hex(6)}@example.com",
+      display_name: "Rev#{SecureRandom.hex(3)}",
+      slack_id: "U#{SecureRandom.hex(8)}"
+    )
+  end
+
+  test "requires a body" do
+    note = Certification::ReviewNote.new(project: @project, author: @author)
+    assert_not note.valid?
+    assert note.errors[:body].any?
+  end
+
+  test "belongs to a project and a user author" do
+    note = Certification::ReviewNote.create!(project: @project, author: @author, body: "Looks good.")
+    assert_equal @project, note.project
+    assert_equal @author, note.author
+    assert_instance_of User, note.author
+  end
+
+  test "a project has many review notes and destroys them with the project" do
+    Certification::ReviewNote.create!(project: @project, author: @author, body: "One")
+    Certification::ReviewNote.create!(project: @project, author: @author, body: "Two")
+    assert_equal 2, @project.review_notes.count
+
+    assert_difference -> { Certification::ReviewNote.count }, -2 do
+      @project.destroy
+    end
+  end
+
+  test "newest_first orders by created_at descending" do
+    older = Certification::ReviewNote.create!(project: @project, author: @author, body: "Older", created_at: 2.days.ago)
+    newer = Certification::ReviewNote.create!(project: @project, author: @author, body: "Newer", created_at: 1.hour.ago)
+    assert_equal [ newer, older ], @project.review_notes.newest_first.to_a
+  end
+
+  test "is versioned by paper_trail" do
+    note = Certification::ReviewNote.create!(project: @project, author: @author, body: "Audited")
+    assert_respond_to note, :versions
+    assert_equal 1, note.versions.count
+  end
+
+  test "the fixture loads" do
+    assert certification_review_notes(:reviewer_note_one).body.present?
+  end
+end


### PR DESCRIPTION
## what's this do?

there are no shared notes for hardware reviews right now; this adds that. setup as a "ledger" you can add notes to.

## show it works

<img width="1292" height="649" alt="image" src="https://github.com/user-attachments/assets/c4249a15-9c2b-4f0a-817a-97834ebd9443" />

## ai?

opus 4.8 is so much better than opus 5 it's offensive