### PR TITLE
feat(reports): make all report options except "other" function similar to "should not have been approved"

### DIFF
--- a/app/controllers/projects/reports_controller.rb
+++ b/app/controllers/projects/reports_controller.rb
@@ -3,7 +3,7 @@ class Projects::ReportsController < ApplicationController
     authorize :report
     @project = ::Project.find(params[:project_id])
 
-    return flag_should_not_have_been_approved if report_params[:reason] == Project::Report::SHOULD_NOT_HAVE_BEEN_APPROVED_REASON
+    return flag_via_slack if Project::Report::SLACK_ONLY_REASONS.include?(report_params[:reason])
 
     if current_user.reports.exists?(project: @project)
       redirect_back_or_to project_path(@project), alert: "You have already reported this project."
@@ -21,8 +21,8 @@ class Projects::ReportsController < ApplicationController
 
   private
 
-    def flag_should_not_have_been_approved
-      result = Project::Report.flag_should_not_have_been_approved!(project: @project, reporter: current_user, details: report_params[:details])
+    def flag_via_slack
+      result = Project::Report.flag_via_slack!(project: @project, reporter: current_user, details: report_params[:details], reason: report_params[:reason])
 
       case result
       when :ok

--- a/app/models/project/report.rb
+++ b/app/models/project/report.rb
@@ -44,8 +44,11 @@ class Project::Report < ApplicationRecord
 
     DETAILS_MIN_LENGTH = 20
 
-    # excluded from REASONS on purpose — never saved as a Project::Report row
+    # These four never save a Project::Report row — Slack-only ping instead.
+    # The other three stay in REASONS/USER_REASONS (unlike this one) so admin
+    # views can still filter historical rows.
     SHOULD_NOT_HAVE_BEEN_APPROVED_REASON = "should_not_have_been_approved"
+    SLACK_ONLY_REASONS = [ "low_effort", "undeclared_ai", "demo_broken", SHOULD_NOT_HAVE_BEEN_APPROVED_REASON ].freeze
     SHOULD_NOT_HAVE_BEEN_APPROVED_CHANNEL =
       Rails.application.credentials.dig(:slack, :should_not_have_been_approved_channel) ||
       ENV["SHOULD_NOT_HAVE_BEEN_APPROVED_SLACK_CHANNEL"] ||
@@ -68,42 +71,46 @@ class Project::Report < ApplicationRecord
       "low_effort" => "Low-effort project",
       "undeclared_ai" => "Uses AI but it's undeclared",
       "demo_broken" => "Demo does not work",
-      "other" => "Other"
+      "other" => "Other",
+      SHOULD_NOT_HAVE_BEEN_APPROVED_REASON => "Project should not have been approved"
     }.freeze
 
     def reason_label
       REASON_LABELS.fetch(reason, reason.humanize)
     end
 
-    # Returns :ok, :details_too_short, :not_allowed (reporter is a project
-    # member), :not_approved, or :throttled (already flagged this approval).
-    def self.flag_should_not_have_been_approved!(project:, reporter:, details:)
+    # Returns :ok, :details_too_short, :not_allowed, :not_approved, or :throttled.
+    def self.flag_via_slack!(project:, reporter:, details:, reason:)
       details = details.to_s.strip
       return :details_too_short if details.length < DETAILS_MIN_LENGTH
       return :not_allowed if !Rails.env.development? && project.users.include?(reporter)
 
       latest_approval = project.ship_reviews.approved.order(Arel.sql("decided_at DESC NULLS LAST"), id: :desc).first
-      return :not_approved unless latest_approval
+      return :not_approved if reason == SHOULD_NOT_HAVE_BEEN_APPROVED_REASON && latest_approval.nil?
 
-      # Tied to the approval, not just (project, reporter), so a re-approval
-      # within the window doesn't swallow a legitimate new flag. Checked as a
-      # plain exists? first — an outage making `write` return falsy shouldn't
-      # be indistinguishable from "already flagged" and silently drop a report.
-      cache_key = "project_report/should_not_have_been_approved/#{latest_approval.id}/#{reporter.id}"
+      # exists? checked before write so a cache outage fails open, not throttled.
+      cache_scope = reason == SHOULD_NOT_HAVE_BEEN_APPROVED_REASON ? latest_approval.id : project.id
+      cache_key = "project_report/slack_flag/#{reason}/#{cache_scope}/#{reporter.id}"
       return :throttled if Rails.cache.exist?(cache_key)
       Rails.cache.write(cache_key, true, expires_in: SHOULD_NOT_HAVE_BEEN_APPROVED_THROTTLE)
 
-      reviewer = latest_approval.reviewer
+      reviewer = latest_approval&.reviewer
 
       Rails.logger.info(
-        "[Project::Report] should_not_have_been_approved flag: project=#{project.id} reporter=#{reporter.id} reviewer=#{reviewer&.id || 'none'}"
+        "[Project::Report] slack_flag (#{reason}): project=#{project.id} reporter=#{reporter.id} reviewer=#{reviewer&.id || 'none'}"
       )
 
       SendSlackDmJob.perform_later(
         SHOULD_NOT_HAVE_BEEN_APPROVED_CHANNEL,
-        "Ship approval flagged",
-        blocks_path: "notifications/reports/should_not_have_been_approved_slack_message",
-        locals: { project: project, reporter: reporter, reviewer: reviewer, details: details.truncate(SHOULD_NOT_HAVE_BEEN_APPROVED_DETAILS_MAX_LENGTH, omission: "") },
+        "Project flagged",
+        blocks_path: "notifications/reports/project_flagged_slack_message",
+        locals: {
+          project: project,
+          reporter: reporter,
+          reviewer: reviewer,
+          reason_label: REASON_LABELS.fetch(reason, reason.humanize),
+          details: details.truncate(SHOULD_NOT_HAVE_BEEN_APPROVED_DETAILS_MAX_LENGTH, omission: "")
+        },
         unfurl_links: false,
         unfurl_media: false
       )

--- a/app/views/notifications/reports/project_flagged_slack_message.slack_message.slocks
+++ b/app/views/notifications/reports/project_flagged_slack_message.slack_message.slocks
@@ -8,9 +8,9 @@ owner = project.memberships.owner.first&.user
 owner_slack_id = owner&.slack_id
 owner_mention = owner_slack_id.present? ? "<@#{owner_slack_id}>" : (owner&.display_name || "Unknown")
 
-header "Ship Approval Flagged"
+header "Project Flagged"
 
-section "*<https://stardance.hackclub.com/projects/#{project.id}|#{project.title}>* was flagged: \"Project should not have been approved\"", markdown: true
+section "*<https://stardance.hackclub.com/projects/#{project.id}|#{project.title}>* was flagged: \"#{reason_label}\"", markdown: true
 
 section "Most recent approving reviewer: #{reviewer_mention}", markdown: true
 


### PR DESCRIPTION
## what's this do?

Makes all reports except "other" instead of creating an on platform report but send it to the shipwrights team channel to be looked at similar to the "should not have been approved" button.

## show it works

<img width="1317" height="683" alt="image" src="https://github.com/user-attachments/assets/c0ca3bee-227c-4ceb-8ab4-6c2f0324a9db" />


## ai?

claude