### PR TITLE
feat(hardware): undo review button

### DIFF
--- a/app/assets/stylesheets/components/_status_pill.scss
+++ b/app/assets/stylesheets/components/_status_pill.scss
@@ -61,6 +61,14 @@
     color: var(--color-space-text-muted, rgba(255, 255, 255, 0.6));
   }
 
+  // A reversed (undone) verdict — shown in the admin hardware review history so a
+  // rewound decision reads as reversed rather than silently disappearing. Lilac,
+  // to stay distinct from the violet "returned" pill.
+  &--reversed {
+    background: var(--color-brand-lilac-soft, rgba(235, 183, 255, 0.18));
+    color: var(--color-brand-lilac);
+  }
+
   &--dismissed {
     background: rgba(255, 255, 255, 0.08);
     color: var(--color-space-text-muted, rgba(255, 255, 255, 0.6));

--- a/app/assets/stylesheets/pages/certification/_hardware_review.scss
+++ b/app/assets/stylesheets/pages/certification/_hardware_review.scss
@@ -577,3 +577,143 @@
     color: var(--color-brand-mint);
   }
 }
+
+// Undo control for the newest decided review, and its confirm dialog. The
+// reversal is destructive (real grant money), so the trigger and confirm are
+// salmon per docs/branding.md §4, and the ledger colour-codes each outcome.
+.review-undo {
+  margin-top: var(--space-s);
+
+  &__dialog {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    width: min(560px, calc(100vw - 48px));
+    max-height: fit-content;
+    padding: 0;
+    border: none;
+    background: transparent;
+    overflow: visible;
+
+    &::backdrop {
+      background: rgba(8, 6, 30, 0.75);
+      backdrop-filter: blur(4px);
+    }
+  }
+
+  &__card {
+    position: relative;
+    display: grid;
+    gap: var(--space-m);
+    padding: var(--space-xl);
+    background: var(--color-set-2-bg);
+    border: 1px solid var(--color-space-border);
+    border-radius: var(--border-radius);
+    box-shadow: 0 24px 60px var(--color-shadow-deep);
+  }
+
+  &__close {
+    position: absolute;
+    top: var(--space-s);
+    right: var(--space-s);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-xxs);
+    appearance: none;
+    background: transparent;
+    border: none;
+    color: var(--color-space-text-muted);
+    cursor: pointer;
+
+    svg {
+      width: 1.15rem;
+      height: 1.15rem;
+    }
+
+    &:hover {
+      color: var(--color-space-text);
+    }
+  }
+
+  &__title {
+    margin: 0;
+    padding-right: var(--space-l);
+    font-size: var(--font-size-xl);
+    font-weight: 700;
+    color: var(--color-space-text);
+  }
+
+  &__lede {
+    margin: 0;
+    font-size: var(--font-size-m);
+    color: var(--color-space-text-muted);
+  }
+
+  &__group {
+    display: grid;
+    gap: var(--space-xs);
+
+    &--block {
+      padding: var(--space-s) var(--space-m);
+      border: 1px solid var(--color-brand-salmon);
+      border-radius: var(--profile-radius);
+      background: var(--color-brand-salmon-soft);
+    }
+  }
+
+  &__group-label {
+    margin: 0;
+    font-size: var(--font-size-s);
+    font-weight: 700;
+    color: var(--color-space-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  &__list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: var(--space-xs);
+  }
+
+  // Plain icon + text rows — no cards or left-stripe accents (that pattern reads
+  // as AI-slop and doesn't match the rest of the program). Colour lives in the
+  // small leading icon only.
+  &__row {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-xs);
+    font-size: var(--font-size-m);
+    color: var(--color-space-text);
+  }
+
+  &__icon {
+    flex: none;
+    width: 1.15rem;
+    height: 1.15rem;
+    margin-top: 0.15rem;
+    color: var(--color-space-text-muted);
+  }
+
+  &__row--reverse &__icon {
+    color: var(--color-brand-mint);
+  }
+
+  &__row--block &__icon {
+    color: var(--color-brand-salmon);
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-s);
+    margin-top: var(--space-s);
+  }
+
+  &__confirm-form {
+    display: inline;
+  }
+}

--- a/app/controllers/admin/certification/funding_requests_controller.rb
+++ b/app/controllers/admin/certification/funding_requests_controller.rb
@@ -1,4 +1,6 @@
 class Admin::Certification::FundingRequestsController < Admin::Certification::ApplicationController
+  include HardwareReviewUndoable
+
   before_action -> { head :not_found unless Flipper.enabled?(:hardware_flow, current_user) }
   before_action :set_funding_request
   before_action :set_body_class
@@ -55,6 +57,9 @@ class Admin::Certification::FundingRequestsController < Admin::Certification::Ap
   def set_funding_request
     @funding_request = ::Certification::FundingRequest.find(params[:id])
   end
+
+  # Names the record HardwareReviewUndoable#undo reverses.
+  def review_for_undo = @funding_request
 
   # Both fetches below fan out to live HTTP (per Hackatime key / Lookout session)
   # on every render, including the re-render after a failed verdict submit. The

--- a/app/controllers/admin/certification/ships_controller.rb
+++ b/app/controllers/admin/certification/ships_controller.rb
@@ -1,7 +1,9 @@
 class Admin::Certification::ShipsController < Admin::Certification::ApplicationController
+  include HardwareReviewUndoable
+
   before_action :release_other_claims, only: [ :next ]
   before_action :set_ship, only: [ :show, :update, :set_project_type, :set_bonus_stardust, :report_fraud,
-                                   :flag_queue_mismatch ]
+                                   :flag_queue_mismatch, :undo ]
   before_action :set_submitter_context, only: [ :show, :update ]
   before_action :set_body_class, only: [ :index, :show, :update, :logs ]
 
@@ -196,6 +198,9 @@ class Admin::Certification::ShipsController < Admin::Certification::ApplicationC
   def set_ship
     @ship = ::Certification::Ship.find(params[:id])
   end
+
+  # Names the record HardwareReviewUndoable#undo reverses.
+  def review_for_undo = @ship
 
   def set_milestone_context
     @reviews_today = ::Certification::Ship.reviewed_today(current_user)

--- a/app/controllers/concerns/hardware_review_queue.rb
+++ b/app/controllers/concerns/hardware_review_queue.rb
@@ -21,7 +21,7 @@ module HardwareReviewQueue
     before_action :release_other_claims, only: [ :next ]
     helper_method :hardware_review_path, :hardware_queue_path, :hardware_next_path,
                   :hardware_skip_path, :hardware_queue_title, :hardware_back_link,
-                  :hardware_flag_for_fraud_path
+                  :hardware_flag_for_fraud_path, :undo_review_path
   end
 
   def design
@@ -215,17 +215,52 @@ module HardwareReviewQueue
       when ::Certification::Ship then :ship
       end
     @past_reviews = past_reviews
+    load_undo_context
     @lapse_timelapses = lapse_timelapses_for_review
     @lookout_recordings = lookout_recordings_for_review
   end
 
+  # Only the newest decided review is reversible, so the undo affordance and its
+  # preflight ledger are computed for @past_reviews.first alone. The preflight
+  # can make an HCB round trip (to check a grant), so it's skipped entirely for
+  # anyone not allowed to undo.
+  def load_undo_context
+    latest_decided = @past_reviews.first
+    return unless latest_decided&.decided?
+    return unless can_undo_review?(latest_decided)
+
+    @undo_review = latest_decided
+    @undo_preflight = ::Certification::ReviewUndoer.new(latest_decided).preflight
+  end
+
+  def can_undo_review?(review)
+    undo_policy_for(review).undo?
+  end
+
+  def undo_policy_for(review)
+    klass = review.is_a?(::Certification::FundingRequest) ?
+      Admin::Certification::FundingRequestPolicy : Admin::Certification::ShipPolicy
+    klass.new(current_user, review)
+  end
+
+  def undo_review_path(review)
+    if review.is_a?(::Certification::FundingRequest)
+      undo_admin_certification_funding_request_path(review)
+    else
+      undo_admin_certification_ship_path(review)
+    end
+  end
+
   # Every decided funding request and ship for this project, newest first. The
-  # active (pending) review is left out - it's the thing being decided.
+  # active (pending) review is left out - it's the thing being decided - except a
+  # reversed one: a funding undo sends the record back to pending, so it would be
+  # the active review, yet we still want it in the history with a "Reversed" badge
+  # rather than silently vanishing.
   def past_reviews
     reviews = @project.certification_funding_requests.includes(:reviewer).to_a +
               @project.ship_reviews.includes(:reviewer).to_a
     reviews
-      .reject { |review| review.pending? || review == @active_review }
+      .reject { |review| (review.pending? || review == @active_review) && review.reversed_at.blank? }
       .sort_by(&:created_at)
       .reverse
   end

--- a/app/controllers/concerns/hardware_review_undoable.rb
+++ b/app/controllers/concerns/hardware_review_undoable.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# The `undo` action shared by the funding-request and ship-certification review
+# controllers. Both reverse a decided review through Certification::ReviewUndoer;
+# each host controller only has to name the record via `review_for_undo`.
+#
+# Runs inside Admin::Certification::ApplicationController, so PaperTrail's
+# whodunnit and the admin Pundit namespace are already wired up.
+module HardwareReviewUndoable
+  extend ActiveSupport::Concern
+
+  def undo
+    review = review_for_undo
+    authorize review, :undo?
+
+    path = hardware_review_path_for(review.project)
+    result = ::Certification::ReviewUndoer.new(review, actor: current_user).undo!
+
+    if result.undone?
+      Rails.logger.info "[HardwareReview#undo] user=#{current_user&.id} #{review.class}=#{review.id} reversed to pending"
+      redirect_to path, notice: undo_success_notice(result)
+    else
+      redirect_to path, alert: result.blocker_summary.presence || "That review can no longer be undone."
+    end
+  rescue Pundit::NotAuthorizedError
+    raise
+  rescue StandardError => e
+    Rails.logger.error "[HardwareReview#undo] user=#{current_user&.id} review=#{params[:id]} #{e.class}: #{e.message}"
+    Sentry.capture_exception(e, tags: { category: "certification.hardware" }, extra: { review_id: params[:id], user_id: current_user&.id })
+    redirect_back fallback_location: admin_root_path, alert: "Failed to undo the review: #{e.message}"
+  end
+
+  private
+
+  def undo_success_notice(result)
+    notice = "Review reversed — it's back in the pending queue."
+    manual = result.manual_steps
+    notice += " Still needs a hand: #{manual.map(&:detail).join(' ')}" if manual.any?
+    notice
+  end
+end

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -73,7 +73,17 @@ export default class extends Controller {
   }
 
   backdropClick(event) {
-    if (this.element.tagName !== "DIALOG") {
+    // The real <dialog> is either this element (controller mounted on the
+    // dialog) or the dialogTarget (controller on a wrapper that also holds the
+    // trigger button). Either way, a backdrop click must close it.
+    const dialog =
+      this.element.tagName === "DIALOG"
+        ? this.element
+        : this.hasDialogTarget
+          ? this.dialogTarget
+          : null;
+
+    if (!dialog) {
       if (event.target === this.element) this.close();
       return;
     }
@@ -82,9 +92,9 @@ export default class extends Controller {
     // dialog itself. Clicks on inner content (including synthetic ones from
     // things like fileInput.click(), which bubble up at coords 0,0) have
     // event.target on the descendant — never treat those as backdrop hits.
-    if (event.target !== this.element) return;
+    if (event.target !== dialog) return;
 
-    const rect = this.element.getBoundingClientRect();
+    const rect = dialog.getBoundingClientRect();
     const clickedInside =
       event.clientX >= rect.left &&
       event.clientX <= rect.right &&

--- a/app/models/certification/funding_request.rb
+++ b/app/models/certification/funding_request.rb
@@ -15,6 +15,7 @@
 #  lock_version              :integer          default(0), not null
 #  prizes_waived             :boolean          default(FALSE), not null
 #  requested_amount_cents    :integer          not null
+#  reversed_at               :datetime
 #  stardust_earned           :integer
 #  status                    :integer          default(0), not null
 #  created_at                :datetime         not null
@@ -489,6 +490,8 @@ module Certification
 
     def stamp_decided_at
       self.decided_at = Time.current
+      # A fresh verdict clears any prior reversal marker.
+      self.reversed_at = nil
     end
 
     # On a decision, advance the project. approved_amount_cents is defaulted in a

--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -12,6 +12,7 @@
 #  lock_version              :integer          default(0), not null
 #  proof_video_url           :string
 #  recert_reason             :text
+#  reversed_at               :datetime
 #  stardust_earned           :float
 #  status                    :integer          default(0), not null
 #  created_at                :datetime         not null
@@ -506,6 +507,8 @@ module Certification
 
     def stamp_decided_at
       self.decided_at = Time.current
+      # A fresh verdict clears any prior reversal marker.
+      self.reversed_at = nil
     end
 
     def apply_verdict_to_project!

--- a/app/models/concerns/shop/hcb_grant_fulfillable.rb
+++ b/app/models/concerns/shop/hcb_grant_fulfillable.rb
@@ -104,7 +104,7 @@ module Shop::HCBGrantFulfillable
   end
 
   def topupable?(grant_rec)
-    HCBService.show_card_grant(hashid: grant_rec.hcb_grant_hashid)["status"] != "canceled"
+    !grant_rec.canceled?
   rescue StandardError => e
     Rails.logger.error "Error checking grant status: #{e.message}"
     false

--- a/app/models/notifications/hardware/review_undone.rb
+++ b/app/models/notifications/hardware/review_undone.rb
@@ -1,0 +1,45 @@
+module Notifications
+  module Hardware
+    # A reviewer reversed a decided hardware review (funding request or ship
+    # certification). The original verdict message can't be unsent, so this is
+    # the correction: it tells the builder the decision was rolled back and the
+    # review is being looked at again.
+    class ReviewUndone < ::Notification
+      self.default_priority     = :high
+      self.aggregatable         = false
+      # No .slack_message suffix: SendSlackDmJob passes this straight to the
+      # renderer with formats: [:slack_message], so a suffixed path raises
+      # MissingTemplate and the DM is swallowed by the job's rescue.
+      self.slack_template_path  = "notifications/hardware/review_undone"
+      self.category_key         = :review_undone
+      self.category_label       = "Review undone"
+      self.category_description = "A verdict on your hardware review was reversed"
+      self.category_group       = "Hardware"
+      self.inbox_record_preloads = :project
+
+      def slack_locals
+        {
+          project_title: record&.project&.title,
+          project_url: record ? project_url_for(record.project) : nil,
+          review_type: record.is_a?(Certification::FundingRequest) ? "funding request" : "ship certification"
+        }
+      end
+
+      def email_subject
+        title = record&.project&.title
+        title.present? ? "The review of #{title} was reopened" : "Your hardware review was reopened"
+      end
+
+      private
+
+      def project_url_for(project)
+        return nil unless project
+
+        routes = Rails.application.routes.url_helpers
+        url_opts = (Rails.application.config.action_controller.default_url_options || {})
+                     .reverse_merge(host: "stardance.hackclub.com", protocol: "https")
+        routes.project_url(project, **url_opts)
+      end
+    end
+  end
+end

--- a/app/models/notifications/registry.rb
+++ b/app/models/notifications/registry.rb
@@ -27,6 +27,7 @@ module Notifications
       Notifications::Hardware::FundingRequestReviewed
       Notifications::Hardware::BuildReviewed
       Notifications::Hardware::ReviewQueueMismatch
+      Notifications::Hardware::ReviewUndone
       Notifications::Workshops::StartingSoon
     ].freeze
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -330,13 +330,18 @@ class Project < ApplicationRecord
   # correction - see Certification::Reviewable#confirm_queue_conversion!.
   attr_accessor :converting_review_queue
 
+  # Set when a reviewer undoes a decided hardware review and the funding approval
+  # that moved the project design -> build is being reversed. The lock has to
+  # open for the rewind - see Certification::ReviewUndoer.
+  attr_accessor :reverting_hardware_review
+
   # Once a project has asked for funding or shipped, its stage decides real
   # money: hardware pays a flat rate and skips the payout review window, so an
   # owner must not be able to flip an already-shipped software project to
   # hardware and change how it gets paid.
   def hardware_stage_locked_once_committed
     return unless hardware_stage_changed?
-    return if advancing_via_funding_approval || converting_review_queue
+    return if advancing_via_funding_approval || converting_review_queue || reverting_hardware_review
 
     if has_any_funding_request?
       errors.add(:hardware_stage, "cannot be changed after a funding request has been submitted")

--- a/app/models/shop_card_grant.rb
+++ b/app/models/shop_card_grant.rb
@@ -24,8 +24,37 @@ class ShopCardGrant < ApplicationRecord
   belongs_to :user
   belongs_to :shop_item
 
+  class << self
+    # Reads an HCB card-grant payload (the body HCBService.show_card_grant
+    # returns) the same way everywhere a grant's safety is judged - shop
+    # fulfillment (Shop::HCBGrantFulfillable#topupable?) and hardware review undo
+    # (Certification::ReviewUndoer) - so the field handling lives in one place.
+    def canceled_grant?(hcb_data)
+      hcb_data.present? && hcb_data["status"].to_s == "canceled"
+    end
+
+    # A grant whose remaining balance still equals the amount granted is
+    # untouched; any less has been spent. Missing/unreadable data is treated as
+    # spent (unsafe) rather than assumed clean - this guards real money.
+    # `expected_cents` is the amount we believe was granted, used only when the
+    # payload omits amount_cents.
+    def spent_grant?(hcb_data, expected_cents: nil)
+      return true if hcb_data.blank?
+
+      balance = hcb_data["balance_cents"]
+      return true if balance.nil?
+
+      balance.to_i < (hcb_data["amount_cents"] || expected_cents).to_i
+    end
+  end
+
   def hcb_data
     @hcb_data ||= HCBService.show_card_grant(hashid: hcb_grant_hashid)
+  end
+
+  # True when HCB reports this grant already cancelled.
+  def canceled?
+    self.class.canceled_grant?(hcb_data)
   end
 
   def hcb_url

--- a/app/policies/admin/certification/funding_request_policy.rb
+++ b/app/policies/admin/certification/funding_request_policy.rb
@@ -15,10 +15,13 @@ class Admin::Certification::FundingRequestPolicy < ApplicationPolicy
   # Same bar as a verdict: only the reviewer holding the claim may re-route it.
   def flag_queue_mismatch? = update?
 
-  # Reversing a decided review is an admin-only correction: it rewinds a verdict
-  # and can cancel a live HCB grant, so it sits above the ordinary reviewer bar.
-  # Still never on your own project.
-  def undo? = user&.admin? && not_own_project?
+  # Reversing a decided review rewinds a verdict and can cancel a live HCB grant.
+  # The reviewer who made the call may take their own verdict back, and an admin
+  # may reverse any decided review. Never on your own project.
+  def undo?
+    return false unless user && not_own_project?
+    user.admin? || own_review?
+  end
 
   class Scope < ApplicationPolicy::Scope
     def resolve
@@ -28,6 +31,8 @@ class Admin::Certification::FundingRequestPolicy < ApplicationPolicy
   end
 
   private
+
+  def own_review? = record.reviewer_id == user.id
 
   def not_own_project?
     return true unless record.respond_to?(:project_id)

--- a/app/policies/admin/certification/funding_request_policy.rb
+++ b/app/policies/admin/certification/funding_request_policy.rb
@@ -15,6 +15,11 @@ class Admin::Certification::FundingRequestPolicy < ApplicationPolicy
   # Same bar as a verdict: only the reviewer holding the claim may re-route it.
   def flag_queue_mismatch? = update?
 
+  # Reversing a decided review is an admin-only correction: it rewinds a verdict
+  # and can cancel a live HCB grant, so it sits above the ordinary reviewer bar.
+  # Still never on your own project.
+  def undo? = user&.admin? && not_own_project?
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       return scope.none unless user&.can_review?

--- a/app/policies/admin/certification/ship_policy.rb
+++ b/app/policies/admin/certification/ship_policy.rb
@@ -16,6 +16,11 @@ class Admin::Certification::ShipPolicy < ApplicationPolicy
   # Same bar as a verdict: only the reviewer holding the claim may re-route it.
   def flag_queue_mismatch? = update?
 
+  # Reversing a decided review is an admin-only correction: it rewinds a verdict
+  # and can cancel a live HCB grant, so it sits above the ordinary reviewer bar.
+  # Never on your own project.
+  def undo? = user&.admin? && not_own_project?
+
   def set_bonus_stardust? = user&.admin?
 
   def report_fraud? = user&.can_review?

--- a/app/policies/admin/certification/ship_policy.rb
+++ b/app/policies/admin/certification/ship_policy.rb
@@ -16,10 +16,13 @@ class Admin::Certification::ShipPolicy < ApplicationPolicy
   # Same bar as a verdict: only the reviewer holding the claim may re-route it.
   def flag_queue_mismatch? = update?
 
-  # Reversing a decided review is an admin-only correction: it rewinds a verdict
-  # and can cancel a live HCB grant, so it sits above the ordinary reviewer bar.
-  # Never on your own project.
-  def undo? = user&.admin? && not_own_project?
+  # Reversing a decided review rewinds a verdict and can cancel a live HCB grant.
+  # The reviewer who made the call may take their own verdict back, and an admin
+  # may reverse any decided review. Never on your own project.
+  def undo?
+    return false unless user && not_own_project?
+    user.admin? || own_review?
+  end
 
   def set_bonus_stardust? = user&.admin?
 
@@ -36,6 +39,8 @@ class Admin::Certification::ShipPolicy < ApplicationPolicy
   end
 
   private
+
+  def own_review? = record.reviewer_id == user.id
 
   def not_own_project?
     !user.memberships.exists?(project_id: record.project_id)

--- a/app/services/certification/review_undoer.rb
+++ b/app/services/certification/review_undoer.rb
@@ -1,0 +1,365 @@
+# frozen_string_literal: true
+
+module Certification
+  # Full-auto reversal of a decided hardware review - a Certification::FundingRequest
+  # or a Certification::Ship. The in-DB state is rewound with `update!`/`destroy!`
+  # so PaperTrail carries the whole reversal, and the one external side effect
+  # (cancelling the HCB grant, or deleting a synced YSWS Airtable record) runs
+  # inside the same row lock, after the reversal, so a failed cancel rolls the DB
+  # changes back and a cancelled grant can never be stranded on a live review.
+  #
+  # A funding request goes back to :pending for a reviewer to re-decide. A ship is
+  # :withdrawn and its project returned to draft, so the builder re-submits the
+  # (still-present) ship post rather than the reviewer silently re-reviewing it.
+  #
+  # This touches real grant money, so it is deliberately conservative:
+  #
+  #   * Only the LATEST decided review on a project can be undone (mirrors
+  #     FundingRequest#latest_for_project?), so undoing never leaves an older
+  #     decision stranded under a newer one.
+  #   * A spent HCB grant, a claimed design kit, or a granted/claimed hardware
+  #     mission reward BLOCKS the undo - those can't be pulled back safely and
+  #     have to be reconciled by hand.
+  #
+  # #preflight classifies every side effect without changing anything, so the
+  # confirm dialog can show exactly what will happen. #undo! performs it.
+  class ReviewUndoer
+    # One line of the reversal ledger. `action` is how the effect is handled:
+    #   :reverse    - undone automatically, in DB
+    #   :block      - can't be undone; its presence makes the whole review un-undoable
+    #   :manual     - left for a human to finish (e.g. a downstream Unified YSWS row)
+    #   :correction - already sent and can't be unsent, so a correction is posted
+    Effect = Struct.new(:effect, :action, :detail, keyword_init: true)
+
+    Outcome = Struct.new(:effects, :undone, keyword_init: true) do
+      def undoable? = blockers.empty?
+      def undone? = !!undone
+      def blockers = effects.select { |e| e.action == :block }
+      def reversals = effects.select { |e| e.action == :reverse }
+      def corrections = effects.select { |e| e.action == :correction }
+      def manual_steps = effects.select { |e| e.action == :manual }
+      def blocker_summary = blockers.map(&:detail).join(" ")
+    end
+
+    attr_reader :review, :actor
+
+    def initialize(review, actor: nil)
+      @review = review
+      @actor = actor
+    end
+
+    # Read-only classification of every side effect. Safe to call from a GET.
+    def preflight
+      return outcome([ block(:decided, "This review hasn't been decided, so there's nothing to undo.") ]) unless review.decided?
+      return outcome([ block(:latest, "A newer review has superseded this one. Undo the most recent decision first.") ]) unless latest_decided_review?
+
+      effects = [ reverse(:review, review_reversal_detail) ]
+      funding? ? funding_effects(effects) : ship_effects(effects)
+      effects << correction(:notifications, "The builder was already told the verdict, so they get a private DM that it's been undone. Nothing is posted publicly.")
+      outcome(effects)
+    end
+
+    # Performs the reversal. Returns an Outcome whose #undone? says whether it
+    # went through. The one external side effect (cancelling the HCB grant) runs
+    # inside the row lock, after the re-check and the DB reversal, so a grant can
+    # never be cancelled unless the review is reversed in the same breath.
+    def undo!
+      pf = preflight
+      return outcome(pf.effects, undone: false) unless pf.undoable?
+
+      original_status = review.status
+      grant_hashid = grant_hashid_to_cancel(pf)
+
+      undone = false
+      review.with_lock do
+        # Cheap re-check under the row lock (no HCB round-trip) so a double-submit
+        # can't undo twice, and so the grant below is only cancelled once we know
+        # the reversal will go through.
+        next unless still_undoable?
+
+        reverse_review_record!
+        funding? ? reverse_funding_side_effects!(original_status) : reverse_ship_side_effects!
+        # External reversals run last: a failure rolls the whole transaction back,
+        # so a cancelled grant can never be stranded on a non-reversed review.
+        raise ActiveRecord::Rollback unless perform_external_reversals!(grant_hashid)
+
+        undone = true
+      end
+      return outcome(pf.effects, undone: false) unless undone
+
+      notify_owner_of_undo!
+      outcome(pf.effects, undone: true)
+    end
+
+    private
+
+    def funding? = review.is_a?(Certification::FundingRequest)
+    def ship? = review.is_a?(Certification::Ship)
+    def project = review.project
+
+    # A funding request goes back to the pending queue for a reviewer to
+    # re-decide; a ship is withdrawn instead, so the builder re-submits the
+    # existing ship rather than the reviewer silently re-reviewing it.
+    def review_reversal_detail
+      if funding?
+        "The verdict is cleared and the review returns to the pending queue."
+      else
+        "The verdict is cleared and the ship submission is withdrawn so the builder can re-submit it."
+      end
+    end
+
+    # --- guards --------------------------------------------------------------
+
+    # Only the newest decided review on the project may be undone. Mirrors
+    # FundingRequest#latest_for_project? for the same-type case, and extends it
+    # across both hardware review tables by decision time.
+    def latest_decided_review?
+      return false unless review.decided?
+      return false if project.nil?
+      return false if newer_same_type_record?
+      return false if newer_decided_cross_type?
+      true
+    end
+
+    def newer_same_type_record?
+      review.class.where(project_id: project.id).where("id > ?", review.id).exists?
+    end
+
+    def newer_decided_cross_type?
+      return false if review.decided_at.blank?
+
+      other_decided_reviews.any? { |r| r.decided_at.present? && r.decided_at > review.decided_at }
+    end
+
+    def other_decided_reviews
+      (project.certification_funding_requests.decided.to_a + project.ship_reviews.decided.to_a)
+        .reject { |r| r.instance_of?(review.class) && r.id == review.id }
+    end
+
+    # DB-only re-check for use inside the row lock.
+    def still_undoable?
+      return false unless review.decided?
+      return false unless latest_decided_review?
+      return false if funding? && review.awards_design_kit? && review.prize_redemptions.exists?
+      return false if ship? && mission_reward_delivered?
+
+      true
+    end
+
+    # --- funding effects -----------------------------------------------------
+
+    def funding_effects(effects)
+      return unless review.approved? # a returned request changed nothing beyond its own record
+
+      effects << reverse(:project_stage, "The project returns to the design stage.") if project&.build_stage?
+      kit_effect(effects) if review.awards_design_kit?
+      grant_effect(effects) if review.hcb_grant_hashid.present?
+    end
+
+    def kit_effect(effects)
+      if review.prize_redemptions.exists?
+        effects << block(:design_kit, "The mission kit has already been claimed, so this approval can't be reversed automatically.")
+      else
+        effects << reverse(:design_kit, "The unclaimed kit offer is withdrawn.")
+      end
+    end
+
+    def grant_effect(effects)
+      data = fetch_grant
+      if data.nil?
+        # Can't confirm the grant is safe to pull back, so refuse rather than
+        # rewind the review while leaving live money on the card.
+        effects << block(:hcb_grant, "Couldn't reach HCB to check the grant. Try again in a moment, or cancel it by hand first.")
+      elsif ShopCardGrant.canceled_grant?(data)
+        effects << manual(:hcb_grant, "The HCB grant is already cancelled - nothing to reverse there.")
+      elsif grant_spent?(data)
+        effects << block(:hcb_grant, "The HCB grant has already been spent (#{spent_summary(data)}). Reconcile or refund it in HCB before undoing.")
+      else
+        effects << reverse(:hcb_grant, "Cancel the unspent $#{review.final_amount_dollars} HCB card grant.")
+      end
+    end
+
+    # Cached for a short window keyed by the grant hashid: the review page runs
+    # this on every render of a decided grant-bearing request, and the status
+    # doesn't change second to second. A lookup failure still falls through to
+    # the block branch above (nothing is cached on error).
+    GRANT_STATUS_CACHE_TTL = 90.seconds
+
+    def fetch_grant
+      Rails.cache.fetch([ "hardware_review_undo", "card_grant", review.hcb_grant_hashid ], expires_in: GRANT_STATUS_CACHE_TTL) do
+        HCBService.show_card_grant(hashid: review.hcb_grant_hashid)
+      end
+    rescue StandardError => e
+      Rails.logger.error("ReviewUndoer grant lookup failed for FundingRequest ##{review.id}: #{e.message}")
+      nil
+    end
+
+    # Spent/cancelled classification reuses ShopCardGrant's field handling, the
+    # same reader the shop-fulfillment path (Shop::HCBGrantFulfillable#topupable?)
+    # uses, so both judge a grant off identical payload fields.
+    def grant_spent?(data) = ShopCardGrant.spent_grant?(data, expected_cents: review.final_amount_cents)
+
+    def spent_summary(data)
+      amount = (data["amount_cents"] || review.final_amount_cents).to_i
+      spent = amount - data["balance_cents"].to_i
+      "$#{spent / 100} of $#{amount / 100} spent"
+    end
+
+    # --- ship effects --------------------------------------------------------
+
+    def ship_effects(effects)
+      effects << block(:mission_reward, "This build's hardware-mission rewards were already granted or claimed. Undo the mission submission by hand first.") if mission_reward_delivered?
+
+      ship_event = review.verdict_ship_event
+      effects << reverse(:ship_event, "The ship post is kept, but its certification is cleared.") if ship_event
+      effects << reverse(:project_state, "The project returns to draft - the builder re-submits the ship when they're ready.") if latest_ship?(ship_event) && project_state_reversible?
+      ysws_effects(effects) if review.approved?
+    end
+
+    # True once a hardware-mission build reward is out the door: the submission
+    # was approved (achievement + stardust granted) or a prize was claimed.
+    # Neither is safe to reverse automatically.
+    def mission_reward_delivered?
+      submission = review.verdict_ship_event&.mission_submission
+      return false unless submission
+
+      submission.approved? || submission.prize_redemptions.exists?
+    end
+
+    def latest_ship?(ship_event)
+      ship_event.nil? || ship_event == project&.last_ship_event
+    end
+
+    # The ship verdict only moved the project's AASM state when the ship was the
+    # latest; only rewind it from a state a verdict could have produced.
+    def project_state_reversible?
+      project && project.ship_status.to_s.in?(%w[approved needs_changes under_review])
+    end
+
+    def ysws_effects(effects)
+      reviews = ysws_reviews_for_ship
+      return if reviews.empty?
+
+      effects << reverse(:ysws_review, "The auto-created YSWS review is deleted.")
+      effects << manual(:unified_ysws, "A YSWS submission already reached the Unified YSWS DB. Remove it there by hand.") if reviews.any? { |r| r.reviewed_at? || r.in_unified_db.present? }
+    end
+
+    # The YSWS review(s) a ship approval spun up. Matched on ship_cert_id, with a
+    # fall back to the ship event for older rows created before ship_cert_id was
+    # populated.
+    def ysws_reviews_for_ship
+      scope = Certification::Ysws.where(ship_cert_id: review.id).to_a
+      scope += Certification::Ysws.where(post_ship_event_id: review.post_ship_event_id, ship_cert_id: nil).to_a if review.post_ship_event_id
+      scope.uniq
+    end
+
+    # --- external reversals (run inside the row lock) ------------------------
+
+    # The grant to cancel, or nil when there's nothing to pull back. Read before
+    # the reversal clears the hashid, and only when preflight confirmed the grant
+    # is present and unspent. Cancellation goes through the same HCBService call
+    # the "cancel all card grants" admin feature uses.
+    def grant_hashid_to_cancel(pf)
+      return nil unless funding?
+      return nil unless pf.effects.any? { |e| e.effect == :hcb_grant && e.action == :reverse }
+
+      review.hcb_grant_hashid
+    end
+
+    def perform_external_reversals!(grant_hashid)
+      HCBService.cancel_card_grant!(hashid: grant_hashid) if grant_hashid.present?
+      delete_synced_ysws_airtable_records! if ship?
+      true
+    rescue StandardError => e
+      Rails.logger.error("ReviewUndoer external reversal failed for #{review.class} ##{review.id}: #{e.message}")
+      false
+    end
+
+    # Only completed/synced YSWS reviews have an Airtable submission row; a
+    # freshly auto-created (pending) one has nothing there, so this is a no-op in
+    # the common case. A missing record is success - there is nothing to remove.
+    def delete_synced_ysws_airtable_records!
+      ysws_reviews_for_ship.each do |yr|
+        next unless yr.airtable_synced_at? || yr.reviewed_at?
+
+        record = Certification::YswsAirtable.record_for(yr.id)
+        record&.destroy
+      rescue Norairrecord::RecordNotFoundError
+        nil
+      end
+    end
+
+    # --- in-DB reversal ------------------------------------------------------
+
+    def reverse_review_record!
+      attrs = {
+        status: reversed_status,
+        decided_at: nil,
+        reviewer_id: nil,
+        claimed_at: nil,
+        claim_expires_at: nil,
+        stardust_earned: nil,
+        # Marks the review as a reversal so the admin review history shows a
+        # "Reversed" badge rather than the review just vanishing. Cleared when the
+        # review is decided again (see #stamp_decided_at in the review models).
+        reversed_at: Time.current
+      }
+      # Cleared so a later re-approval issues a fresh grant rather than trusting
+      # the now-cancelled one (issue_hcb_grant! short-circuits on a present hashid).
+      attrs[:hcb_grant_hashid] = nil if funding? && review.hcb_grant_hashid.present?
+      review.update!(attrs)
+    end
+
+    # A funding request goes back to :pending so a reviewer re-decides it. A ship
+    # is :withdrawn instead: it leaves the reviewer queue and the pending-review
+    # guards (so it can't be re-decided silently and doesn't trip the one-pending
+    # -per-project index), and the builder re-submits the still-present ship post.
+    def reversed_status = ship? ? :withdrawn : :pending
+
+    def reverse_funding_side_effects!(original_status)
+      return unless original_status == "approved"
+      return unless project&.build_stage?
+
+      project.with_lock do
+        project.reverting_hardware_review = true
+        project.update!(hardware_stage: "design")
+      end
+    end
+
+    def reverse_ship_side_effects!
+      ship_event = review.verdict_ship_event
+      ship_event&.update!(certification_status: "pending")
+      withdraw_project_ship! if latest_ship?(ship_event) && project_state_reversible?
+      ysws_reviews_for_ship.each(&:destroy!)
+    end
+
+    # Return the project to draft and clear shipped_at, mirroring the AASM
+    # `withdraw_ship` event's end state so the ship reads as un-submitted and the
+    # builder gets the ship button back. A direct update because `withdraw_ship`
+    # only fires from submitted/under_review, and a decided ship sits in
+    # approved/needs_changes.
+    def withdraw_project_ship!
+      project.with_lock { project.update!(ship_status: "draft", shipped_at: nil) }
+    end
+
+    # --- correction (after commit) -------------------------------------------
+
+    # The builder was already told the verdict, so a reversal DMs them privately.
+    # Nothing is posted to the public review channel - the DM is the correction.
+    def notify_owner_of_undo!
+      Notifications::Hardware::ReviewUndone.notify(recipient: owner, actor: actor, record: review)
+    rescue StandardError => e
+      Rails.logger.error("ReviewUndoer owner notification failed for #{review.class} ##{review.id}: #{e.message}")
+    end
+
+    def owner = review.owner
+
+    # --- effect/outcome builders ---------------------------------------------
+
+    def outcome(effects, undone: false) = Outcome.new(effects: effects, undone: undone)
+    def reverse(effect, detail) = Effect.new(effect: effect, action: :reverse, detail: detail)
+    def block(effect, detail) = Effect.new(effect: effect, action: :block, detail: detail)
+    def manual(effect, detail) = Effect.new(effect: effect, action: :manual, detail: detail)
+    def correction(effect, detail) = Effect.new(effect: effect, action: :correction, detail: detail)
+  end
+end

--- a/app/views/admin/certification/hardware_reviews/_undo_review.html.erb
+++ b/app/views/admin/certification/hardware_reviews/_undo_review.html.erb
@@ -1,0 +1,77 @@
+<%# The undo control for the newest decided review, plus its confirm modal.
+    The modal shows the preflight ledger so a reviewer sees exactly what the
+    reversal does before committing to it.
+    Locals: review (required), preflight (required, a ReviewUndoer::Outcome). %>
+<%
+  dialog_id = "undo-review-#{review.model_name.param_key}-#{review.id}"
+  # Every concrete reversal, grant cancellation included (it's a :reverse effect),
+  # under one "Things this will do" heading.
+  things = preflight.reversals
+  blockers = preflight.blockers
+%>
+
+<div class="review-undo" data-controller="modal">
+  <%# Admin-only correction, so it carries the orange dashed admin-tool marker. %>
+  <%= admin_tool do %>
+    <button type="button" class="action-btn action-btn--small action-btn--destructive review-undo__trigger"
+            data-action="click->modal#open">
+      Undo review
+    </button>
+  <% end %>
+
+  <dialog data-modal-target="dialog" class="review-undo__dialog"
+          aria-labelledby="<%= dialog_id %>-title">
+    <div class="review-undo__card">
+      <button type="button" class="review-undo__close" data-action="click->modal#close" aria-label="Close">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+          <line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line>
+        </svg>
+      </button>
+
+      <h2 class="review-undo__title" id="<%= dialog_id %>-title">Undo this review?</h2>
+      <p class="review-undo__lede">This rewinds the latest verdict. Here's exactly what happens.</p>
+
+      <% if blockers.any? %>
+        <div class="review-undo__group review-undo__group--block" role="alert">
+          <p class="review-undo__group-label">Can't be undone yet</p>
+          <ul class="review-undo__list">
+            <% blockers.each do |effect| %>
+              <li class="review-undo__row review-undo__row--block">
+                <svg class="review-undo__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 9v4"></path><path d="M12 17h.01"></path><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path></svg>
+                <span><%= effect.detail %></span>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <% if things.any? %>
+        <div class="review-undo__group">
+          <p class="review-undo__group-label">Things this will do</p>
+          <ul class="review-undo__list">
+            <% things.each do |effect| %>
+              <li class="review-undo__row review-undo__row--reverse">
+                <svg class="review-undo__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                <span><%= effect.detail %></span>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <div class="review-undo__actions">
+        <button type="button" class="action-btn action-btn--small action-btn--secondary"
+                data-action="click->modal#close">Cancel</button>
+        <% if preflight.undoable? %>
+          <%= button_to "Undo review", undo_review_path(review), method: :post,
+                class: "action-btn action-btn--small action-btn--destructive",
+                form_class: "review-undo__confirm-form",
+                data: { turbo: false } %>
+        <% else %>
+          <button type="button" class="action-btn action-btn--small action-btn--destructive" disabled
+                  aria-disabled="true">Undo review</button>
+        <% end %>
+      </div>
+    </div>
+  </dialog>
+</div>

--- a/app/views/admin/certification/hardware_reviews/_undo_review.html.erb
+++ b/app/views/admin/certification/hardware_reviews/_undo_review.html.erb
@@ -11,13 +11,15 @@
 %>
 
 <div class="review-undo" data-controller="modal">
-  <%# Admin-only correction, so it carries the orange dashed admin-tool marker. %>
-  <%= admin_tool do %>
+  <%# Only rendered for someone the undo policy lets reverse this review — its own
+      reviewer or an admin — so it wears the orange dashed "manageable-by-viewer"
+      marker for all of them. %>
+  <div class="admin tools-do">
     <button type="button" class="action-btn action-btn--small action-btn--destructive review-undo__trigger"
             data-action="click->modal#open">
       Undo review
     </button>
-  <% end %>
+  </div>
 
   <dialog data-modal-target="dialog" class="review-undo__dialog"
           aria-labelledby="<%= dialog_id %>-title">

--- a/app/views/admin/certification/hardware_reviews/show.html.erb
+++ b/app/views/admin/certification/hardware_reviews/show.html.erb
@@ -90,13 +90,21 @@
                 <li class="hardware-review__history-item">
                   <div class="hardware-review__history-head">
                     <span class="hardware-review__timeline-label"><%= is_funding ? "Design funding" : "Build certification" %></span>
-                    <span class="status-pill status-pill--<%= review.status %>"><%= review.status.capitalize %></span>
+                    <%# A reversed review keeps its history slot but wears a purple
+                        "Reversed" badge instead of its (now rewound) verdict. %>
+                    <% if review.reversed_at.present? %>
+                      <span class="status-pill status-pill--reversed">Reversed</span>
+                    <% else %>
+                      <span class="status-pill status-pill--<%= review.status %>"><%= review.status.capitalize %></span>
+                    <% end %>
                     <span class="hardware-review__timeline-meta">
                       <%# A routing correction has no verdict to report, so it says
-                          what happened to it instead of an amount or a kit. %>
-                      <% if review.misfiled? %>
+                          what happened to it instead of an amount or a kit. A
+                          reversed review skips that wording and shows what the
+                          rewound verdict had been. %>
+                      <% if review.misfiled? && review.reversed_at.blank? %>
                         Wrong queue, waiting on the builder
-                      <% elsif review.withdrawn? %>
+                      <% elsif review.withdrawn? && review.reversed_at.blank? %>
                         Withdrawn, wrong queue
                       <% elsif is_funding %>
                         <% if review.awards_design_kit? %>
@@ -110,7 +118,9 @@
                         <% end %>
                       <% end %>
                     </span>
-                    <% if review.decided_at %>
+                    <% if review.reversed_at %>
+                      <span class="hardware-review__timeline-meta">reversed <%= l(review.reversed_at.to_date, format: :short) %></span>
+                    <% elsif review.decided_at %>
                       <span class="hardware-review__timeline-meta"><%= l(review.decided_at.to_date, format: :short) %></span>
                     <% end %>
                     <% if review.reviewer %>
@@ -127,6 +137,12 @@
                     <p class="hardware-review__history-feedback hardware-review__history-feedback--internal">
                       Reviewer note: <%= review.internal_reason %>
                     </p>
+                  <% end %>
+                  <%# Only the newest decided review is reversible; the controller
+                      sets @undo_review to it and @undo_preflight to its ledger. %>
+                  <% if @undo_review && review == @undo_review && @undo_preflight %>
+                    <%= render "admin/certification/hardware_reviews/undo_review",
+                          review: review, preflight: @undo_preflight %>
                   <% end %>
                 </li>
               <% end %>

--- a/app/views/notifications/hardware/review_undone.slack_message.slocks
+++ b/app/views/notifications/hardware/review_undone.slack_message.slocks
@@ -1,0 +1,11 @@
+header ":arrows_counterclockwise: A review decision was reversed"
+
+if project_url.present?
+  section "The #{review_type} decision on *<#{project_url}|#{project_title}>* was undone by a reviewer. It's back in the queue for another look - no action is needed from you right now.", markdown: true
+else
+  section "The #{review_type} decision on *#{project_title}* was undone by a reviewer. It's back in the queue for another look - no action is needed from you right now.", markdown: true
+end
+
+actions [
+  button("View project", "view_project", url: project_url)
+] if project_url.present?

--- a/app/views/notifications/inbox/_review_undone.html.erb
+++ b/app/views/notifications/inbox/_review_undone.html.erb
@@ -1,0 +1,7 @@
+<% review = notification.record %>
+<span class="notifications-item__verb">A reviewer reopened the review of</span>
+<% if review&.project %>
+  <%= link_to review.project.title, project_path(review.project), class: "notifications-item__actor" %>
+<% else %>
+  <strong>your hardware project</strong>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -870,6 +870,7 @@ Rails.application.routes.draw do
         patch :set_bonus_stardust, on: :member
         post :report_fraud, on: :member
         post :flag_queue_mismatch, on: :member
+        post :undo, on: :member
         scope module: :ships do
           resource :claim, only: [ :create, :destroy ]
         end
@@ -877,6 +878,7 @@ Rails.application.routes.draw do
 
       resources :funding_requests, path: "funding", only: [ :update ] do
         post :flag_queue_mismatch, on: :member
+        post :undo, on: :member
         scope module: :funding_requests do
           resource :claim, only: [ :create, :destroy ]
         end

--- a/db/migrate/20260825184443_add_reversed_at_to_hardware_reviews.rb
+++ b/db/migrate/20260825184443_add_reversed_at_to_hardware_reviews.rb
@@ -1,0 +1,6 @@
+class AddReversedAtToHardwareReviews < ActiveRecord::Migration[8.1]
+  def change
+    add_column :certification_funding_requests, :reversed_at, :datetime
+    add_column :certification_ship_reviews, :reversed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_25_002911) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_25_184443) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
@@ -193,6 +193,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_25_002911) do
     t.boolean "prizes_waived", default: false, null: false
     t.bigint "project_id", null: false
     t.integer "requested_amount_cents", null: false
+    t.datetime "reversed_at"
     t.bigint "reviewer_id"
     t.integer "stardust_earned"
     t.integer "status", default: 0, null: false
@@ -261,6 +262,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_25_002911) do
     t.string "proof_video_url"
     t.text "recert_reason"
     t.bigint "returned_by_id"
+    t.datetime "reversed_at"
     t.bigint "reviewer_id"
     t.float "stardust_earned"
     t.integer "status", default: 0, null: false

--- a/test/controllers/admin/certification/hardware_review_undo_test.rb
+++ b/test/controllers/admin/certification/hardware_review_undo_test.rb
@@ -72,12 +72,12 @@ class Admin::Certification::HardwareReviewUndoTest < ActionDispatch::Integration
     assert @funding.reload.approved?
   end
 
-  test "a non-admin reviewer cannot undo - it is admin only" do
+  test "a reviewer cannot undo a review another reviewer decided" do
     certifier = create_user(slack_id: "U_UNDO_CERT", display_name: "undo-certifier")
     certifier.grant_role!(:project_certifier)
     sign_in certifier
 
-    # A plain reviewer can open the review page, but the undo control is hidden...
+    # @funding was decided by @reviewer, so to this reviewer the control is hidden...
     HCBService.stub(:show_card_grant, unspent_grant) do
       get admin_certification_hardware_review_path(@project)
     end
@@ -88,6 +88,54 @@ class Admin::Certification::HardwareReviewUndoTest < ActionDispatch::Integration
     post undo_admin_certification_funding_request_path(@funding)
     assert_response :forbidden
     assert @funding.reload.approved?
+  end
+
+  test "a reviewer undoes their own funding review" do
+    certifier = create_user(slack_id: "U_UNDO_OWN_FR", display_name: "undo-own-fr")
+    certifier.grant_role!(:project_certifier)
+    @funding.update_columns(reviewer_id: certifier.id)
+    sign_in certifier
+
+    HCBService.stub(:show_card_grant, unspent_grant) do
+      HCBService.stub(:cancel_card_grant!, ->(hashid:) { { "status" => "canceled" } }) do
+        post undo_admin_certification_funding_request_path(@funding)
+      end
+    end
+
+    assert_redirected_to admin_certification_hardware_review_path(@project)
+    assert @funding.reload.pending?, "the reviewer's own verdict is reversed"
+  end
+
+  test "a reviewer sees the undo control on a review they decided" do
+    certifier = create_user(slack_id: "U_UNDO_OWN_VIEW", display_name: "undo-own-view")
+    certifier.grant_role!(:project_certifier)
+    @funding.update_columns(reviewer_id: certifier.id)
+    sign_in certifier
+
+    HCBService.stub(:show_card_grant, unspent_grant) do
+      get admin_certification_hardware_review_path(@project)
+    end
+
+    assert_response :success
+    assert_select ".review-undo__trigger", text: /Undo review/
+  end
+
+  test "a reviewer undoes their own ship certification" do
+    certifier = create_user(slack_id: "U_UNDO_OWN_SHIP", display_name: "undo-own-ship")
+    certifier.grant_role!(:project_certifier)
+    project = Project.create!(title: "Undo Own Ship #{SecureRandom.hex(3)}", hardware_stage: "build")
+    project.memberships.create!(user: @owner, role: :owner)
+    ship_event = Post::ShipEvent.create!(body: "Ship it", uploading_attachments: true, hours_at_ship: 4)
+    Post.create!(project: project, user: @owner, postable: ship_event)
+    project.update_columns(ship_status: "submitted", shipped_at: Time.current)
+    cert = project.ship_reviews.create!(status: :pending, post_ship_event: ship_event)
+    cert.update!(status: :approved, reviewer: certifier)
+    sign_in certifier
+
+    post undo_admin_certification_ship_path(cert)
+
+    assert_redirected_to admin_certification_hardware_review_path(project)
+    assert cert.reload.withdrawn?, "the reviewer's own ship verdict is withdrawn"
   end
 
   test "a reviewer undoes an approved ship certification" do

--- a/test/controllers/admin/certification/hardware_review_undo_test.rb
+++ b/test/controllers/admin/certification/hardware_review_undo_test.rb
@@ -1,0 +1,167 @@
+require "test_helper"
+
+# The `undo` endpoints on the funding-request and ship controllers. HCB is
+# stubbed throughout - undoing a funding approval cancels a real card grant.
+class Admin::Certification::HardwareReviewUndoTest < ActionDispatch::IntegrationTest
+  def unspent_grant(amount_cents: 6_000)
+    Hashie::Mash.new("id" => "cdg_test", "status" => "active",
+                     "amount_cents" => amount_cents, "balance_cents" => amount_cents, "disbursements" => [])
+  end
+
+  def spent_grant(amount_cents: 6_000, balance_cents: 500)
+    Hashie::Mash.new("id" => "cdg_test", "status" => "active",
+                     "amount_cents" => amount_cents, "balance_cents" => balance_cents,
+                     "disbursements" => [ { "transaction_id" => "txn_1" } ])
+  end
+
+  setup do
+    Flipper.enable(:hardware_flow)
+    @reviewer = create_user(slack_id: "U_UNDO_C_REV", display_name: "undo-c-rev")
+    @reviewer.grant_role!(:admin)
+    @owner = create_user(slack_id: "U_UNDO_C_OWNER", display_name: "undo-c-owner", verified: true)
+
+    @project = Project.create!(title: "Undo C #{SecureRandom.hex(3)}", hardware_stage: "design")
+    @project.memberships.create!(user: @owner, role: :owner)
+    add_devlog(@project, "design")
+    @funding = approved_funding_with_grant
+
+    sign_in @reviewer
+  end
+
+  teardown { Flipper.disable(:hardware_flow) }
+
+  test "a reviewer undoes an approved funding request" do
+    HCBService.stub(:show_card_grant, unspent_grant) do
+      HCBService.stub(:cancel_card_grant!, ->(hashid:) { { "status" => "canceled" } }) do
+        post undo_admin_certification_funding_request_path(@funding)
+      end
+    end
+
+    assert_redirected_to admin_certification_hardware_review_path(@project)
+    assert @funding.reload.pending?
+    assert_equal "design", @project.reload.hardware_stage
+    assert_nil @funding.hcb_grant_hashid
+  end
+
+  test "undoing a spent grant is refused with the blocker as the alert" do
+    HCBService.stub(:show_card_grant, spent_grant) do
+      post undo_admin_certification_funding_request_path(@funding)
+    end
+
+    assert_redirected_to admin_certification_hardware_review_path(@project)
+    assert_match(/spent/i, flash[:alert])
+    assert @funding.reload.approved?, "a blocked undo leaves the verdict intact"
+    assert_equal "build", @project.reload.hardware_stage
+  end
+
+  test "a reviewer cannot undo a review on their own project" do
+    @project.memberships.create!(user: @reviewer, role: :contributor)
+
+    post undo_admin_certification_funding_request_path(@funding)
+
+    assert_response :forbidden
+    assert @funding.reload.approved?
+  end
+
+  test "a non-reviewer cannot undo" do
+    sign_in @owner
+
+    post undo_admin_certification_funding_request_path(@funding)
+
+    assert_response :forbidden
+    assert @funding.reload.approved?
+  end
+
+  test "a non-admin reviewer cannot undo - it is admin only" do
+    certifier = create_user(slack_id: "U_UNDO_CERT", display_name: "undo-certifier")
+    certifier.grant_role!(:project_certifier)
+    sign_in certifier
+
+    # A plain reviewer can open the review page, but the undo control is hidden...
+    HCBService.stub(:show_card_grant, unspent_grant) do
+      get admin_certification_hardware_review_path(@project)
+    end
+    assert_response :success
+    assert_select ".review-undo__trigger", 0
+
+    # ...and the action itself is forbidden.
+    post undo_admin_certification_funding_request_path(@funding)
+    assert_response :forbidden
+    assert @funding.reload.approved?
+  end
+
+  test "a reviewer undoes an approved ship certification" do
+    project = Project.create!(title: "Undo Ship #{SecureRandom.hex(3)}", hardware_stage: "build")
+    project.memberships.create!(user: @owner, role: :owner)
+    ship_event = Post::ShipEvent.create!(body: "Ship it", uploading_attachments: true, hours_at_ship: 4)
+    Post.create!(project: project, user: @owner, postable: ship_event)
+    project.update_columns(ship_status: "submitted", shipped_at: Time.current)
+    cert = project.ship_reviews.create!(status: :pending, post_ship_event: ship_event)
+    cert.update!(status: :approved, reviewer: @reviewer)
+
+    post undo_admin_certification_ship_path(cert)
+
+    assert_redirected_to admin_certification_hardware_review_path(project)
+    assert cert.reload.withdrawn?, "the undone ship review is withdrawn, not left pending"
+    assert_equal "pending", ship_event.reload.certification_status
+    assert_equal "draft", project.reload.ship_status, "the project is un-submitted, not auto-queued"
+    assert_not project.reload.awaiting_ship_review?, "no pending review remains to block a manual re-ship"
+  end
+
+  test "the review page offers an undo control for the latest decided review" do
+    HCBService.stub(:show_card_grant, unspent_grant) do
+      get admin_certification_hardware_review_path(@project)
+    end
+
+    assert_response :success
+    assert_select ".review-undo__trigger", text: /Undo review/
+    # The trigger carries the orange dashed admin-tool marker.
+    assert_select ".tools-do .review-undo__trigger"
+    assert_select ".review-undo__group-label", text: /Things this will do/
+    assert_select ".review-undo__confirm-form button", text: /Undo review/
+  end
+
+  test "a spent grant disables the undo confirm and shows the blocker" do
+    HCBService.stub(:show_card_grant, spent_grant) do
+      get admin_certification_hardware_review_path(@project)
+    end
+
+    assert_response :success
+    assert_select ".review-undo__row--block", text: /spent/i
+    assert_select ".review-undo__confirm-form", count: 0
+    assert_select "button[disabled]", text: /Undo review/
+  end
+
+  test "an undone funding review stays in the history with a Reversed badge" do
+    HCBService.stub(:show_card_grant, unspent_grant) do
+      HCBService.stub(:cancel_card_grant!, ->(hashid:) { { "status" => "canceled" } }) do
+        post undo_admin_certification_funding_request_path(@funding)
+      end
+    end
+    assert @funding.reload.reversed_at.present?
+
+    get admin_certification_hardware_review_path(@project)
+
+    assert_response :success
+    assert_select ".hardware-review__history .status-pill--reversed", text: /Reversed/
+  end
+
+  private
+
+  def add_devlog(project, phase)
+    devlog = Post::Devlog.new(body: "log", duration_seconds: 3600, phase: phase)
+    devlog.uploading_attachments = true
+    devlog.save!
+    Post.create!(project: project, user: @owner, postable: devlog)
+  end
+
+  def approved_funding_with_grant
+    fr = @project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 3, requested_amount_cents: 6_000, status: :pending
+    )
+    HCBService.stub(:create_card_grant, { "id" => "cdg_test" }) do
+      fr.update!(reviewer: @reviewer, status: :approved, feedback: "great")
+    end
+    fr.reload
+  end
+end

--- a/test/models/certification/funding_request_test.rb
+++ b/test/models/certification/funding_request_test.rb
@@ -15,6 +15,7 @@
 #  lock_version              :integer          default(0), not null
 #  prizes_waived             :boolean          default(FALSE), not null
 #  requested_amount_cents    :integer          not null
+#  reversed_at               :datetime
 #  stardust_earned           :integer
 #  status                    :integer          default(0), not null
 #  created_at                :datetime         not null

--- a/test/models/certification/ship_test.rb
+++ b/test/models/certification/ship_test.rb
@@ -14,6 +14,7 @@
 #  lock_version              :integer          default(0), not null
 #  proof_video_url           :string
 #  recert_reason             :text
+#  reversed_at               :datetime
 #  stardust_earned           :float
 #  status                    :integer          default(0), not null
 #  created_at                :datetime         not null

--- a/test/models/notifications/hardware/review_undone_test.rb
+++ b/test/models/notifications/hardware/review_undone_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+module Notifications
+  module Hardware
+    class ReviewUndoneTest < ActiveSupport::TestCase
+      setup do
+        Flipper.enable(:hardware_flow)
+        @owner = create_user(slack_id: "U_RU_OWNER", display_name: "ru_owner", verified: true)
+        @reviewer = create_user(slack_id: "U_RU_REV", display_name: "ru_rev")
+        @project = Project.create!(title: "Undone HW", hardware_stage: "design")
+        Project::Membership.create!(project: @project, user: @owner, role: :owner)
+        devlog = Post::Devlog.new(body: "log", duration_seconds: 3600, phase: "design")
+        devlog.uploading_attachments = true
+        devlog.save!
+        Post.create!(project: @project, user: @owner, postable: devlog)
+        @funding = @project.certification_funding_requests.create!(
+          user: @owner, complexity_tier: 2, requested_amount_cents: 3_000, status: :pending
+        )
+        @funding.update!(reviewer: @reviewer, status: :returned, feedback: "redo")
+      end
+
+      teardown { Flipper.disable(:hardware_flow) }
+
+      test "is registered and high priority" do
+        assert_includes Notifications::Registry.all, Notifications::Hardware::ReviewUndone
+        assert_equal :high, Notifications::Hardware::ReviewUndone.default_priority
+      end
+
+      test "slack locals name the project and the review type" do
+        notification = Notifications::Hardware::ReviewUndone.notify(
+          recipient: @owner, actor: @reviewer, record: @funding
+        )
+        locals = notification.slack_locals
+
+        assert_equal "Undone HW", locals[:project_title]
+        assert_equal "funding request", locals[:review_type]
+        assert locals[:project_url].present?
+      end
+
+      test "email subject names the project" do
+        notification = Notifications::Hardware::ReviewUndone.notify(
+          recipient: @owner, actor: @reviewer, record: @funding
+        )
+        assert_equal "The review of Undone HW was reopened", notification.email_subject
+      end
+
+      test "the owner slack template renders valid blocks" do
+        notification = Notifications::Hardware::ReviewUndone.notify(
+          recipient: @owner, actor: @reviewer, record: @funding
+        )
+        rendered = ApplicationController.renderer.new.render(
+          template: "notifications/hardware/review_undone",
+          formats: [ :slack_message ],
+          locals: notification.slack_locals
+        )
+        assert JSON.parse(rendered)["blocks"].present?
+      end
+    end
+  end
+end

--- a/test/services/certification/review_undoer_test.rb
+++ b/test/services/certification/review_undoer_test.rb
@@ -1,0 +1,348 @@
+require "test_helper"
+
+# Exercises the full-auto reversal of a decided hardware review. Every HCB call
+# is stubbed - this class touches real grant money, so the suite must never
+# reach a live API.
+class Certification::ReviewUndoerTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  # A card grant that has NOT been spent: balance still equals the amount.
+  def unspent_grant(hashid: "cdg_test", amount_cents: 6_000)
+    Hashie::Mash.new("id" => hashid, "status" => "active",
+                     "amount_cents" => amount_cents, "balance_cents" => amount_cents,
+                     "disbursements" => [])
+  end
+
+  # A card grant that has been partially spent: balance below the amount.
+  def spent_grant(hashid: "cdg_test", amount_cents: 6_000, balance_cents: 1_000)
+    Hashie::Mash.new("id" => hashid, "status" => "active",
+                     "amount_cents" => amount_cents, "balance_cents" => balance_cents,
+                     "disbursements" => [ { "transaction_id" => "txn_1" } ])
+  end
+
+  setup do
+    Flipper.enable(:hardware_flow)
+    @owner = create_user(slack_id: "U_UNDO_OWNER", display_name: "undo-owner", verified: true)
+    @reviewer = create_user(slack_id: "U_UNDO_REV", display_name: "undo-rev")
+    @reviewer.grant_role!(:admin)
+    @project = Project.create!(title: "Undo HW #{SecureRandom.hex(4)}", hardware_stage: "design")
+    @project.memberships.create!(user: @owner, role: :owner)
+    add_devlog(@project, "design")
+  end
+
+  # ---- funding request preflight -----------------------------------------
+
+  test "preflight marks an unspent grant as reversible and the review as undoable" do
+    fr = approved_funding_with_grant
+    pf = HCBService.stub(:show_card_grant, unspent_grant) do
+      Certification::ReviewUndoer.new(fr).preflight
+    end
+
+    assert pf.undoable?, "an approved, unspent funding request should be undoable"
+    grant = pf.effects.find { |e| e.effect == :hcb_grant }
+    assert_equal :reverse, grant.action
+    stage = pf.effects.find { |e| e.effect == :project_stage }
+    assert_equal :reverse, stage.action
+  end
+
+  test "preflight blocks a review whose grant has been spent" do
+    fr = approved_funding_with_grant
+    pf = HCBService.stub(:show_card_grant, spent_grant) do
+      Certification::ReviewUndoer.new(fr).preflight
+    end
+
+    assert_not pf.undoable?
+    grant = pf.effects.find { |e| e.effect == :hcb_grant }
+    assert_equal :block, grant.action
+    assert pf.blockers.any?
+  end
+
+  test "preflight blocks a superseded (non-latest) funding request" do
+    old = @project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 2, requested_amount_cents: 3_000, status: :pending
+    )
+    old.update!(reviewer: @reviewer, status: :returned, feedback: "redo")
+    # Resubmit supersedes the returned one.
+    @project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 2, requested_amount_cents: 3_000, status: :pending
+    )
+
+    pf = Certification::ReviewUndoer.new(old).preflight
+    assert_not pf.undoable?
+    assert pf.effects.any? { |e| e.effect == :latest && e.action == :block }
+  end
+
+  test "preflight records the owner notification as a correction, not an unsend" do
+    fr = approved_funding_with_grant
+    pf = HCBService.stub(:show_card_grant, unspent_grant) do
+      Certification::ReviewUndoer.new(fr).preflight
+    end
+
+    note = pf.effects.find { |e| e.effect == :notifications }
+    assert_equal :correction, note.action
+  end
+
+  test "preflight blocks a claimed design kit" do
+    fr = approved_kit_funding
+    redeem_kit!(fr)
+
+    pf = Certification::ReviewUndoer.new(fr).preflight
+    assert_not pf.undoable?
+    kit = pf.effects.find { |e| e.effect == :design_kit }
+    assert_equal :block, kit.action
+  end
+
+  # ---- funding request undo! ---------------------------------------------
+
+  test "undo! reverses an approved funding request and records paper_trail" do
+    fr = approved_funding_with_grant
+    versions_before = fr.versions.count
+
+    cancelled = nil
+    result = HCBService.stub(:show_card_grant, unspent_grant) do
+      HCBService.stub(:cancel_card_grant!, ->(hashid:) { cancelled = hashid; { "status" => "canceled" } }) do
+        Certification::ReviewUndoer.new(fr, actor: @reviewer).undo!
+      end
+    end
+
+    assert result.undone?
+    assert_equal "cdg_test", cancelled, "the unspent grant must be cancelled"
+
+    fr.reload
+    assert fr.pending?
+    assert_nil fr.decided_at
+    assert_nil fr.reviewer_id
+    assert_nil fr.stardust_earned
+    assert_nil fr.hcb_grant_hashid, "clearing the hashid lets a re-approval issue a fresh grant"
+    assert fr.reversed_at.present?, "the review is marked reversed for the history badge"
+    assert_equal "design", @project.reload.hardware_stage
+    assert_operator fr.versions.count, :>, versions_before, "the reversal must be paper_trailed"
+  end
+
+  test "deciding a reversed funding request again clears the reversal marker" do
+    fr = approved_funding_with_grant
+    HCBService.stub(:show_card_grant, unspent_grant) do
+      HCBService.stub(:cancel_card_grant!, ->(hashid:) { { "status" => "canceled" } }) do
+        Certification::ReviewUndoer.new(fr, actor: @reviewer).undo!
+      end
+    end
+    assert fr.reload.reversed_at.present?
+
+    HCBService.stub(:create_card_grant, { "id" => "cdg_new" }) do
+      fr.update!(reviewer: @reviewer, status: :approved)
+    end
+
+    assert_nil fr.reload.reversed_at, "a fresh verdict clears the reversal marker"
+  end
+
+  test "undo! refuses a spent grant and leaves the review approved" do
+    fr = approved_funding_with_grant
+
+    cancel_called = false
+    result = HCBService.stub(:show_card_grant, spent_grant) do
+      HCBService.stub(:cancel_card_grant!, ->(hashid:) { cancel_called = true }) do
+        Certification::ReviewUndoer.new(fr, actor: @reviewer).undo!
+      end
+    end
+
+    assert_not result.undone?
+    assert_not cancel_called, "a spent grant must never be cancelled"
+    assert fr.reload.approved?, "a blocked undo must leave the verdict intact"
+    assert_equal "build", @project.reload.hardware_stage
+  end
+
+  test "undo! of a returned funding request touches no grant and leaves the stage alone" do
+    fr = @project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 2, requested_amount_cents: 3_000, status: :pending
+    )
+    fr.update!(reviewer: @reviewer, status: :returned, feedback: "needs work")
+
+    grant_touched = false
+    result = HCBService.stub(:show_card_grant, ->(*) { grant_touched = true }) do
+      HCBService.stub(:cancel_card_grant!, ->(**) { grant_touched = true }) do
+        Certification::ReviewUndoer.new(fr, actor: @reviewer).undo!
+      end
+    end
+
+    assert result.undone?
+    assert_not grant_touched, "a returned request never had a grant"
+    assert fr.reload.pending?
+    assert_equal "design", @project.reload.hardware_stage
+  end
+
+  test "undo! notifies the owner of the reversal" do
+    fr = approved_funding_with_grant
+
+    assert_difference -> { @owner.notifications.where(type: "Notifications::Hardware::ReviewUndone").count }, 1 do
+      HCBService.stub(:show_card_grant, unspent_grant) do
+        HCBService.stub(:cancel_card_grant!, ->(hashid:) { { "status" => "canceled" } }) do
+          Certification::ReviewUndoer.new(fr, actor: @reviewer).undo!
+        end
+      end
+    end
+  end
+
+  test "undo! refuses a superseded (non-latest) funding request" do
+    old = @project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 2, requested_amount_cents: 3_000, status: :pending
+    )
+    old.update!(reviewer: @reviewer, status: :returned, feedback: "redo")
+    @project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 2, requested_amount_cents: 3_000, status: :pending
+    )
+
+    result = Certification::ReviewUndoer.new(old, actor: @reviewer).undo!
+
+    assert_not result.undone?
+    assert old.reload.returned?, "a superseded review is left exactly as it was"
+  end
+
+  # ---- caching + lock window ---------------------------------------------
+
+  test "preflight caches the grant lookup so repeated renders don't re-hit HCB" do
+    fr = approved_funding_with_grant
+    calls = 0
+
+    Rails.stub(:cache, ActiveSupport::Cache::MemoryStore.new) do
+      HCBService.stub(:show_card_grant, ->(hashid:) { calls += 1; unspent_grant }) do
+        2.times { Certification::ReviewUndoer.new(fr).preflight }
+      end
+    end
+
+    assert_equal 1, calls, "the grant status should be fetched once and served from cache after"
+  end
+
+  test "undo! does not cancel the grant when the lock-time re-check fails" do
+    fr = approved_funding_with_grant
+    undoer = Certification::ReviewUndoer.new(fr, actor: @reviewer)
+    cancel_called = false
+
+    result = HCBService.stub(:show_card_grant, unspent_grant) do
+      HCBService.stub(:cancel_card_grant!, ->(hashid:) { cancel_called = true }) do
+        undoer.stub(:still_undoable?, false) do
+          undoer.undo!
+        end
+      end
+    end
+
+    assert_not result.undone?
+    assert_not cancel_called, "the grant must not be cancelled once the lock-time re-check fails"
+    assert fr.reload.approved?, "a re-check failure leaves the verdict intact"
+    assert_equal "build", @project.reload.hardware_stage
+  end
+
+  # ---- ship undo! --------------------------------------------------------
+
+  test "undo! reverses an approved ship and deletes the auto-created YSWS review" do
+    cert, ship_event = approved_ship
+
+    assert @project.reload.ship_status == "approved"
+    assert_equal "approved", ship_event.reload.certification_status
+    ysws = Certification::Ysws.find_by(ship_cert_id: cert.id)
+    assert ysws, "approving a ship should have created a YSWS review"
+
+    result = Certification::ReviewUndoer.new(cert, actor: @reviewer).undo!
+
+    assert result.undone?
+    # Withdrawn, not pending: the ship leaves the reviewer queue and the pending
+    # guards so the builder re-submits rather than the reviewer re-deciding.
+    assert cert.reload.withdrawn?, "the undone ship review is withdrawn, not left pending"
+    assert_equal "pending", ship_event.reload.certification_status
+    assert_equal "draft", @project.reload.ship_status, "the project is un-submitted, not auto-queued"
+    assert_nil @project.shipped_at, "shipped_at is cleared so the ship reads as withdrawn"
+    assert_not @project.awaiting_ship_review?, "no pending review remains to block a manual re-ship"
+    assert_nil Certification::Ysws.find_by(id: ysws.id), "the auto-created YSWS review should be gone"
+  end
+
+  test "undo! blocks a ship whose hardware mission rewards were granted" do
+    cert = approved_hardware_mission_ship
+
+    pf = Certification::ReviewUndoer.new(cert).preflight
+    assert_not pf.undoable?
+    reward = pf.effects.find { |e| e.effect == :mission_reward }
+    assert_equal :block, reward.action
+
+    result = Certification::ReviewUndoer.new(cert, actor: @reviewer).undo!
+    assert_not result.undone?
+    assert cert.reload.approved?
+  end
+
+  private
+
+  def add_devlog(project, phase)
+    devlog = Post::Devlog.new(body: "log", duration_seconds: 3600, phase: phase)
+    devlog.uploading_attachments = true
+    devlog.save!
+    Post.create!(project: project, user: @owner, postable: devlog)
+  end
+
+  def approved_funding_with_grant
+    fr = @project.certification_funding_requests.create!(
+      user: @owner, complexity_tier: 3, requested_amount_cents: 6_000, status: :pending
+    )
+    HCBService.stub(:create_card_grant, { "id" => "cdg_test" }) do
+      fr.update!(reviewer: @reviewer, status: :approved, feedback: "great")
+    end
+    fr.reload
+  end
+
+  PIXEL_PNG = Base64.decode64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=")
+
+  def approved_kit_funding
+    mission = create_mission
+    mission.update!(hardware: true)
+    kit = ShopItem.new(name: "Kit #{SecureRandom.hex(3)}", description: "kit",
+                       ticket_cost: 0, type: "ShopItem::ThirdPartyPhysical", enabled: true, mission_prize_only: true)
+    kit.image.attach(io: StringIO.new(PIXEL_PNG), filename: "kit.png", content_type: "image/png")
+    kit.save!
+    mission.prizes.create!(shop_item: kit, position: 0, category: :after_design)
+    @project.mission_attachments.create!(mission: mission)
+    @kit_item = kit
+
+    fr = @project.certification_funding_requests.create!(user: @owner, status: :pending)
+    fr.update!(reviewer: @reviewer, status: :approved)
+    fr.reload
+  end
+
+  # Places a free order for the kit and records the redemption against the
+  # funding request, standing in for a builder actually claiming their kit.
+  # The order is saved without validation - the shop's order validations are
+  # not what this test exercises, only that a redemption exists.
+  def redeem_kit!(funding_request)
+    order = ShopOrder.new(
+      user: @owner, shop_item: @kit_item, quantity: 1,
+      frozen_item_price: 0, frozen_address: { "line_1" => "1 St", "country" => "US" }
+    )
+    order.save!(validate: false)
+    Mission::PrizeRedemption.record!(shop_order: order, gate: funding_request)
+  end
+
+  def approved_ship
+    project = Project.create!(title: "Ship HW #{SecureRandom.hex(4)}", hardware_stage: "build")
+    project.memberships.create!(user: @owner, role: :owner)
+    @project = project
+    ship_event = Post::ShipEvent.create!(body: "Ship it", uploading_attachments: true, hours_at_ship: 5)
+    Post.create!(project: project, user: @owner, postable: ship_event)
+    project.update_columns(ship_status: "submitted", shipped_at: Time.current)
+    cert = project.ship_reviews.create!(status: :pending, post_ship_event: ship_event)
+    cert.update!(status: :approved, reviewer: @reviewer)
+    [ cert.reload, ship_event ]
+  end
+
+  def approved_hardware_mission_ship
+    project = Project.create!(title: "MissionShip #{SecureRandom.hex(4)}", hardware_stage: "build")
+    project.memberships.create!(user: @owner, role: :owner)
+    @project = project
+    mission = create_mission
+    mission.update!(hardware: true, achievement_name: "Done")
+    project.mission_attachments.create!(mission: mission)
+    ship_event = Post::ShipEvent.create!(body: "Shipped!", uploading_attachments: true, hours_at_ship: 3)
+    project.posts.create!(user: @owner, postable: ship_event)
+    project.update_columns(ship_status: "submitted", shipped_at: Time.current)
+    submission = Mission::Submission.create!(ship_event: ship_event, mission: mission, payout_path: "voting")
+    cert = project.ship_reviews.create!(status: :pending, post_ship_event: ship_event)
+    cert.update!(status: :approved, reviewer: @reviewer)
+    assert submission.reload.approved?, "setup: hardware mission submission should be approved"
+    cert.reload
+  end
+end


### PR DESCRIPTION
## what's this do?

there are cases where a review is later noticed it needs to be removed. this could not be achieved. this adds the ability for admins to undo reviews.

## show it works

<img width="1266" height="330" alt="image" src="https://github.com/user-attachments/assets/08706aa3-6f6d-4645-bacf-fb2666be5906" />
<img width="868" height="953" alt="image" src="https://github.com/user-attachments/assets/bac24316-20b1-421d-8cdd-9a59452b9320" />
<img width="1123" height="220" alt="image" src="https://github.com/user-attachments/assets/e3295372-3907-447b-a336-22f90344b90a" />

https://github.com/user-attachments/assets/131c7189-a385-454f-9ed6-7a4a93d7d529

## ai?

opus 4.8