### PR TITLE
feat(hardware): fraud flag button

### DIFF
--- a/app/assets/stylesheets/pages/certification/_hardware_review.scss
+++ b/app/assets/stylesheets/pages/certification/_hardware_review.scss
@@ -328,6 +328,120 @@
     font-size: var(--font-size-s);
     resize: vertical;
   }
+
+  // Fraud flag lives inside the review's secondary-actions card as a button;
+  // reporting notifies the fraud team but doesn't hide the project.
+  &__fraud-flagged {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-s);
+    margin: 0;
+    color: var(--color-space-text-muted);
+    font-size: var(--font-size-s);
+  }
+
+  &__fraud-flagged-badge {
+    padding: 0.15rem 0.6rem;
+    font-weight: 700;
+    color: var(--color-brand-salmon);
+    background: var(--color-brand-salmon-soft);
+    border: 1px solid var(--color-brand-salmon);
+    border-radius: 999px;
+  }
+
+  &__fraud-modal {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    width: min(460px, calc(100vw - 48px));
+    max-height: fit-content;
+    padding: 0;
+    border: none;
+    background: transparent;
+    overflow: visible;
+
+    &::backdrop {
+      background: rgba(8, 6, 30, 0.75);
+      backdrop-filter: blur(4px);
+    }
+  }
+
+  &__fraud-modal-card {
+    position: relative;
+    display: grid;
+    gap: var(--space-m);
+    padding: var(--space-xl);
+    background: var(--color-set-2-bg);
+    border: 1px solid var(--color-brand-salmon);
+    border-radius: var(--border-radius);
+    box-shadow: 0 24px 60px var(--color-shadow-deep);
+  }
+
+  &__fraud-modal-close {
+    position: absolute;
+    top: var(--space-s);
+    right: var(--space-s);
+    width: 2rem;
+    height: 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    appearance: none;
+    background: none;
+    border: none;
+    border-radius: 50%;
+    font-size: 1.5rem;
+    line-height: 1;
+    color: var(--color-space-text-muted);
+    cursor: pointer;
+
+    &:hover {
+      color: var(--color-space-text);
+    }
+  }
+
+  &__fraud-modal-title {
+    margin: 0;
+    padding-right: var(--space-l);
+    font-size: var(--font-size-l);
+    color: var(--color-space-text);
+  }
+
+  &__fraud-modal-note {
+    margin: 0;
+    font-size: var(--font-size-s);
+    line-height: 1.4;
+    color: var(--color-space-text-muted);
+  }
+
+  &__fraud-form {
+    display: grid;
+    gap: var(--space-s);
+  }
+
+  &__fraud-form-input {
+    width: 100%;
+    padding: var(--space-s);
+    font-family: inherit;
+    font-size: var(--font-size-s);
+    color: var(--color-space-text);
+    background: var(--color-set-1-bg);
+    border: 1px solid var(--color-space-border);
+    border-radius: 8px;
+    resize: vertical;
+
+    &:focus-visible {
+      outline: 2px solid var(--color-brand-salmon);
+      outline-offset: 1px;
+    }
+  }
+
+  &__fraud-form-actions {
+    display: flex;
+    gap: var(--space-s);
+    justify-content: flex-end;
+  }
 }
 
 // Reviewer's own hardware numbers, shown in place on the queue rather than

--- a/app/controllers/admin/certification/application_controller.rb
+++ b/app/controllers/admin/certification/application_controller.rb
@@ -3,12 +3,16 @@ class Admin::Certification::ApplicationController < Admin::ApplicationController
   # global dash and the funding/ship verdict controllers use the global routes;
   # the per-mission dash overrides them (see Admin::Missions::HardwareReviews).
   helper_method :hardware_review_path, :hardware_queue_path, :hardware_next_path,
-                :hardware_queue_title, :hardware_back_link
+                :hardware_queue_title, :hardware_back_link, :hardware_flag_for_fraud_path
 
   private
 
   def hardware_review_path(project)
     admin_certification_hardware_review_path(project)
+  end
+
+  def hardware_flag_for_fraud_path(project)
+    flag_for_fraud_admin_certification_hardware_review_path(project)
   end
 
   def hardware_queue_path(stage)

--- a/app/controllers/admin/certification/hardware_reviews_controller.rb
+++ b/app/controllers/admin/certification/hardware_reviews_controller.rb
@@ -8,8 +8,8 @@ class Admin::Certification::HardwareReviewsController < Admin::Certification::Ap
   include HardwareReviewQueue
 
   before_action -> { head :not_found unless Flipper.enabled?(:hardware_flow, current_user) }
-  before_action :set_project, only: [ :show ]
-  before_action -> { head :not_found unless @project.hardware? }, only: [ :show ]
+  before_action :set_project, only: [ :show, :flag_for_fraud ]
+  before_action -> { head :not_found unless @project.hardware? }, only: [ :show, :flag_for_fraud ]
 
   # GET /admin/certification/hardware - kept so older links land somewhere sensible.
   def index

--- a/app/controllers/admin/missions/hardware_reviews_controller.rb
+++ b/app/controllers/admin/missions/hardware_reviews_controller.rb
@@ -10,7 +10,7 @@ module Admin
 
       skip_before_action :authorize_mission_management
       before_action -> { head :not_found unless Flipper.enabled?(:hardware_flow, current_user) }
-      before_action :set_project, only: [ :show ]
+      before_action :set_project, only: [ :show, :flag_for_fraud ]
 
       def index
         authorize_hardware_queue
@@ -35,6 +35,10 @@ module Admin
 
       def hardware_review_path(project)
         admin_mission_hardware_review_path(@mission.slug, project)
+      end
+
+      def hardware_flag_for_fraud_path(project)
+        flag_for_fraud_admin_mission_hardware_review_path(@mission.slug, project)
       end
 
       def hardware_queue_path(stage)

--- a/app/controllers/concerns/hardware_review_queue.rb
+++ b/app/controllers/concerns/hardware_review_queue.rb
@@ -20,7 +20,7 @@ module HardwareReviewQueue
     before_action :set_body_class
     before_action :release_other_claims, only: [ :next ]
     helper_method :hardware_review_path, :hardware_queue_path, :hardware_next_path,
-                  :hardware_queue_title, :hardware_back_link
+                  :hardware_queue_title, :hardware_back_link, :hardware_flag_for_fraud_path
   end
 
   def design
@@ -59,6 +59,37 @@ module HardwareReviewQueue
     authorize_hardware_review(@project)
     load_review_context
     render "admin/certification/hardware_reviews/show"
+  end
+
+  # Flags the project for the fraud team. Reuses Project::Report's existing fraud
+  # machinery — the model's after_commit fires the Slack notify and PaperTrail
+  # records the flag. No verdict is recorded and the project stays visible;
+  # this is a heads-up, not a review action. Idempotent on the unique
+  # (reporter_id, project_id) index.
+  def flag_for_fraud
+    authorize_hardware_review(@project)
+
+    report = ::Project::Report.new(
+      project: @project,
+      reporter: current_user,
+      reason: "fraud",
+      details: params[:details].to_s.strip,
+      status: :pending
+    )
+
+    if report.save
+      redirect_to hardware_review_path(@project),
+                  notice: "Flagged for fraud review. The fraud team has been notified."
+    elsif report.errors.of_kind?(:reporter_id, :taken)
+      redirect_to hardware_review_path(@project),
+                  notice: "You've already flagged this project for fraud."
+    else
+      redirect_to hardware_review_path(@project),
+                  alert: report.errors.full_messages.to_sentence
+    end
+  rescue ActiveRecord::RecordNotUnique
+    redirect_to hardware_review_path(@project),
+                notice: "You've already flagged this project for fraud."
   end
 
   private

--- a/app/models/certification/funding_request.rb
+++ b/app/models/certification/funding_request.rb
@@ -140,7 +140,11 @@ module Certification
     scope :in_hardware_mission_queue, -> { joins(:project).merge(::Project.hardware.with_hardware_mission) }
 
     def self.available_for(user)
-      super.merge(for_reviewer(user))
+      # Chained AFTER the merge on purpose: `merge` would replace this project_id
+      # filter with for_reviewer's own project_id condition and drop the fraud
+      # hold-back. A pending fraud report keeps the project out of the queue
+      # until the fraud team clears it.
+      super.merge(for_reviewer(user)).where.not(project_id: fraud_flagged_project_ids)
     end
 
     # Health target for the pending queue. Above this we read as "behind".

--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -186,7 +186,11 @@ module Certification
     scope :in_hardware_mission_queue, -> { joins(:project).merge(::Project.hardware.with_hardware_mission) }
 
     def self.available_for(user)
-      super.merge(for_reviewer(user))
+      # Chained AFTER the merge on purpose: `merge` would replace this project_id
+      # filter with for_reviewer's own project_id condition and drop the fraud
+      # hold-back. A pending fraud report keeps the project out of the queue
+      # until the fraud team clears it.
+      super.merge(for_reviewer(user)).where.not(project_id: fraud_flagged_project_ids)
     end
 
     # Claim-next for the software queue. The hardware queue has its own

--- a/app/models/concerns/certification/reviewable.rb
+++ b/app/models/concerns/certification/reviewable.rb
@@ -30,6 +30,14 @@ module Certification
         )
       end
 
+      # Projects with an unresolved (pending) fraud report. They're held back
+      # from the review queue and the "next" hand-out so a flagged build isn't
+      # served to a reviewer until the fraud team clears it — the project stays
+      # reachable directly, it's just not auto-offered.
+      def fraud_flagged_project_ids
+        ::Project::Report.pending.where(reason: "fraud").select(:project_id)
+      end
+
       def atomic_claim!(record_id, user)
         now = Time.current
         expires = now + CLAIM_TTL

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -508,6 +508,12 @@ class Project < ApplicationRecord
     @_latest_funding_request = certification_funding_requests.order(created_at: :desc).first
   end
 
+  # The open fraud flag on this project, if any. The hardware review page derives
+  # its "flagged for fraud" state from this rather than a dedicated column.
+  def pending_fraud_report
+    reports.pending.where(reason: "fraud").order(created_at: :desc).first
+  end
+
   # Name of the Hackatime project this project's time is filed under (and which
   # Project::EnsureHackatimeProjectsJob seeds for hardware builders to pick in
   # Lapse): the project title, so timelapse time lands under the same Hackatime

--- a/app/policies/admin/certification/hardware_review_policy.rb
+++ b/app/policies/admin/certification/hardware_review_policy.rb
@@ -25,6 +25,14 @@ class Admin::Certification::HardwareReviewPolicy < ApplicationPolicy
     user&.can_review? && not_own_project?
   end
 
+  # Same bar as Certification::ShipPolicy#report_fraud?: any reviewer may flag,
+  # including on a project they belong to (the fraud report skips the own-project
+  # guard on purpose). Flagging notifies the fraud team; it doesn't decide the
+  # review.
+  def flag_for_fraud?
+    user&.can_review?
+  end
+
   private
 
   def not_own_project?

--- a/app/views/admin/certification/hardware_reviews/_fraud_flag.html.erb
+++ b/app/views/admin/certification/hardware_reviews/_fraud_flag.html.erb
@@ -1,0 +1,48 @@
+<%# Fraud flag control — a button that sits inside the review's secondary-actions
+    card (not its own panel). Reuses Project::Report's existing fraud machinery
+    (Slack notify + PaperTrail on create); the flagged state is derived from a
+    pending fraud report, not a column.
+    Locals:
+      project    (required) the project being reviewed
+      fraud_flag (required) the open fraud Project::Report, or nil %>
+<% if fraud_flag %>
+  <p class="hardware-review__fraud-flagged">
+    <span class="hardware-review__fraud-flagged-badge">Flagged for fraud review</span>
+    reported by <%= fraud_flag.reporter.display_name %> · pending
+  </p>
+<% else %>
+  <button type="button" class="action-btn action-btn--small action-btn--destructive"
+          onclick="document.getElementById('hardware-fraud-flag').showModal()">
+    Flag for fraud
+  </button>
+
+  <dialog id="hardware-fraud-flag" class="hardware-review__fraud-modal"
+          data-controller="modal" aria-labelledby="hardware-fraud-flag-title">
+    <div class="hardware-review__fraud-modal-card">
+      <button type="button" class="hardware-review__fraud-modal-close"
+              data-action="click->modal#close" aria-label="Close">&times;</button>
+      <h3 class="hardware-review__fraud-modal-title" id="hardware-fraud-flag-title">
+        Flag for fraud
+      </h3>
+      <p class="hardware-review__fraud-modal-note">
+        This notifies the fraud team and is recorded in the audit log. It does
+        not hide the project or change its review.
+      </p>
+      <%= form_with url: hardware_flag_for_fraud_path(project), method: :post,
+            class: "hardware-review__fraud-form" do |form| %>
+        <%= form.text_area :details, rows: 4, required: true,
+              minlength: ::Project::Report::DETAILS_MIN_LENGTH,
+              class: "hardware-review__fraud-form-input",
+              "aria-label": "Fraud details (at least #{::Project::Report::DETAILS_MIN_LENGTH} characters)",
+              placeholder: "What looks suspicious? (at least #{::Project::Report::DETAILS_MIN_LENGTH} characters)" %>
+        <div class="hardware-review__fraud-form-actions">
+          <button type="button" class="action-btn action-btn--small action-btn--secondary"
+                  data-action="click->modal#close">Cancel</button>
+          <%= form.submit "Flag for fraud",
+                class: "action-btn action-btn--small action-btn--destructive",
+                data: { disable_with: "Flagging…" } %>
+        </div>
+      <% end %>
+    </div>
+  </dialog>
+<% end %>

--- a/app/views/admin/certification/hardware_reviews/show.html.erb
+++ b/app/views/admin/certification/hardware_reviews/show.html.erb
@@ -198,6 +198,23 @@
             </div>
           <% end %>
         </details>
+
+        <%# Read-only fraud-report status — always visible in the details column
+            (unlike the flag control in the sidebar, which needs the claim), so
+            any reviewer can see at a glance whether this project is flagged. %>
+        <div class="ship-review__panel hardware-review__fraud-status">
+          <h2 class="ship-review__panel-title">Fraud report</h2>
+          <% if (fraud_report = @project.pending_fraud_report) %>
+            <p class="hardware-review__fraud-flagged">
+              <span class="hardware-review__fraud-flagged-badge">Flagged for fraud review</span>
+              reported by <%= fraud_report.reporter.display_name %> ·
+              <%= l(fraud_report.created_at.to_date, format: :short) %> · pending
+            </p>
+            <p class="ship-review__description"><%= fraud_report.details %></p>
+          <% else %>
+            <p class="ship-review__description">No fraud report on this project.</p>
+          <% end %>
+        </div>
       </section>
 
       <aside class="ship-review__sidebar hardware-review__sidebar">
@@ -278,6 +295,10 @@
                     class="action-btn action-btn--small action-btn--destructive">
               Unclaim review
             </button>
+
+            <%# Flag for fraud — a button in this same secondary-actions card. %>
+            <%= render "admin/certification/hardware_reviews/fraud_flag",
+                  project: @project, fraud_flag: @project.pending_fraud_report %>
           </div>
         <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -842,6 +842,7 @@ Rails.application.routes.draw do
           get :build
           get :next
         end
+        post :flag_for_fraud, on: :member
       end
     end
     get "mission_reviews", to: "missions/submissions#overview", as: :mission_reviews
@@ -891,6 +892,7 @@ Rails.application.routes.draw do
           get :build
           get :next
         end
+        post :flag_for_fraud, on: :member
       end
 
       resources :devlog_reviews, only: [ :update ]

--- a/test/controllers/admin/certification/hardware_reviews_controller_test.rb
+++ b/test/controllers/admin/certification/hardware_reviews_controller_test.rb
@@ -258,6 +258,107 @@ class Admin::Certification::HardwareReviewsControllerTest < ActionDispatch::Inte
     assert_response :forbidden
   end
 
+  # --- Flag for fraud ---------------------------------------------------------
+
+  test "flagging a project for fraud creates a pending fraud report and notifies the fraud team" do
+    assert_difference -> { ::Project::Report.where(reason: "fraud").count }, 1 do
+      assert_enqueued_with(job: SendSlackDmJob) do
+        post flag_for_fraud_admin_certification_hardware_review_path(@design_project),
+             params: { details: "This looks like a resold kit rather than a real build." }
+      end
+    end
+
+    report = ::Project::Report.where(reason: "fraud").order(:created_at).last
+    assert_equal @design_project.id, report.project_id
+    assert_equal @reviewer.id, report.reporter_id
+    assert report.pending?
+    assert_redirected_to admin_certification_hardware_review_path(@design_project)
+  end
+
+  test "flagging without details is rejected — a reason is required" do
+    assert_no_difference -> { ::Project::Report.where(reason: "fraud").count } do
+      post flag_for_fraud_admin_certification_hardware_review_path(@design_project)
+    end
+
+    assert_redirected_to admin_certification_hardware_review_path(@design_project)
+  end
+
+  test "flagging with a too-short typed reason is rejected" do
+    assert_no_difference -> { ::Project::Report.where(reason: "fraud").count } do
+      post flag_for_fraud_admin_certification_hardware_review_path(@design_project),
+           params: { details: "too short" }
+    end
+
+    assert_redirected_to admin_certification_hardware_review_path(@design_project)
+  end
+
+  test "flagging the same project twice is idempotent on the unique index" do
+    post flag_for_fraud_admin_certification_hardware_review_path(@design_project),
+         params: { details: "First pass: the demo video looks staged and reused." }
+    assert_equal 1, ::Project::Report.where(reason: "fraud", project: @design_project).count
+
+    assert_no_difference -> { ::Project::Report.count } do
+      post flag_for_fraud_admin_certification_hardware_review_path(@design_project),
+           params: { details: "Second pass: same reviewer flags it again by mistake." }
+    end
+
+    assert_redirected_to admin_certification_hardware_review_path(@design_project)
+  end
+
+  test "a non-reviewer can't flag a project for fraud" do
+    sign_in @owner
+
+    assert_no_difference -> { ::Project::Report.count } do
+      post flag_for_fraud_admin_certification_hardware_review_path(@design_project),
+           params: { details: "A non-reviewer should never reach this action at all." }
+    end
+
+    assert_response :forbidden
+  end
+
+  test "the review page shows a flag-for-fraud button when the project is not flagged" do
+    ::Certification::FundingRequest.atomic_claim!(@funding.id, @reviewer)
+
+    get admin_certification_hardware_review_path(@design_project)
+
+    assert_response :success
+    assert_select "form[action=?]", flag_for_fraud_admin_certification_hardware_review_path(@design_project)
+    assert_select "button", text: /Flag for fraud/
+    assert_select ".hardware-review__fraud-flagged", count: 0
+  end
+
+  test "the review page shows the flagged state while a pending fraud report exists" do
+    @design_project.reports.create!(
+      reporter: @reviewer, reason: "fraud", status: :pending,
+      details: "Looks like a resold kit, not a real build."
+    )
+    ::Certification::FundingRequest.atomic_claim!(@funding.id, @reviewer)
+
+    get admin_certification_hardware_review_path(@design_project)
+
+    assert_response :success
+    assert_select ".hardware-review__fraud-flagged-badge", text: /Flagged for fraud review/
+    assert_select ".hardware-review__fraud-flagged", text: /#{@reviewer.display_name}/
+    # The button and its modal give way to the flagged state.
+    assert_select "form[action=?]", flag_for_fraud_admin_certification_hardware_review_path(@design_project), count: 0
+  end
+
+  test "the fraud-report status card is always shown in the details column" do
+    # No claim held: the status card lives in the details column, not the
+    # claim-gated sidebar, so it renders regardless of who holds the review.
+    get admin_certification_hardware_review_path(@design_project)
+    assert_response :success
+    assert_select ".hardware-review__fraud-status", text: /No fraud report on this project/
+
+    @design_project.reports.create!(
+      reporter: @reviewer, reason: "fraud", status: :pending,
+      details: "Looks like a resold kit, not a real build."
+    )
+    get admin_certification_hardware_review_path(@design_project)
+    assert_select ".hardware-review__fraud-status .hardware-review__fraud-flagged-badge",
+          text: /Flagged for fraud review/
+  end
+
   private
 
   # A second reviewer, to prove a released claim is actually offered onward.

--- a/test/models/certification/funding_request_test.rb
+++ b/test/models/certification/funding_request_test.rb
@@ -64,6 +64,24 @@ class Certification::FundingRequestTest < ActiveSupport::TestCase
     Post.create!(project: @project, user: @owner, postable: devlog)
   end
 
+  test "available_for holds back projects with an unresolved fraud report" do
+    fr = @project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 2, requested_amount_cents: 3_000, status: :pending
+    )
+    assert_includes ::Certification::FundingRequest.available_for(@reviewer), fr
+
+    report = @project.reports.create!(
+      reporter: @reviewer, reason: "fraud", status: :pending,
+      details: "Looks like a resold kit, not a real build."
+    )
+    assert_not_includes ::Certification::FundingRequest.available_for(@reviewer), fr,
+      "a project with a pending fraud report should be held back from the review queue"
+
+    report.update!(status: :dismissed)
+    assert_includes ::Certification::FundingRequest.available_for(@reviewer), fr,
+      "clearing the fraud report should return the project to the queue"
+  end
+
   test "rejects a requested amount above the tier maximum" do
     fr = @project.certification_funding_requests.new(user: @owner, complexity_tier: 1, requested_amount_cents: 5_000)
     assert_not fr.valid?


### PR DESCRIPTION
## what's this do?

adds a button that sends a project over as a fraud report. if a hardware project is flagged as fraud it's also hidden from the queue somewhat

## show it works

<img width="709" height="460" alt="image" src="https://github.com/user-attachments/assets/3cf479a2-d156-46a5-a9cc-a826781dda1d" />

<img width="865" height="648" alt="image" src="https://github.com/user-attachments/assets/02a165cc-10f4-42a3-a1d9-417ebfd74e8c" />

<img width="1288" height="358" alt="image" src="https://github.com/user-attachments/assets/0bc242c0-fe58-429d-a091-e20eb162b752" />
^ shows in the review page so it doesn't get reviewed accidentally

<img width="1928" height="829" alt="image" src="https://github.com/user-attachments/assets/2941373c-0d50-449f-8d03-e4fcb9f59040" />

## ai?

opus 4.8