### PR TITLE
fix(hardware): put hardware review undo behind a flipper

### DIFF
--- a/app/controllers/concerns/hardware_review_queue.rb
+++ b/app/controllers/concerns/hardware_review_queue.rb
@@ -228,6 +228,8 @@ module HardwareReviewQueue
   # can make an HCB round trip (to check a grant), so it's skipped entirely for
   # anyone not allowed to undo.
   def load_undo_context
+    return unless Flipper.enabled?(:hardware_review_undo, current_user)
+
     latest_decided = @past_reviews.first
     return unless latest_decided&.decided?
     return unless can_undo_review?(latest_decided)

--- a/app/controllers/concerns/hardware_review_undoable.rb
+++ b/app/controllers/concerns/hardware_review_undoable.rb
@@ -9,6 +9,10 @@
 module HardwareReviewUndoable
   extend ActiveSupport::Concern
 
+  included do
+    before_action :require_hardware_review_undo_flag, only: :undo
+  end
+
   def undo
     review = review_for_undo
     authorize review, :undo?
@@ -31,6 +35,12 @@ module HardwareReviewUndoable
   end
 
   private
+
+  # Reversing a decided hardware review is gated behind a flag while the
+  # stardust-payout clawback for reversed builds is still being sorted out.
+  def require_hardware_review_undo_flag
+    head :not_found unless Flipper.enabled?(:hardware_review_undo, current_user)
+  end
 
   def undo_success_notice(result)
     notice = "Review reversed — it's back in the pending queue."

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -40,6 +40,7 @@ Rails.application.config.after_initialize do
         week_1_release
         hardware_flow
         hardware_action_items
+        hardware_review_undo
         public_hardware_reviews
         ship_event_payouts
         payout_recommendations

--- a/test/controllers/admin/certification/hardware_review_undo_test.rb
+++ b/test/controllers/admin/certification/hardware_review_undo_test.rb
@@ -16,6 +16,7 @@ class Admin::Certification::HardwareReviewUndoTest < ActionDispatch::Integration
 
   setup do
     Flipper.enable(:hardware_flow)
+    Flipper.enable(:hardware_review_undo)
     @reviewer = create_user(slack_id: "U_UNDO_C_REV", display_name: "undo-c-rev")
     @reviewer.grant_role!(:admin)
     @owner = create_user(slack_id: "U_UNDO_C_OWNER", display_name: "undo-c-owner", verified: true)
@@ -28,7 +29,10 @@ class Admin::Certification::HardwareReviewUndoTest < ActionDispatch::Integration
     sign_in @reviewer
   end
 
-  teardown { Flipper.disable(:hardware_flow) }
+  teardown do
+    Flipper.disable(:hardware_flow)
+    Flipper.disable(:hardware_review_undo)
+  end
 
   test "a reviewer undoes an approved funding request" do
     HCBService.stub(:show_card_grant, unspent_grant) do


### PR DESCRIPTION
## what's this do?

turns out there are a few edge cases that make undoing a review potentially a bad idea. still good to have & a relatively easy thing to fix, just lower in my priority list than other tasks right now.

## show it works

<img width="1169" height="406" alt="image" src="https://github.com/user-attachments/assets/83e09aa3-74be-4f65-ba05-3b3051a24822" />
voila, no more undo review button

## ai?

opus 4.8