### PR TITLE
fix(project-settings): show actual project type when locked

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -156,8 +156,8 @@
                     change and a live control here would only fail validation. %>
                 <% if @project.hardware_stage_locked? %>
                   <div class="project-show__stage-toggle project-show__stage-toggle--locked" aria-label="Project type (locked)">
-                    <span class="project-show__stage-choice-label project-show__stage-choice-label--locked">Software</span>
-                    <span class="project-show__stage-choice-label project-show__stage-choice-label--locked project-show__stage-choice-label--selected">Hardware</span>
+                    <span class="project-show__stage-choice-label project-show__stage-choice-label--locked <%= "project-show__stage-choice-label--selected" unless @project.hardware? %>">Software</span>
+                    <span class="project-show__stage-choice-label project-show__stage-choice-label--locked <%= "project-show__stage-choice-label--selected" if @project.hardware? %>">Hardware</span>
                   </div>
                 <% else %>
                   <div class="project-show__stage-toggle" role="radiogroup" aria-label="Project type">

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -229,6 +229,40 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[type='hidden'][name='project[hardware_stage]']"
   end
 
+  test "locked software project shows Software as the selected type" do
+    ship = Post::ShipEvent.new(body: "shipped", uploading_attachments: true)
+    ActiveRecord::Base.transaction do
+      ship.save!(validate: false)
+      Post.create!(project: @project, user: @owner, postable: ship)
+    end
+
+    sign_in @owner
+
+    get project_path(@project, editing: true)
+
+    assert_response :success
+    assert_select ".project-show__stage-choice-label--selected", text: "Software", count: 1
+    assert_select ".project-show__stage-choice-label--selected", text: "Hardware", count: 0
+  end
+
+  test "locked hardware project shows Hardware as the selected type" do
+    @project.update!(hardware_stage: "build")
+
+    ship = Post::ShipEvent.new(body: "shipped", uploading_attachments: true)
+    ActiveRecord::Base.transaction do
+      ship.save!(validate: false)
+      Post.create!(project: @project, user: @owner, postable: ship)
+    end
+
+    sign_in @owner
+
+    get project_path(@project, editing: true)
+
+    assert_response :success
+    assert_select ".project-show__stage-choice-label--selected", text: "Hardware", count: 1
+    assert_select ".project-show__stage-choice-label--selected", text: "Software", count: 0
+  end
+
   test "new project dialog offers the hardware project option and stage chooser" do
     sign_in @owner
 


### PR DESCRIPTION
## what's this do?

fixes the project type showing as Hardware for software projects once the type gets locked after funding/shipping.

the locked version was always marking Hardware as selected instead of checking the actual project type.

## show it works

Running 2 tests in a single process

 Running:

..

Finished in 22.224551s
2 runs, 6 assertions, 0 failures, 0 errors, 0 skips

## ai?

nah
