### PR TITLE
feat(projects): freeze project info editing while a ship is pending review

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -39,6 +39,7 @@ class ProjectsController < ApplicationController
     @is_member = current_user && @members.include?(current_user)
     @active_nav_slug = @is_member ? "projects" : "home"
     @can_edit_project = policy(@project).update?
+    @is_owner = current_user && @project.memberships.exists?(user_id: current_user.id, role: :owner)
     @admin_editing_project = !@is_member && current_user&.admin?
     @follower_count = @project.project_follows.size
     @viewer_follow = current_user && @project.project_follows.find_by(user_id: current_user.id)

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -12,11 +12,11 @@ class ProjectPolicy < ApplicationPolicy
     end
 
     def edit?
-        owns? || user&.admin?
+        editable_by_owner? || user&.admin?
     end
 
     def update?
-        owns? || user&.admin?
+        editable_by_owner? || user&.admin?
     end
 
     def destroy?
@@ -74,5 +74,9 @@ class ProjectPolicy < ApplicationPolicy
     def owns?
         return false unless user && record
         user.memberships.exists?(project: record, role: "owner")
+    end
+
+    def editable_by_owner?
+        owns? && !record.awaiting_ship_review?
     end
 end

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -20,6 +20,7 @@
   viewer_follow = @viewer_follow
   total_hours = @total_hours || (@project.duration_seconds / 3600.0).round
   can_edit_project = @can_edit_project
+  is_owner = @is_owner
   admin_editing_project = @admin_editing_project
   # Only highlight the unfinished sections when the user arrived via the
   # "Complete project info" button (which adds ?complete=1).
@@ -498,6 +499,13 @@
                   <% else %>
                     <%= edit_project_link %>
                   <% end %>
+                <% elsif is_owner && !can_edit_project %>
+                  <button type="button" class="project-show__pill project-show__pill--outline" aria-disabled="true"
+                          data-controller="tooltip"
+                          data-tooltip-message-value="Your project is under review. Editing is locked until it's decided."
+                          data-tooltip-position-value="top">
+                    Edit project
+                  </button>
                 <% end %>
 
                 <% if current_user && !is_member %>


### PR DESCRIPTION

## what's this do?

blocks user from updating project information whilst the project is in a pending state

## show it works

<img width="437" height="183" alt="image" src="https://github.com/user-attachments/assets/72e51718-2ea2-4725-b2b7-32dda587ac03" />


## ai?

claude
