### PR TITLE
fix(hardware): persist review skips

### DIFF
--- a/app/controllers/admin/certification/application_controller.rb
+++ b/app/controllers/admin/certification/application_controller.rb
@@ -3,7 +3,8 @@ class Admin::Certification::ApplicationController < Admin::ApplicationController
   # global dash and the funding/ship verdict controllers use the global routes;
   # the per-mission dash overrides them (see Admin::Missions::HardwareReviews).
   helper_method :hardware_review_path, :hardware_queue_path, :hardware_next_path,
-                :hardware_queue_title, :hardware_back_link, :hardware_flag_for_fraud_path
+                :hardware_skip_path, :hardware_queue_title, :hardware_back_link,
+                :hardware_flag_for_fraud_path
 
   private
 
@@ -21,6 +22,10 @@ class Admin::Certification::ApplicationController < Admin::ApplicationController
 
   def hardware_next_path(stage:, skip: nil)
     next_admin_certification_hardware_reviews_path(stage: stage, skip: skip)
+  end
+
+  def hardware_skip_path(stage:)
+    skip_admin_certification_hardware_reviews_path(stage: stage)
   end
 
   def hardware_queue_title(design)

--- a/app/controllers/admin/missions/hardware_reviews_controller.rb
+++ b/app/controllers/admin/missions/hardware_reviews_controller.rb
@@ -53,6 +53,10 @@ module Admin
         next_admin_mission_hardware_reviews_path(@mission.slug, stage: stage, skip: skip)
       end
 
+      def hardware_skip_path(stage:)
+        skip_admin_mission_hardware_reviews_path(@mission.slug, stage: stage)
+      end
+
       def hardware_queue_title(design)
         "#{@mission.name} #{design ? 'design' : 'build'} review queue"
       end

--- a/app/controllers/concerns/hardware_review_queue.rb
+++ b/app/controllers/concerns/hardware_review_queue.rb
@@ -20,7 +20,8 @@ module HardwareReviewQueue
     before_action :set_body_class
     before_action :release_other_claims, only: [ :next ]
     helper_method :hardware_review_path, :hardware_queue_path, :hardware_next_path,
-                  :hardware_queue_title, :hardware_back_link, :hardware_flag_for_fraud_path
+                  :hardware_skip_path, :hardware_queue_title, :hardware_back_link,
+                  :hardware_flag_for_fraud_path
   end
 
   def design
@@ -53,6 +54,20 @@ module HardwareReviewQueue
     else
       redirect_to hardware_next_path(stage: stage, skip: (skip[:tokens] + [ candidate[:token] ]).join(","))
     end
+  end
+
+  # A reviewer passing on a submission. Records a per-reviewer skip so the queue
+  # keeps it out of *their* next-up for the cooldown window, then rejoins the
+  # normal `next` flow — whose release_other_claims hands the claim back so
+  # another reviewer can pick it up right away.
+  def skip
+    authorize_hardware_queue
+
+    stage = params[:stage].presence_in(%w[design build]) || "design"
+    record = skip_target
+    ::Certification::ReviewSkip.record!(user: current_user, reviewable: record) if record
+
+    redirect_to hardware_next_path(stage: stage)
   end
 
   def show
@@ -216,11 +231,13 @@ module HardwareReviewQueue
   end
 
   def hardware_funding_scope
-    ::Certification::FundingRequest.available_for(current_user).joins(:project).where(project: reviewable_projects)
+    ::Certification::FundingRequest.available_for(current_user).not_skipped_by(current_user)
+      .joins(:project).where(project: reviewable_projects)
   end
 
   def hardware_ship_scope
-    ::Certification::Ship.available_for(current_user).joins(:project).where(project: reviewable_projects)
+    ::Certification::Ship.available_for(current_user).not_skipped_by(current_user)
+      .joins(:project).where(project: reviewable_projects)
   end
 
   def hardware_funding_list_scope
@@ -315,6 +332,15 @@ module HardwareReviewQueue
     Date.parse(value.to_s)
   rescue ArgumentError, TypeError
     nil
+  end
+
+  # The submission behind a "funding:ID" / "ship:ID" skip token.
+  def skip_target
+    type, id = params[:token].to_s.split(":", 2)
+    case type
+    when "funding" then ::Certification::FundingRequest.find_by(id: id)
+    when "ship" then ::Certification::Ship.find_by(id: id)
+    end
   end
 
   def parse_skip_tokens

--- a/app/models/certification/review_skip.rb
+++ b/app/models/certification/review_skip.rb
@@ -1,0 +1,49 @@
+# == Schema Information
+#
+# Table name: certification_review_skips
+#
+#  id              :bigint           not null, primary key
+#  reviewable_type :string           not null
+#  skipped_at      :datetime         not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  reviewable_id   :bigint           not null
+#  user_id         :bigint           not null
+#
+# Indexes
+#
+#  index_certification_review_skips_on_reviewable  (reviewable_type,reviewable_id)
+#  index_certification_review_skips_on_user_id     (user_id)
+#  index_review_skips_unique_reviewer_reviewable   (user_id,reviewable_type,reviewable_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+module Certification
+  # A reviewer's decision to pass on a submission for now. Persisted per
+  # (reviewer, submission) so the hardware queue can keep a skipped submission
+  # out of *that* reviewer's next-up for a cooldown window, while other
+  # reviewers can still pick it up immediately. Re-skipping refreshes the clock.
+  class ReviewSkip < ApplicationRecord
+    self.table_name = "certification_review_skips"
+
+    # How long a skip keeps a submission out of the skipper's queue.
+    SKIP_COOLDOWN = 3.hours
+
+    belongs_to :user
+    belongs_to :reviewable, polymorphic: true
+
+    # Skips still inside their cooldown window.
+    scope :active, -> { where(skipped_at: SKIP_COOLDOWN.ago..) }
+
+    # Records (or refreshes) this reviewer's skip of this submission. Kept to one
+    # row per pair by the unique index, so re-skipping just restarts the clock.
+    def self.record!(user:, reviewable:)
+      skip = find_or_initialize_by(user: user, reviewable: reviewable)
+      skip.skipped_at = Time.current
+      skip.save!
+      skip
+    end
+  end
+end

--- a/app/models/concerns/certification/reviewable.rb
+++ b/app/models/concerns/certification/reviewable.rb
@@ -52,6 +52,18 @@ module Certification
           .update_all(reviewer_id: nil, claim_expires_at: nil, updated_at: Time.current)
       end
 
+      # Drops the submissions this reviewer skipped within the cooldown window.
+      # Per-reviewer: another reviewer's queue is unaffected, so a skip hides a
+      # submission from the skipper without taking it out of circulation.
+      def not_skipped_by(user)
+        return all if user.blank?
+
+        skipped = Certification::ReviewSkip.active
+          .where(user_id: user.id, reviewable_type: polymorphic_name)
+          .select(:reviewable_id)
+        where.not(id: skipped)
+      end
+
       # Records this queue may hand out next. Defaults to everything claimable;
       # override to narrow when one model backs more than one queue.
       def next_eligible_scope(user)

--- a/app/policies/admin/certification/hardware_review_policy.rb
+++ b/app/policies/admin/certification/hardware_review_policy.rb
@@ -21,6 +21,10 @@ class Admin::Certification::HardwareReviewPolicy < ApplicationPolicy
     index?
   end
 
+  def skip?
+    index?
+  end
+
   def show?
     user&.can_review? && not_own_project?
   end

--- a/app/views/admin/certification/funding_requests/_form.html.erb
+++ b/app/views/admin/certification/funding_requests/_form.html.erb
@@ -8,6 +8,14 @@
   <% end %>
 <% end %>
 
+<%# Skip form, rendered outside the verdict form for the same nesting reason as
+    unclaim; the button in the actions row submits it via the `form` attribute.
+    A persisted skip keeps this request out of the reviewer's next-up for the
+    cooldown window instead of bouncing them straight back to it. %>
+<%= form_with url: hardware_skip_path(stage: "design"), method: :post, id: "skip-form-#{funding_request.id}" do %>
+  <%= hidden_field_tag :token, "funding:#{funding_request.id}" %>
+<% end %>
+
 <%= form_with model: funding_request, url: admin_certification_funding_request_path(funding_request), method: :patch, class: "review-form", multipart: true do |f| %>
 <% if local_assigns[:redirect_to_hardware] %>
   <%# Sends the verdict back to the combined hardware review page. %>
@@ -102,8 +110,8 @@
 
   <div class="review-form__actions">
     <%= f.submit "Submit verdict", class: "action-btn action-btn--large action-btn--primary" %>
-    <%= link_to "Skip and get next", hardware_next_path(stage: "design", skip: "funding:#{funding_request.id}"),
-          class: "action-btn action-btn--small action-btn--secondary" %>
+    <button type="submit" form="skip-form-<%= funding_request.id %>"
+            class="action-btn action-btn--small action-btn--secondary">Skip and get next</button>
     <%= link_to "Back to queue", hardware_queue_path("design"), class: "review-form__back" %>
   </div>
 <% end %>

--- a/app/views/admin/certification/ships/_form.html.erb
+++ b/app/views/admin/certification/ships/_form.html.erb
@@ -8,6 +8,16 @@
   <% end %>
 <% end %>
 
+<%# Skip form (hardware queue only), rendered outside the verdict form for the
+    same nesting reason as unclaim; the button in the actions row submits it via
+    the `form` attribute. A persisted skip keeps this ship out of the reviewer's
+    next-up for the cooldown window instead of bouncing them straight back. %>
+<% if local_assigns[:redirect_to_hardware] %>
+  <%= form_with url: hardware_skip_path(stage: "build"), method: :post, id: "skip-form-#{ship.id}" do %>
+    <%= hidden_field_tag :token, "ship:#{ship.id}" %>
+  <% end %>
+<% end %>
+
 <div data-controller="certification--verdict-preview"
      data-action="submit->certification--verdict-preview#intercept">
 
@@ -125,8 +135,8 @@
     <%= f.submit "Submit verdict", class: "action-btn action-btn--large action-btn--primary",
           data: { "certification--video-drop-target": "submitBtn" } %>
     <% if local_assigns[:redirect_to_hardware] %>
-      <%= link_to "Skip and get next", hardware_next_path(stage: "build", skip: "ship:#{ship.id}"),
-            class: "action-btn action-btn--small action-btn--secondary" %>
+      <button type="submit" form="skip-form-<%= ship.id %>"
+              class="action-btn action-btn--small action-btn--secondary">Skip and get next</button>
     <% else %>
       <%= link_to "Skip and get next", next_admin_certification_ships_path(skip: ship.id),
             class: "action-btn action-btn--small action-btn--secondary" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -841,6 +841,7 @@ Rails.application.routes.draw do
           get :design
           get :build
           get :next
+          post :skip
         end
         post :flag_for_fraud, on: :member
       end
@@ -891,6 +892,7 @@ Rails.application.routes.draw do
           get :design
           get :build
           get :next
+          post :skip
         end
         post :flag_for_fraud, on: :member
       end

--- a/db/migrate/20260825002911_create_certification_review_skips.rb
+++ b/db/migrate/20260825002911_create_certification_review_skips.rb
@@ -1,0 +1,18 @@
+class CreateCertificationReviewSkips < ActiveRecord::Migration[8.1]
+  def change
+    create_table :certification_review_skips do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :reviewable, polymorphic: true, null: false
+      t.datetime :skipped_at, null: false
+
+      t.timestamps
+    end
+
+    # One skip row per reviewer per submission; re-skipping refreshes skipped_at
+    # rather than piling up rows. Also serves the per-reviewer cooldown lookup.
+    add_index :certification_review_skips,
+              [ :user_id, :reviewable_type, :reviewable_id ],
+              unique: true,
+              name: "index_review_skips_unique_reviewer_reviewable"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_24_163145) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_25_002911) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
@@ -232,6 +232,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_24_163145) do
     t.datetime "updated_at", null: false
     t.bigint "ysws_review_id", null: false
     t.index ["ysws_review_id"], name: "index_certification_mac_analyses_on_ysws_review_id", unique: true
+  end
+
+  create_table "certification_review_skips", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "reviewable_id", null: false
+    t.string "reviewable_type", null: false
+    t.datetime "skipped_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["reviewable_type", "reviewable_id"], name: "index_certification_review_skips_on_reviewable"
+    t.index ["user_id", "reviewable_type", "reviewable_id"], name: "index_review_skips_unique_reviewer_reviewable", unique: true
+    t.index ["user_id"], name: "index_certification_review_skips_on_user_id"
   end
 
   create_table "certification_ship_reviews", force: :cascade do |t|
@@ -1688,6 +1700,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_24_163145) do
   add_foreign_key "certification_integrities", "users", column: "claimed_by_id"
   add_foreign_key "certification_integrities", "users", column: "reviewer_id"
   add_foreign_key "certification_mac_analyses", "certification_ysws_reviews", column: "ysws_review_id"
+  add_foreign_key "certification_review_skips", "users"
   add_foreign_key "certification_ship_reviews", "post_ship_events", on_delete: :nullify
   add_foreign_key "certification_ship_reviews", "projects"
   add_foreign_key "certification_ship_reviews", "users", column: "reviewer_id"

--- a/test/controllers/admin/certification/hardware_reviews_controller_test.rb
+++ b/test/controllers/admin/certification/hardware_reviews_controller_test.rb
@@ -316,6 +316,86 @@ class Admin::Certification::HardwareReviewsControllerTest < ActionDispatch::Inte
     assert_response :forbidden
   end
 
+  # Skipping a build review records a per-reviewer skip and moves on, rather
+  # than bouncing the reviewer straight back to the same submission.
+  test "skipping a build review records a skip and advances" do
+    post skip_admin_certification_hardware_reviews_path, params: { stage: "build", token: "ship:#{@ship.id}" }
+
+    assert ::Certification::ReviewSkip.exists?(user: @reviewer, reviewable: @ship)
+    assert_redirected_to next_admin_certification_hardware_reviews_path(stage: "build")
+  end
+
+  test "skipping a design review records a skip and advances" do
+    post skip_admin_certification_hardware_reviews_path, params: { stage: "design", token: "funding:#{@funding.id}" }
+
+    assert ::Certification::ReviewSkip.exists?(user: @reviewer, reviewable: @funding)
+    assert_redirected_to next_admin_certification_hardware_reviews_path(stage: "design")
+  end
+
+  # The whole point of the fix: a skipped build review is not handed back to the
+  # skipper (their only build item is now hidden, so the queue is empty), but a
+  # different reviewer is still offered it right away.
+  test "a skipped build review is hidden from the skipper yet offered to others" do
+    ::Certification::ReviewSkip.record!(user: @reviewer, reviewable: @ship)
+
+    get next_admin_certification_hardware_reviews_path(stage: "build")
+    assert_redirected_to build_admin_certification_hardware_reviews_path
+
+    sign_in other_reviewer
+    get next_admin_certification_hardware_reviews_path(stage: "build")
+    assert_redirected_to admin_certification_hardware_review_path(@build_project)
+  end
+
+  # End to end through the button: skipping a review you hold hands the claim
+  # back (via next's release), so another reviewer is offered it right away.
+  test "skipping a claimed build review releases it for another reviewer" do
+    ::Certification::Ship.atomic_claim!(@ship.id, @reviewer)
+
+    post skip_admin_certification_hardware_reviews_path, params: { stage: "build", token: "ship:#{@ship.id}" }
+    follow_redirect!
+
+    assert_nil @ship.reload.reviewer_id, "skipping must hand the claim back"
+    assert ::Certification::Ship.available_for(other_reviewer).exists?(id: @ship.id)
+  end
+
+  test "a skipped design review is hidden from the skipper" do
+    ::Certification::ReviewSkip.record!(user: @reviewer, reviewable: @funding)
+
+    get next_admin_certification_hardware_reviews_path(stage: "design")
+    assert_redirected_to design_admin_certification_hardware_reviews_path
+  end
+
+  # The skip is a cooldown, not a permanent pass: once it lapses the submission
+  # comes back to the reviewer.
+  test "a skip stops hiding the review once its cooldown lapses" do
+    ::Certification::ReviewSkip.record!(user: @reviewer, reviewable: @ship)
+
+    travel_to(::Certification::ReviewSkip::SKIP_COOLDOWN.from_now + 1.minute) do
+      get next_admin_certification_hardware_reviews_path(stage: "build")
+      assert_redirected_to admin_certification_hardware_review_path(@build_project)
+    end
+  end
+
+  test "a claimed build review offers a skip button posting to the skip path" do
+    ::Certification::Ship.atomic_claim!(@ship.id, @reviewer)
+
+    get admin_certification_hardware_review_path(@build_project)
+
+    assert_response :success
+    assert_select "button[form=?]", "skip-form-#{@ship.id}", count: 1
+    assert_select "form[action=?]", skip_admin_certification_hardware_reviews_path(stage: "build")
+  end
+
+  test "a claimed design review offers a skip button posting to the skip path" do
+    ::Certification::FundingRequest.atomic_claim!(@funding.id, @reviewer)
+
+    get admin_certification_hardware_review_path(@design_project)
+
+    assert_response :success
+    assert_select "button[form=?]", "skip-form-#{@funding.id}", count: 1
+    assert_select "form[action=?]", skip_admin_certification_hardware_reviews_path(stage: "design")
+  end
+
   test "the review page shows a flag-for-fraud button when the project is not flagged" do
     ::Certification::FundingRequest.atomic_claim!(@funding.id, @reviewer)
 

--- a/test/models/certification/review_skip_test.rb
+++ b/test/models/certification/review_skip_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+
+# == Schema Information
+#
+# Table name: certification_review_skips
+#
+#  id              :bigint           not null, primary key
+#  reviewable_type :string           not null
+#  skipped_at      :datetime         not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  reviewable_id   :bigint           not null
+#  user_id         :bigint           not null
+#
+# Indexes
+#
+#  index_certification_review_skips_on_reviewable  (reviewable_type,reviewable_id)
+#  index_certification_review_skips_on_user_id     (user_id)
+#  index_review_skips_unique_reviewer_reviewable   (user_id,reviewable_type,reviewable_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class Certification::ReviewSkipTest < ActiveSupport::TestCase
+  setup do
+    @reviewer = create_user(slack_id: "U_SKIP_REV", display_name: "skip-reviewer")
+    @ship = ::Certification::Ship.create!(project: Project.create!(title: "Skip bot"), status: :pending)
+  end
+
+  test "record! stamps a skip for the reviewer and submission" do
+    freeze_time do
+      skip = ::Certification::ReviewSkip.record!(user: @reviewer, reviewable: @ship)
+
+      assert_equal @reviewer, skip.user
+      assert_equal @ship, skip.reviewable
+      assert_equal Time.current, skip.skipped_at
+    end
+  end
+
+  test "record! refreshes the clock instead of piling up rows" do
+    first = travel_to(3.hours.ago) { ::Certification::ReviewSkip.record!(user: @reviewer, reviewable: @ship) }
+
+    assert_no_difference -> { ::Certification::ReviewSkip.count } do
+      ::Certification::ReviewSkip.record!(user: @reviewer, reviewable: @ship)
+    end
+    assert_operator first.reload.skipped_at, :>, 1.minute.ago
+  end
+
+  test "active excludes skips older than the cooldown" do
+    fresh = ::Certification::ReviewSkip.record!(user: @reviewer, reviewable: @ship)
+    stale_ship = ::Certification::Ship.create!(project: Project.create!(title: "Stale bot"), status: :pending)
+    stale = travel_to((::Certification::ReviewSkip::SKIP_COOLDOWN + 1.minute).ago) do
+      ::Certification::ReviewSkip.record!(user: @reviewer, reviewable: stale_ship)
+    end
+
+    active_ids = ::Certification::ReviewSkip.active.pluck(:id)
+    assert_includes active_ids, fresh.id
+    assert_not_includes active_ids, stale.id
+  end
+
+  test "not_skipped_by hides a recently skipped submission from that reviewer only" do
+    ::Certification::ReviewSkip.record!(user: @reviewer, reviewable: @ship)
+    other = create_user(slack_id: "U_SKIP_REV2", display_name: "skip-reviewer-2")
+
+    assert_not ::Certification::Ship.not_skipped_by(@reviewer).exists?(id: @ship.id)
+    assert ::Certification::Ship.not_skipped_by(other).exists?(id: @ship.id)
+  end
+
+  test "not_skipped_by offers a submission again once its skip has expired" do
+    travel_to((::Certification::ReviewSkip::SKIP_COOLDOWN + 1.minute).ago) do
+      ::Certification::ReviewSkip.record!(user: @reviewer, reviewable: @ship)
+    end
+
+    assert ::Certification::Ship.not_skipped_by(@reviewer).exists?(id: @ship.id)
+  end
+end


### PR DESCRIPTION
## what's this do?

Skipping a review previously did not work; this persists skips to the database and resets them after 3 hours.

## show it works

https://github.com/user-attachments/assets/ab81bf16-4557-42f6-bc60-e4b31461e5f7

## ai?

opus 4.8