### PR TITLE
feat(certification): link to individual lapses on telescreen & bucket them with their devlogs

### DIFF
--- a/app/assets/stylesheets/pages/admin/_ysws_reviews.scss
+++ b/app/assets/stylesheets/pages/admin/_ysws_reviews.scss
@@ -1635,6 +1635,31 @@ body:has(.certification-ysws) {
       }
     }
 
+    .devlog-recordings-section {
+      padding-top: var(--space-m);
+      border-top: 1px solid var(--color-space-border);
+
+      // The shared recordings partial wraps itself in .ship-review__panel card
+      // chrome (surface + large heading). Nested inside a devlog that reads as
+      // a competing card, so strip it back to a compact, labelled gallery that
+      // matches the git/media labels above it.
+      .recording-gallery {
+        padding: 0;
+        background: none;
+        border: none;
+      }
+
+      .ship-review__panel-title {
+        margin: 0 0 var(--space-xs);
+        color: var(--color-space-text-muted);
+        font-family: var(--font-family-sans);
+        font-size: var(--font-size-xs);
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+    }
+
     .empty-devlogs {
       text-align: center;
       padding: var(--space-xxl);

--- a/app/assets/stylesheets/pages/certification/_recording_gallery.scss
+++ b/app/assets/stylesheets/pages/certification/_recording_gallery.scss
@@ -93,4 +93,26 @@
     color: var(--color-space-text-muted, rgba(255, 255, 255, 0.7));
     font-size: 0.8rem;
   }
+
+  // "Open in Telescreen" deep-link on Lapse recordings — a small mint pill,
+  // matching the &__source badge tone but as an actionable outline button.
+  &__telescreen {
+    align-self: flex-start;
+    margin-top: 0.15rem;
+    padding: 0.1rem 0.5rem;
+    border: 1px solid var(--color-brand-mint);
+    border-radius: 999px;
+    color: var(--color-brand-mint);
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition:
+      background 0.15s ease,
+      color 0.15s ease;
+
+    &:hover {
+      background: var(--color-brand-mint);
+      color: var(--color-space-bg);
+    }
+  }
 }

--- a/app/controllers/admin/certification/ysws_controller.rb
+++ b/app/controllers/admin/certification/ysws_controller.rb
@@ -136,8 +136,17 @@ class Admin::Certification::YswsController < Admin::Certification::ApplicationCo
 
     @lapse_timelapses = lapse_timelapses_for_ysws_review
     @lookout_recordings = lookout_recordings_for_ysws_review
+    # Owner Hackatime uid for Telescreen deep-links on Lapse recordings.
+    @lapse_owner_uid = @review.project.memberships.owner.first&.user&.hackatime_identity&.uid
 
     @devlog_windows = devlog_windows_for_review(@review)
+    # Attach each timelapse to the devlog whose time window it was recorded in,
+    # so a reviewer sees the recordings that produced a devlog's logged time
+    # right beside it. The top gallery still lists every lapse.
+    @devlog_lapses = ::Certification::DevlogLapseBucketer.call(
+      timelapses: @lapse_timelapses,
+      windows:    @devlog_windows
+    )
     @devlog_commits = begin
       load_commits_with_stats(
         @devlog_windows,

--- a/app/controllers/concerns/hardware_review_queue.rb
+++ b/app/controllers/concerns/hardware_review_queue.rb
@@ -203,6 +203,8 @@ module HardwareReviewQueue
     @funding_request = @project.latest_funding_request
     @ship = @project.latest_ship_review
     @owner = review_owner
+    # Owner Hackatime uid for Telescreen deep-links on Lapse recordings.
+    @lapse_owner_uid = @owner&.hackatime_identity&.uid
     @active_review =
       if @funding_request&.pending?
         @funding_request

--- a/app/helpers/telescreen_helper.rb
+++ b/app/helpers/telescreen_helper.rb
@@ -32,6 +32,14 @@ module TelescreenHelper
     "#{telescreen_base_url}/workbench/hackatime?slack=#{ERB::Util.url_encode(slack)}"
   end
 
+  # Deep-links a single Lapse timelapse into Telescreen's lapse workbench, which
+  # keys on the owner's Hackatime uid (u) and the lapse id (t).
+  def telescreen_lapse_url(hackatime_uid:, lapse_id:)
+    return if hackatime_uid.blank? || lapse_id.blank?
+
+    "#{telescreen_base_url}/workbench/lapse?u=#{ERB::Util.url_encode(hackatime_uid.to_s)}&t=#{ERB::Util.url_encode(lapse_id.to_s)}"
+  end
+
   def displayed_telescreen_url(url)
     uri = URI.parse(url.to_s)
     return url unless uri.is_a?(URI::HTTP) && uri.host.present?

--- a/app/services/certification/devlog_lapse_bucketer.rb
+++ b/app/services/certification/devlog_lapse_bucketer.rb
@@ -1,0 +1,48 @@
+module Certification
+  # Groups Lapse timelapses under the devlog whose time window they fall in, so
+  # a reviewer sees each recording beside the devlog it contributed time to.
+  #
+  # A lapse belongs to the half-open window [since, before) its recording time
+  # (createdAt) lands in — the same rule YswsController buckets commits by, so a
+  # lapse lands under the devlog a commit at that instant would.
+  class DevlogLapseBucketer
+    # timelapses: LapseService hashes, each with :createdAt (epoch milliseconds).
+    # windows:    { post_devlog_id => { since: iso8601, before: iso8601 } }.
+    # Returns:    { post_devlog_id => [timelapse, ...] }, only for devlogs with
+    #             at least one lapse; input order is preserved within a bucket.
+    def self.call(timelapses:, windows:)
+      new(timelapses, windows).call
+    end
+
+    def initialize(timelapses, windows)
+      @timelapses = Array(timelapses)
+      @windows = windows.map do |devlog_id, w|
+        [ devlog_id, Time.parse(w[:since]), Time.parse(w[:before]) ]
+      end
+    end
+
+    def call
+      @timelapses.each_with_object({}) do |tl, buckets|
+        devlog_id = devlog_id_for(tl)
+        (buckets[devlog_id] ||= []) << tl if devlog_id
+      end
+    end
+
+    private
+
+    def devlog_id_for(timelapse)
+      recorded_at = recorded_at_for(timelapse)
+      return nil unless recorded_at
+
+      match = @windows.find { |_id, since, before| recorded_at >= since && recorded_at < before }
+      match&.first
+    end
+
+    def recorded_at_for(timelapse)
+      millis = timelapse[:createdAt]
+      return nil if millis.blank?
+
+      Time.zone.at(millis.to_i / 1000)
+    end
+  end
+end

--- a/app/views/admin/certification/funding_requests/_recording_gallery.html.erb
+++ b/app/views/admin/certification/funding_requests/_recording_gallery.html.erb
@@ -2,7 +2,8 @@
       title:      panel heading
       empty_text: shown when items is blank
       items:      array of { source:, video_url:, poster_url:, processing:,
-                  name:, duration: (seconds), recorded_at: (Time or nil) } %>
+                  name:, duration: (seconds), recorded_at: (Time or nil),
+                  telescreen_url: (optional Telescreen deep-link) } %>
 <div class="ship-review__panel recording-gallery">
   <h2 class="ship-review__panel-title"><%= title %></h2>
 
@@ -33,6 +34,11 @@
               <%= [ format_clock(item[:duration]),
                     (item[:recorded_at] && l(item[:recorded_at].to_date, format: :short)) ].compact.join(" · ") %>
             </span>
+            <% if item[:telescreen_url].present? %>
+              <%= link_to "Open in Telescreen", item[:telescreen_url],
+                    class: "recording-gallery__telescreen",
+                    target: "_blank", rel: "noopener noreferrer" %>
+            <% end %>
           </div>
         </li>
       <% end %>

--- a/app/views/admin/certification/funding_requests/_recordings.html.erb
+++ b/app/views/admin/certification/funding_requests/_recordings.html.erb
@@ -2,7 +2,12 @@
     screen recordings merged into one gallery, newest-first. The capture tool
     doesn't matter to a reviewer, so they're shown as a single list. Locals:
       timelapses: Lapse API hashes (LapseService)
-      recordings: Lookout hashes (LookoutService) %>
+      recordings: Lookout hashes (LookoutService)
+      title:      optional panel heading (default "Recordings")
+      telescreen_uid: optional owner Hackatime uid; when present, each Lapse gets
+                  an "Open in Telescreen" deep-link (Lookout recordings never do) %>
+<% title ||= "Recordings" %>
+<% telescreen_uid ||= nil %>
 <%
   items = Array(timelapses).map do |tl|
     {
@@ -12,7 +17,8 @@
       name: tl[:name].presence || "Untitled recording",
       duration: tl[:duration],
       recorded_at: tl[:createdAt].present? ? Time.zone.at(tl[:createdAt].to_i / 1000) : nil,
-      processing: tl[:visibility] == "FAILED_PROCESSING" ? "Processing failed" : "Still processing…"
+      processing: tl[:visibility] == "FAILED_PROCESSING" ? "Processing failed" : "Still processing…",
+      telescreen_url: telescreen_lapse_url(hackatime_uid: telescreen_uid, lapse_id: tl[:id])
     }
   end
 
@@ -34,6 +40,6 @@
     correctly from controllers outside funding_requests, e.g. the combined
     hardware review page. %>
 <%= render "admin/certification/funding_requests/recording_gallery",
-      title: "Recordings",
+      title: title,
       empty_text: "No recordings found for this project.",
       items: items %>

--- a/app/views/admin/certification/hardware_reviews/show.html.erb
+++ b/app/views/admin/certification/hardware_reviews/show.html.erb
@@ -58,7 +58,8 @@
         <% end %>
 
         <%= render "admin/certification/funding_requests/recordings",
-              timelapses: @lapse_timelapses, recordings: @lookout_recordings %>
+              timelapses: @lapse_timelapses, recordings: @lookout_recordings,
+              telescreen_uid: @lapse_owner_uid %>
 
         <div class="ship-review__panel hardware-review__history-panel">
           <h2 class="ship-review__panel-title">Review history</h2>

--- a/app/views/admin/certification/ysws/_devlog_review.html.erb
+++ b/app/views/admin/certification/ysws/_devlog_review.html.erb
@@ -126,6 +126,18 @@
       </div>
       <%= Certification::CommitGraphBuilder.new(dl_commits).svg %>
     </div>
+
+    <%# Timelapses recorded within this devlog's time window — the recordings
+        that produced its logged time. Only shown when there are any; every
+        lapse still appears in the page-level gallery. %>
+    <% dl_lapses = @devlog_lapses&.dig(devlog_review.post_devlog_id) || [] %>
+    <% if dl_lapses.any? %>
+      <div class="devlog-recordings-section">
+        <%= render "admin/certification/funding_requests/recordings",
+              timelapses: dl_lapses, recordings: [], title: "Timelapses",
+              telescreen_uid: @lapse_owner_uid %>
+      </div>
+    <% end %>
   </div>
 
   <!-- Review Decision Panel -->

--- a/app/views/admin/certification/ysws/show.html.erb
+++ b/app/views/admin/certification/ysws/show.html.erb
@@ -124,7 +124,8 @@
       <!-- Lapse / Lookout Recordings -->
       <section class="review-card recordings-card">
         <%= render "admin/certification/funding_requests/recordings",
-              timelapses: @lapse_timelapses, recordings: @lookout_recordings %>
+              timelapses: @lapse_timelapses, recordings: @lookout_recordings,
+              telescreen_uid: @lapse_owner_uid %>
       </section>
 
       <% if @review.project.update_description.present? %>

--- a/test/helpers/telescreen_helper_test.rb
+++ b/test/helpers/telescreen_helper_test.rb
@@ -37,4 +37,15 @@ class TelescreenHelperTest < ActionView::TestCase
     url = "https://example.com/cases/2518"
     assert_equal url, displayed_telescreen_url(url)
   end
+
+  test "lapse url points at the workbench with the owner uid and lapse id" do
+    assert_equal "https://telescreen.hackclub.com/workbench/lapse?u=51046&t=abc123",
+                 telescreen_lapse_url(hackatime_uid: "51046", lapse_id: "abc123")
+  end
+
+  test "lapse url is blank without a uid or a lapse id" do
+    assert_nil telescreen_lapse_url(hackatime_uid: nil, lapse_id: "abc123")
+    assert_nil telescreen_lapse_url(hackatime_uid: "51046", lapse_id: nil)
+    assert_nil telescreen_lapse_url(hackatime_uid: "", lapse_id: "")
+  end
 end

--- a/test/services/certification/devlog_lapse_bucketer_test.rb
+++ b/test/services/certification/devlog_lapse_bucketer_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+module Certification
+  class DevlogLapseBucketerTest < ActiveSupport::TestCase
+    # Two back-to-back day-long windows for devlogs 101 and 202.
+    WINDOWS = {
+      101 => { since: "2026-06-01T00:00:00Z", before: "2026-06-02T00:00:00Z" },
+      202 => { since: "2026-06-02T00:00:00Z", before: "2026-06-03T00:00:00Z" }
+    }.freeze
+
+    # A Lapse timelapse hash carries its recording time as epoch milliseconds.
+    def lapse(id, recorded_at)
+      { id: id, createdAt: (recorded_at.to_i * 1000).to_s }
+    end
+
+    test "buckets a lapse under the devlog whose window contains its recording time" do
+      tl = lapse("a", Time.utc(2026, 6, 1, 12))
+
+      result = DevlogLapseBucketer.call(timelapses: [ tl ], windows: WINDOWS)
+
+      assert_equal [ tl ], result[101]
+      assert_nil result[202]
+    end
+
+    test "drops a lapse recorded outside every devlog window" do
+      tl = lapse("orphan", Time.utc(2026, 6, 5, 12))
+
+      result = DevlogLapseBucketer.call(timelapses: [ tl ], windows: WINDOWS)
+
+      assert_empty result
+    end
+
+    test "splits multiple lapses across the devlogs they contributed to" do
+      first  = lapse("first", Time.utc(2026, 6, 1, 9))
+      second = lapse("second", Time.utc(2026, 6, 2, 15))
+
+      result = DevlogLapseBucketer.call(timelapses: [ first, second ], windows: WINDOWS)
+
+      assert_equal [ first ], result[101]
+      assert_equal [ second ], result[202]
+    end
+
+    test "a lapse on a window boundary belongs to the later window" do
+      # Windows are half-open [since, before): the instant a window ends is the
+      # next window's start, so a boundary lapse buckets forward, like commits.
+      tl = lapse("boundary", Time.utc(2026, 6, 2, 0, 0, 0))
+
+      result = DevlogLapseBucketer.call(timelapses: [ tl ], windows: WINDOWS)
+
+      assert_nil result[101]
+      assert_equal [ tl ], result[202]
+    end
+
+    test "skips a lapse with a blank recording time" do
+      result = DevlogLapseBucketer.call(timelapses: [ { id: "x", createdAt: nil } ], windows: WINDOWS)
+
+      assert_empty result
+    end
+  end
+end

--- a/test/views/admin/certification/funding_requests/recordings_telescreen_test.rb
+++ b/test/views/admin/certification/funding_requests/recordings_telescreen_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+# The "Open in Telescreen" link on Lapse recordings in the shared recordings
+# gallery. The URL itself is covered by TelescreenHelperTest; this checks the
+# gallery surfaces the link for a Lapse (given the owner uid) and never for a
+# Lookout recording or when the uid is missing.
+class Admin::Certification::FundingRequests::RecordingsTelescreenTest < ActionView::TestCase
+  LAPSE = {
+    id: "lapse-1", playbackUrl: "https://videos.example/l1.mp4",
+    thumbnailUrl: "", name: "Soldering", duration: 120, createdAt: "1", visibility: "PUBLIC"
+  }.freeze
+  LOOKOUT = { video_url: "https://videos.example/lk.mp4", thumbnail_url: "", mode: "screen", duration: 60, recorded_at: nil }.freeze
+
+  def render_recordings(timelapses:, recordings: [], telescreen_uid: nil)
+    render partial: "admin/certification/funding_requests/recordings",
+           locals: { timelapses: timelapses, recordings: recordings, telescreen_uid: telescreen_uid }
+  end
+
+  test "shows an Open in Telescreen link on a Lapse when the owner uid is present" do
+    render_recordings(timelapses: [ LAPSE ], telescreen_uid: "51046")
+
+    assert_select "a.recording-gallery__telescreen[href=?]",
+                  "https://telescreen.hackclub.com/workbench/lapse?u=51046&t=lapse-1"
+  end
+
+  test "omits the Telescreen link when the owner uid is missing" do
+    render_recordings(timelapses: [ LAPSE ], telescreen_uid: nil)
+
+    assert_select "a.recording-gallery__telescreen", count: 0
+  end
+
+  test "never shows a Telescreen link on a Lookout recording" do
+    render_recordings(timelapses: [], recordings: [ LOOKOUT ], telescreen_uid: "51046")
+
+    assert_select "a.recording-gallery__telescreen", count: 0
+  end
+end

--- a/test/views/admin/certification/ysws/devlog_review_lapses_test.rb
+++ b/test/views/admin/certification/ysws/devlog_review_lapses_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+# Rendering-level guard for lapses shown inside their contributing devlog on the
+# YSWS review page. The bucketing rule itself is covered by
+# Certification::DevlogLapseBucketerTest; this checks the partial actually
+# surfaces a bucketed lapse (and stays quiet when a devlog has none).
+class Admin::Certification::Ysws::DevlogReviewLapsesTest < ActionView::TestCase
+  POST_DEVLOG_ID = 4242
+
+  def devlog_review
+    post_devlog = Post::Devlog.new(id: POST_DEVLOG_ID, duration_seconds: 3600, phase: "build", body: "Built the thing")
+    review = Certification::Devlog.new(
+      id: 77, post_devlog_id: POST_DEVLOG_ID,
+      original_minutes: 60, approved_minutes: 60, status: "pending", justification: ""
+    )
+    review.post_devlog = post_devlog
+    review
+  end
+
+  def render_devlog(devlog_lapses:)
+    @devlog_commits = { POST_DEVLOG_ID => [] }
+    @repo_info = nil
+    @review = Certification::Ysws.new(id: 1, project: Project.new(repo_url: "https://github.com/example/repo"))
+    @devlog_lapses = devlog_lapses
+    render partial: "admin/certification/ysws/devlog_review",
+           locals: { devlog_review: devlog_review, frozen: false, sidebar_trigger: false, mac_recommendation: nil }
+  end
+
+  test "renders a devlog's bucketed timelapses inside the devlog" do
+    lapse = {
+      id: "tl1", playbackUrl: "https://videos.example/tl1.mp4",
+      thumbnailUrl: "https://videos.example/tl1.jpg", name: "Soldering",
+      duration: 120, createdAt: "1", visibility: "PUBLIC"
+    }
+
+    render_devlog(devlog_lapses: { POST_DEVLOG_ID => [ lapse ] })
+
+    assert_select ".devlog-recordings-section" do
+      assert_select ".recording-gallery__source", text: "Lapse"
+      assert_select "video source[src=?]", "https://videos.example/tl1.mp4"
+    end
+  end
+
+  test "omits the recordings section when the devlog has no lapses" do
+    render_devlog(devlog_lapses: { POST_DEVLOG_ID => [] })
+
+    assert_select ".devlog-recordings-section", count: 0
+  end
+end


### PR DESCRIPTION
## what's this do?

- this links to telescreen for every individual lapse
- buckets lapses into the devlogs they contributed to

## show it works

<img width="1173" height="1212" alt="image" src="https://github.com/user-attachments/assets/ab0a309e-90e1-4e4e-b8f4-2bfe7e1a0068" />

## ai?

opus 4.8