### PR TITLE
fix: preload mission_attachments in showcase_projects to eliminate n+1

### DIFF
--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -369,6 +369,7 @@ class Mission < ApplicationRecord
       .or(Project.where(deleted_at: nil, id: shipped_ids))
       .joins("LEFT JOIN (#{devlog_likes.to_sql}) mission_devlog_likes ON mission_devlog_likes.project_id = projects.id")
       .left_joins(:project_follows, :banner_attachment)
+      .includes(mission_attachments: :mission)
       .group("projects.id", "mission_devlog_likes.devlog_likes_count", "active_storage_attachments.id")
       .order(Arel.sql(<<~SQL))
         (active_storage_attachments.id IS NULL) ASC,


### PR DESCRIPTION
## Summary

Adds \.includes(mission_attachments: :mission)\ to the \showcase_projects\ query in the Mission model.

## Problem

The gallery view on mission show pages calls \project.display_banner\ for each project, which internally calls \current_mission_attachment\. Without preloading, this triggers a separate \SELECT\ on \project_mission_attachments\ for every project in the gallery (~48 DB hits per request per the issue description).

## Fix

Preloading \mission_attachments: :mission\ ensures:
1. \current_mission_attachment\ uses the in-memory collection (already checks \mission_attachments.loaded?\)
2. The \.mission\ association is also loaded, avoiding a secondary n+1 when \current_mission\ is called

## Impact

Reduces DB queries from ~48 to ~2 for the gallery view.

Fixes #1132