### PR TITLE
feat(hardware): better wrong queue card

### DIFF
--- a/app/models/concerns/certification/reviewable.rb
+++ b/app/models/concerns/certification/reviewable.rb
@@ -288,22 +288,26 @@ module Certification
     def awaiting_queue_answer? = misfiled?
 
     # True when this review was flagged as wrong-queue at some point, even if it
-    # has since been rewound to pending by the builder disputing it. Read from
-    # PaperTrail because disputing restores the status in place, so the record
-    # itself keeps no trace - and the next reviewer to pick it up needs to know
-    # it has already been round this loop once. `internal_reason` holds why.
+    # has since been rewound to pending by the builder disputing it, or decided
+    # by a later reviewer. Read from PaperTrail because disputing restores the
+    # status in place and a later verdict overwrites the reviewer, so the record
+    # itself keeps no trace - and whoever picks it up next needs to know it has
+    # already been round this loop once. `internal_reason` holds why;
+    # `misfiling_flag` holds who raised it and when.
     def previously_misfiled?
-      # PaperTrail records enum changes by name ("pending" -> "misfiled"), except
-      # the create version, which carries the raw integer. Accept either.
-      misfiled_value = self.class.statuses["misfiled"]
-      versions.any? do |version|
-        change = version.changeset["status"]
-        next false unless change.is_a?(Array)
+      misfiling_version.present?
+    end
 
-        change.last.to_s == "misfiled" || change.last == misfiled_value
-      end
-    rescue StandardError
-      false
+    # Who flagged this review as belonging in the other hardware queue, and when,
+    # reconstructed from PaperTrail. `nil` unless previously_misfiled?. The flag
+    # is raised behind the reviewer's claim, so the flagger is the record's
+    # reviewer at the moment of the flag - which the live record no longer holds
+    # once the flag is disputed away or a later verdict reassigns it.
+    def misfiling_flag
+      version = misfiling_version
+      return nil unless version
+
+      { reviewer: misfiling_reviewer(version), at: version.created_at }
     end
 
     # Read by Notifications::Hardware::ReviewQueueMismatch to render the Slack
@@ -326,6 +330,34 @@ module Certification
     end
 
     private
+
+    # The most recent PaperTrail version that flipped this record into `misfiled`.
+    # Memoized: previously_misfiled? and misfiling_flag both read it on the same
+    # instance, and each read otherwise scans the whole version list.
+    def misfiling_version
+      return @misfiling_version if defined?(@misfiling_version)
+
+      # PaperTrail records enum changes by name ("pending" -> "misfiled"), except
+      # the create version, which carries the raw integer. Accept either.
+      misfiled_value = self.class.statuses["misfiled"]
+      @misfiling_version = versions.reverse_each.find do |version|
+        change = version.changeset["status"]
+        change.is_a?(Array) && (change.last.to_s == "misfiled" || change.last == misfiled_value)
+      end
+    rescue StandardError
+      @misfiling_version = nil
+    end
+
+    # The reviewer on the record at the moment it was flagged. Prefer the change
+    # itself (set when a reviewer flags without holding the claim); otherwise the
+    # reviewer was already claimed and unchanged by the flag, so reify the
+    # pre-flag snapshot to recover it.
+    def misfiling_reviewer(version)
+      reviewer_id = version.changeset.dig("reviewer_id", 1) || version.reify&.reviewer_id
+      reviewer_id && User.find_by(id: reviewer_id)
+    rescue StandardError
+      nil
+    end
 
     # action_items and feedback_prose each scan the feedback with the regex, and
     # both are read several times per timeline render. Parse once and memoize,

--- a/app/views/admin/certification/hardware_reviews/_wrong_queue_flag.html.erb
+++ b/app/views/admin/certification/hardware_reviews/_wrong_queue_flag.html.erb
@@ -1,0 +1,14 @@
+<%# The wrong-queue flag in a review's history: that it was sent back once as
+    belonging in the other hardware queue, and who raised it when. Reconstructed
+    from PaperTrail (a dispute rewinds the reviewer, a later verdict overwrites
+    it), so the flagger survives only in the versions. Rendered on the bounced
+    active review and merged into a decided review that had been sent back once.
+    Locals: review (required). %>
+<% flag = review.misfiling_flag %>
+<span class="hardware-review__timeline-meta">Flagged as the wrong queue</span>
+<% if flag&.dig(:reviewer) %>
+  <span class="hardware-review__timeline-meta">by <%= flag[:reviewer].display_name %></span>
+<% end %>
+<% if flag&.dig(:at) %>
+  <span class="hardware-review__timeline-meta"><%= l(flag[:at].to_date, format: :short) %></span>
+<% end %>

--- a/app/views/admin/certification/hardware_reviews/show.html.erb
+++ b/app/views/admin/certification/hardware_reviews/show.html.erb
@@ -74,11 +74,16 @@
             <div class="hardware-review__history-item hardware-review__history-item--bounced">
               <div class="hardware-review__history-head">
                 <span class="hardware-review__timeline-label">This review</span>
-                <span class="status-pill status-pill--misfiled">Sent back once</span>
-                <span class="hardware-review__timeline-meta">
-                  A reviewer flagged this as the wrong queue and the builder disagreed.
-                </span>
+                <%= render "admin/certification/hardware_reviews/wrong_queue_flag", review: @active_review %>
+                <% if @active_review_type == :funding %>
+                  <span class="hardware-review__timeline-meta">
+                    $<%= @active_review.requested_amount_dollars %> · <%= @active_review.tier_label %>
+                  </span>
+                <% end %>
               </div>
+              <p class="hardware-review__history-feedback">
+                The builder disagreed, so it's back in this queue for review.
+              </p>
               <% if @active_review.internal_reason.present? %>
                 <p class="hardware-review__history-feedback hardware-review__history-feedback--internal">
                   Reviewer note: <%= @active_review.internal_reason %>
@@ -94,24 +99,22 @@
                 <li class="hardware-review__history-item">
                   <div class="hardware-review__history-head">
                     <span class="hardware-review__timeline-label"><%= is_funding ? "Design funding" : "Build certification" %></span>
-                    <%# A reversed review keeps its history slot but wears a purple
+                    <%# A reversed review keeps its history slot but wears a
                         "Reversed" badge instead of its (now rewound) verdict. %>
                     <% if review.reversed_at.present? %>
                       <span class="status-pill status-pill--reversed">Reversed</span>
                     <% else %>
                       <span class="status-pill status-pill--<%= review.status %>"><%= review.status.capitalize %></span>
                     <% end %>
-                    <span class="hardware-review__timeline-meta">
-                      <%# A routing correction has no verdict to report, so it says
-                          what happened to it instead of an amount or a kit. A
-                          reversed review skips that wording and shows what the
-                          rewound verdict had been. %>
-                      <% if review.misfiled? && review.reversed_at.blank? %>
-                        Wrong queue, waiting on the builder
-                      <% elsif review.withdrawn? && review.reversed_at.blank? %>
-                        Withdrawn, wrong queue
-                      <% elsif is_funding %>
-                        <% if review.awards_design_kit? %>
+                    <%# The submitted facts a normal review shows - amount and tier -
+                        carry on a wrong-queue row too, which reports the submitted
+                        request rather than a verdict it never reached; a reversed
+                        review shows the rewound verdict value instead. %>
+                    <% if is_funding %>
+                      <span class="hardware-review__timeline-meta">
+                        <% if (review.misfiled? || review.withdrawn?) && review.reversed_at.blank? %>
+                          $<%= review.requested_amount_dollars %> · <%= review.tier_label %>
+                        <% elsif review.awards_design_kit? %>
                           <%= review.design_kit_shop_item&.name || "Kit" %>
                         <% elsif review.kit_mission? %>
                           No kit
@@ -120,15 +123,27 @@
                         <% else %>
                           $<%= review.final_amount_dollars %> · <%= review.tier_label %>
                         <% end %>
-                      <% end %>
-                    </span>
-                    <% if review.reversed_at %>
-                      <span class="hardware-review__timeline-meta">reversed <%= l(review.reversed_at.to_date, format: :short) %></span>
-                    <% elsif review.decided_at %>
-                      <span class="hardware-review__timeline-meta"><%= l(review.decided_at.to_date, format: :short) %></span>
+                      </span>
+                    <% end %>
+                    <%# The verdict date; for a reversal, when it was reversed; for a
+                        routing correction that never reached a verdict, the flag date. %>
+                    <% review_date = review.reversed_at || review.decided_at || review.misfiling_flag&.dig(:at) %>
+                    <% if review_date %>
+                      <span class="hardware-review__timeline-meta"><%= "reversed " if review.reversed_at %><%= l(review_date.to_date, format: :short) %></span>
                     <% end %>
                     <% if review.reviewer %>
                       <span class="hardware-review__timeline-meta">by <%= review.reviewer.display_name %></span>
+                    <% end %>
+                    <% if review.misfiled? && review.reversed_at.blank? %>
+                      <span class="hardware-review__timeline-meta">Wrong queue, waiting on the builder</span>
+                    <% elsif review.withdrawn? && review.reversed_at.blank? %>
+                      <span class="hardware-review__timeline-meta">Withdrawn, wrong queue</span>
+                    <% end %>
+                    <%# A verdict on a review that had been sent back once as the
+                        wrong queue merges the earlier flag into this one card,
+                        rather than losing that history the moment it's decided. %>
+                    <% if review.decided? && review.previously_misfiled? %>
+                      <%= render "admin/certification/hardware_reviews/wrong_queue_flag", review: review %>
                     <% end %>
                   </div>
                   <% if review.feedback.present? %>
@@ -137,7 +152,10 @@
                   <% if is_funding %>
                     <%= render "admin/certification/funding_requests/feedback_images", funding_request: review %>
                   <% end %>
-                  <% if review.internal_reason.present? %>
+                  <%# internal_reason is the wrong-queue note; surface it only while the
+                      review is still in a routing state (misfiled/withdrawn), never as a
+                      stale note merged onto a real verdict (approved/returned). %>
+                  <% if review.internal_reason.present? && !review.decided? %>
                     <p class="hardware-review__history-feedback hardware-review__history-feedback--internal">
                       Reviewer note: <%= review.internal_reason %>
                     </p>

--- a/test/integration/hardware_queue_mismatch_test.rb
+++ b/test/integration/hardware_queue_mismatch_test.rb
@@ -313,7 +313,7 @@ class HardwareQueueMismatchTest < ActionDispatch::IntegrationTest
     get admin_certification_hardware_review_path(project)
 
     assert_select ".hardware-review__history-item--bounced" do
-      assert_select ".status-pill--misfiled", text: "Sent back once"
+      assert_select ".hardware-review__timeline-meta", text: /Flagged as the wrong queue/
       assert_select ".hardware-review__history-feedback--internal", text: /Get a parts grant first/
     end
     assert_select ".ship-review__description", text: /first review on this project/, count: 0


### PR DESCRIPTION
## what's this do?

the misfiled queue card in the hardware review dashboard currently has 2 issues:
- it weirdly merges with any other reviews
- basically no info is given

## show it works

<img width="1159" height="532" alt="image" src="https://github.com/user-attachments/assets/f713d3e4-4eb7-47c4-b200-3812a628b00b" />


## ai?

opus 4.8