### PR TITLE
feat(shop): let shop items pick which org money is pulled from

### DIFF
--- a/app/assets/stylesheets/pages/shop/_admin_shop_item_form.scss
+++ b/app/assets/stylesheets/pages/shop/_admin_shop_item_form.scss
@@ -44,4 +44,55 @@
   .modifier-entry__title {
     color: var(--color-space-text);
   }
+
+  // Two-button segmented control for choosing an HCB source org.
+  &__segmented {
+    display: inline-flex;
+    margin-top: var(--space-xs);
+    border: 2px solid var(--color-set-1-fg-secondary);
+    border-radius: 9999px;
+    overflow: hidden;
+  }
+
+  &__segmented-option {
+    margin: 0;
+    cursor: pointer;
+
+    & + & {
+      border-left: 2px solid var(--color-set-1-fg-secondary);
+    }
+  }
+
+  &__segmented-input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  &__segmented-label {
+    display: block;
+    padding: var(--space-xs) var(--space-m);
+    font-size: 0.875rem;
+    color: var(--color-set-1-fg-secondary);
+    transition:
+      background 0.1s,
+      color 0.1s;
+  }
+
+  &__segmented-option:hover &__segmented-label {
+    color: var(--color-space-text);
+  }
+
+  &__segmented-input:checked + &__segmented-label {
+    background: var(--color-brand-mint);
+    color: var(--color-set-1-bg);
+    font-weight: 600;
+  }
+
+  &__segmented-input:focus-visible + &__segmented-label {
+    outline: 2px solid var(--color-brand-mint);
+    outline-offset: 2px;
+  }
 }

--- a/app/controllers/admin/shop/items_controller.rb
+++ b/app/controllers/admin/shop/items_controller.rb
@@ -193,6 +193,7 @@ class Admin::Shop::ItemsController < Admin::ApplicationController
         :hcb_merchant_lock,
         :hcb_preauthorization_instructions,
         :hcb_one_time_use,
+        :hcb_org_slug,
         :agh_contents,
         :image,
         :buyable_by_self,

--- a/app/models/concerns/shop/hcb_grant_fulfillable.rb
+++ b/app/models/concerns/shop/hcb_grant_fulfillable.rb
@@ -1,9 +1,15 @@
 module Shop::HCBGrantFulfillable
   extend ActiveSupport::Concern
 
+  # The HCB organizations a grant item may draw its card grant from. Blank means
+  # the app-wide default (HCBService::DEFAULT_SLUG); "stardance-hardware" targets
+  # the hardware sub-org, matching Certification::FundingRequest#issue_hcb_grant!.
+  HCB_ORG_SLUGS = %w[stardance stardance-hardware].freeze
+
   included do
     has_many :shop_card_grants, through: :shop_orders
     after_save :enqueue_hcb_locks_update, if: :hcb_locks_changed?
+    validates :hcb_org_slug, inclusion: { in: HCB_ORG_SLUGS }, allow_blank: true
   end
 
   def fulfill!(shop_order)
@@ -73,6 +79,7 @@ module Shop::HCBGrantFulfillable
         category_lock: hcb_category_lock,
         purpose: name,
         one_time_use: hcb_one_time_use?,
+        organization: effective_hcb_org_slug,
         **extra_grant_options
       )
     rescue HCBError
@@ -122,6 +129,10 @@ module Shop::HCBGrantFulfillable
   def grant_label = "grant"
 
   def extra_grant_options = {}
+
+  # The org this item's card grant is drawn from, defaulting to the app-wide HCB
+  # org when the admin hasn't chosen one.
+  def effective_hcb_org_slug = hcb_org_slug.presence || HCBService::DEFAULT_SLUG
 
   def hcb_locks_changed?
     saved_change_to_hcb_merchant_lock? ||

--- a/app/models/shop_item.rb
+++ b/app/models/shop_item.rb
@@ -30,6 +30,7 @@
 #  hcb_keyword_lock                  :string
 #  hcb_merchant_lock                 :string
 #  hcb_one_time_use                  :boolean          default(FALSE)
+#  hcb_org_slug                      :string
 #  hcb_preauthorization_instructions :text
 #  internal_description              :string
 #  limited                           :boolean

--- a/app/models/shop_item/h_c_b_grant.rb
+++ b/app/models/shop_item/h_c_b_grant.rb
@@ -30,6 +30,7 @@
 #  hcb_keyword_lock                  :string
 #  hcb_merchant_lock                 :string
 #  hcb_one_time_use                  :boolean          default(FALSE)
+#  hcb_org_slug                      :string
 #  hcb_preauthorization_instructions :text
 #  internal_description              :string
 #  limited                           :boolean

--- a/app/models/shop_item/h_c_b_preauth_grant.rb
+++ b/app/models/shop_item/h_c_b_preauth_grant.rb
@@ -30,6 +30,7 @@
 #  hcb_keyword_lock                  :string
 #  hcb_merchant_lock                 :string
 #  hcb_one_time_use                  :boolean          default(FALSE)
+#  hcb_org_slug                      :string
 #  hcb_preauthorization_instructions :text
 #  internal_description              :string
 #  limited                           :boolean

--- a/app/views/admin/shop/items/_form.html.erb
+++ b/app/views/admin/shop/items/_form.html.erb
@@ -319,6 +319,24 @@
 
         <% if shop_item.type.in?(%w[ShopItem::HCBGrant ShopItem::HCBPreauthGrant]) %>
           <div class="card">
+            <h3>HCB Source Organization</h3>
+            <div class="shop-item-form__field">
+              <span class="shop-item-form__hint">Which HCB organization this grant's card is drawn from.</span>
+              <% selected_org = shop_item.hcb_org_slug.presence || Shop::HCBGrantFulfillable::HCB_ORG_SLUGS.first %>
+              <div class="shop-item-form__segmented" role="radiogroup" aria-label="HCB source organization">
+                <% Shop::HCBGrantFulfillable::HCB_ORG_SLUGS.each do |org| %>
+                  <label class="shop-item-form__segmented-option">
+                    <%= f.radio_button :hcb_org_slug, org, checked: selected_org == org, class: "shop-item-form__segmented-input" %>
+                    <span class="shop-item-form__segmented-label">
+                      <%= org %><% if org == Shop::HCBGrantFulfillable::HCB_ORG_SLUGS.first %> (default)<% end %>
+                    </span>
+                  </label>
+                <% end %>
+              </div>
+            </div>
+          </div>
+
+          <div class="card">
             <h3>HCB Locks</h3>
             <div class="shop-item-form__field">
               <%= f.label :hcb_merchant_lock, "HCB Merchant Lock", class: "shop-item-form__label" %>

--- a/db/migrate/20260824181134_add_hcb_org_slug_to_shop_items.rb
+++ b/db/migrate/20260824181134_add_hcb_org_slug_to_shop_items.rb
@@ -1,0 +1,5 @@
+class AddHCBOrgSlugToShopItems < ActiveRecord::Migration[8.1]
+  def change
+    add_column :shop_items, :hcb_org_slug, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1192,6 +1192,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_25_002911) do
     t.string "hcb_keyword_lock"
     t.string "hcb_merchant_lock"
     t.boolean "hcb_one_time_use", default: false
+    t.string "hcb_org_slug"
     t.text "hcb_preauthorization_instructions"
     t.string "internal_description"
     t.boolean "limited"

--- a/test/controllers/admin/shop/items_controller_test.rb
+++ b/test/controllers/admin/shop/items_controller_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+# The HCB source-org picker lets an admin route a grant item's card grant to a
+# specific HCB org. These cover the admin form + params plumbing behind it.
+class Admin::Shop::ItemsControllerTest < ActionDispatch::IntegrationTest
+  include UserFactory
+
+  PIXEL = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=".freeze
+
+  setup do
+    @admin = create_user(slack_id: "U_ITEMS_ADMIN", display_name: "items_admin")
+    @admin.grant_role!(:admin)
+
+    @grant_item = ShopItem::HCBGrant.new(
+      name: "Grant Item", description: "A grant", ticket_cost: 0, usd_cost: 25, enabled: true
+    )
+    @grant_item.image.attach(io: StringIO.new(Base64.decode64(PIXEL)), filename: "px.png", content_type: "image/png")
+    @grant_item.save!
+  end
+
+  test "updating a grant item persists the chosen hcb org" do
+    sign_in @admin
+    patch admin_shop_item_path(@grant_item), params: { shop_item: { hcb_org_slug: "stardance-hardware" } }
+
+    assert_redirected_to admin_shop_item_path(@grant_item)
+    assert_equal "stardance-hardware", @grant_item.reload.hcb_org_slug
+  end
+
+  test "the org picker is shown for grant items" do
+    sign_in @admin
+    get edit_admin_shop_item_path(@grant_item)
+
+    assert_response :success
+    assert_select "input[type=radio][name='shop_item[hcb_org_slug]'][value=stardance]"
+    assert_select "input[type=radio][name='shop_item[hcb_org_slug]'][value='stardance-hardware']"
+  end
+
+  test "the org picker is hidden for non-grant items" do
+    non_grant = ShopItem::ThirdPartyPhysical.new(
+      name: "Patch", description: "physical", ticket_cost: 0, usd_cost: 5, enabled: true
+    )
+    non_grant.image.attach(io: StringIO.new(Base64.decode64(PIXEL)), filename: "px.png", content_type: "image/png")
+    non_grant.save!
+
+    sign_in @admin
+    get edit_admin_shop_item_path(non_grant)
+
+    assert_response :success
+    assert_select "input[name='shop_item[hcb_org_slug]']", count: 0
+  end
+end

--- a/test/fixtures/shop_items.yml
+++ b/test/fixtures/shop_items.yml
@@ -36,6 +36,7 @@
 #  hcb_keyword_lock                  :string
 #  hcb_merchant_lock                 :string
 #  hcb_one_time_use                  :boolean          default(FALSE)
+#  hcb_org_slug                      :string
 #  hcb_preauthorization_instructions :text
 #  internal_description              :string
 #  limited                           :boolean

--- a/test/models/shop/hcb_grant_fulfillable_test.rb
+++ b/test/models/shop/hcb_grant_fulfillable_test.rb
@@ -127,4 +127,51 @@ class Shop::HCBGrantFulfillableTest < ActiveSupport::TestCase
     assert @order.reload.fulfilled?
     assert_equal 2600, ShopCardGrant.find_by(hcb_grant_hashid: "grt_live").expected_amount_cents
   end
+
+  test "the chosen hcb org is passed through to create_card_grant" do
+    @item.update!(hcb_org_slug: "stardance-hardware")
+
+    captured = nil
+    grant = ->(**kwargs) { captured = kwargs; GRANT_RESPONSE }
+    HCBService.stub(:create_card_grant, grant) do
+      HCBService.stub(:rename_transaction, true) { @item.fulfill!(@order) }
+    end
+
+    assert_equal "stardance-hardware", captured[:organization]
+  end
+
+  test "a blank hcb org falls back to the default slug" do
+    assert_nil @item.hcb_org_slug
+
+    captured = nil
+    grant = ->(**kwargs) { captured = kwargs; GRANT_RESPONSE }
+    HCBService.stub(:create_card_grant, grant) do
+      HCBService.stub(:rename_transaction, true) { @item.fulfill!(@order) }
+    end
+
+    assert_equal HCBService::DEFAULT_SLUG, captured[:organization]
+  end
+
+  test "hcb_org_slug is limited to the allowed orgs, with blank allowed" do
+    @item.hcb_org_slug = "some-other-org"
+    assert_not @item.valid?
+    assert_includes @item.errors[:hcb_org_slug], "is not included in the list"
+
+    %w[stardance stardance-hardware].each do |org|
+      @item.hcb_org_slug = org
+      assert @item.valid?, "#{org} should be an allowed HCB org"
+    end
+
+    @item.hcb_org_slug = ""
+    assert @item.valid?, "blank must be allowed and treated as the default"
+  end
+
+  test "a non-grant item neither validates nor exposes hcb_org_slug" do
+    item = ShopItem::ThirdPartyPhysical.new(hcb_org_slug: "nonsense")
+    item.valid?
+
+    assert_empty item.errors[:hcb_org_slug], "non-grant items must not validate hcb_org_slug"
+    assert_not item.respond_to?(:effective_hcb_org_slug, true),
+               "non-grant items must not mix in grant fulfillment behavior"
+  end
 end

--- a/test/models/shop_item_test.rb
+++ b/test/models/shop_item_test.rb
@@ -30,6 +30,7 @@
 #  hcb_keyword_lock                  :string
 #  hcb_merchant_lock                 :string
 #  hcb_one_time_use                  :boolean          default(FALSE)
+#  hcb_org_slug                      :string
 #  hcb_preauthorization_instructions :text
 #  internal_description              :string
 #  limited                           :boolean


### PR DESCRIPTION
## what's this do?

Hackpad grants are currently pulling from the main stardance hcb organization, because that's what the shop defaults to and has no way to change it. This lets you pick if a grant should pull from `stardance` or `stardance-hardware`.

## show it works

<img width="1302" height="268" alt="image" src="https://github.com/user-attachments/assets/d3e06e69-3b12-464a-8748-67e766e22cb7" />
^ added to the shop gui

tests added, all pass.

## ai?

opus 4.8