### PR TITLE
refact(jobs): triage job queues

### DIFF
--- a/app/jobs/activity_daily_summary_job.rb
+++ b/app/jobs/activity_daily_summary_job.rb
@@ -1,5 +1,5 @@
 class ActivityDailySummaryJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   CHANNEL_ID = "C0AR0M43H61" # stardance-construction
 

--- a/app/jobs/ahoy_backfill_project_created_job.rb
+++ b/app/jobs/ahoy_backfill_project_created_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AhoyBackfillProjectCreatedJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform
     already_tracked = Ahoy::Event

--- a/app/jobs/ahoy_geocode_job.rb
+++ b/app/jobs/ahoy_geocode_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AhoyGeocodeJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
   limits_concurrency to: 1, key: "ahoy_geocode", duration: 1.second
 
   def perform(visit_id)

--- a/app/jobs/broadcast_notification_job.rb
+++ b/app/jobs/broadcast_notification_job.rb
@@ -1,5 +1,5 @@
 class BroadcastNotificationJob < ApplicationJob
-  queue_as :latency_5m
+  queue_as :latency_10s
 
   discard_on ActiveJob::DeserializationError
 

--- a/app/jobs/broadcast_unseen_count_job.rb
+++ b/app/jobs/broadcast_unseen_count_job.rb
@@ -1,5 +1,5 @@
 class BroadcastUnseenCountJob < ApplicationJob
-  queue_as :latency_5m
+  queue_as :latency_10s
 
   discard_on ActiveJob::DeserializationError
 

--- a/app/jobs/broadcast_vote_to_channel_job.rb
+++ b/app/jobs/broadcast_vote_to_channel_job.rb
@@ -1,5 +1,5 @@
 class BroadcastVoteToChannelJob < ApplicationJob
-  queue_as :default
+  queue_as :latency_10s
 
   CHANNEL_ID = "C0AFB0JU00P"
 

--- a/app/jobs/certification/ysws_airtable_sync_job.rb
+++ b/app/jobs/certification/ysws_airtable_sync_job.rb
@@ -4,7 +4,7 @@ module Certification
   class YswsAirtableSyncJob < ApplicationJob
     include Rails.application.routes.url_helpers
 
-    queue_as :default
+    queue_as :literally_whenever
 
     # rescue_from(StandardError) must be declared FIRST — ActiveJob checks handlers in reverse registration order (last = highest priority), so retry_on declarations below will take precedence over this catch-all for Faraday errors.
     rescue_from(StandardError) do |error|

--- a/app/jobs/cleanup_guest_users_job.rb
+++ b/app/jobs/cleanup_guest_users_job.rb
@@ -1,5 +1,5 @@
 class CleanupGuestUsersJob < ApplicationJob
-  queue_as :background
+  queue_as :literally_whenever
 
   RETENTION = 30.days
   MAX_PER_RUN = 500

--- a/app/jobs/external_dashboard/webhook_job.rb
+++ b/app/jobs/external_dashboard/webhook_job.rb
@@ -2,7 +2,7 @@ module ExternalDashboard
   class WebhookJob < ::ApplicationJob
     class RetriableServerError < StandardError; end
 
-    queue_as :default
+    queue_as :latency_5m
 
     self.enqueue_after_transaction_commit = true
 

--- a/app/jobs/fraud/calculate_payouts_job.rb
+++ b/app/jobs/fraud/calculate_payouts_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Fraud::CalculatePayoutsJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform(manual: false)
     orders = eligible_orders(manual)

--- a/app/jobs/fraud_daily_summary_job.rb
+++ b/app/jobs/fraud_daily_summary_job.rb
@@ -1,5 +1,5 @@
 class FraudDailySummaryJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   FRAUD_CHANNEL_ID = "C0B239CM64W"
 

--- a/app/jobs/gorse/sync_feedback_job.rb
+++ b/app/jobs/gorse/sync_feedback_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Gorse::SyncFeedbackJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform(user, item, feedback_type, value: 1, timestamp: Time.current, comment: nil)
     payload = Gorse::FeedbackPayload.new(

--- a/app/jobs/gorse/sync_post_job.rb
+++ b/app/jobs/gorse/sync_post_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Gorse::SyncPostJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform(post)
     post.sync_to_gorse_now

--- a/app/jobs/gorse/sync_project_job.rb
+++ b/app/jobs/gorse/sync_project_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Gorse::SyncProjectJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform(project)
     project.sync_to_gorse_now

--- a/app/jobs/gorse/sync_user_job.rb
+++ b/app/jobs/gorse/sync_user_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Gorse::SyncUserJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform(user)
     user.sync_to_gorse_now

--- a/app/jobs/jelly_sync_job.rb
+++ b/app/jobs/jelly_sync_job.rb
@@ -1,5 +1,5 @@
 class JellySyncJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   # Ceiling on how far one run will page. The first run backfills over several
   # runs rather than trying to walk the whole mailbox inside one job.

--- a/app/jobs/mission/migrate_projects_to_hardware_job.rb
+++ b/app/jobs/mission/migrate_projects_to_hardware_job.rb
@@ -1,5 +1,5 @@
 class Mission::MigrateProjectsToHardwareJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   # When a mission is switched to hardware, its already-attached software
   # projects are converted to hardware so they match the mission's type. They

--- a/app/jobs/notification_delivery_job.rb
+++ b/app/jobs/notification_delivery_job.rb
@@ -1,5 +1,5 @@
 class NotificationDeliveryJob < ApplicationJob
-  queue_as :latency_5m
+  queue_as :latency_10s
 
   discard_on ActiveJob::DeserializationError
 

--- a/app/jobs/project/ensure_hackatime_projects_job.rb
+++ b/app/jobs/project/ensure_hackatime_projects_job.rb
@@ -14,7 +14,7 @@
 # old one instead of moving the link, so time already recorded under the old
 # name keeps counting toward the project.
 class Project::EnsureHackatimeProjectsJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   # Far enough back to cover any Hackatime history, so the existence check
   # can't mistake an old project for a missing one.

--- a/app/jobs/project/magic_happening_letter_job.rb
+++ b/app/jobs/project/magic_happening_letter_job.rb
@@ -1,5 +1,5 @@
 class Project::MagicHappeningLetterJob < ApplicationJob
-  queue_as :default
+  queue_as :latency_5m
   notify_maintainers_on_exhaustion StandardError, maintainers_slack_ids: [ "U0823F39GV8", "U07L45W79E1" ], wait: :polynomially_longer, attempts: 3
 
   def perform(project)

--- a/app/jobs/project/post_to_magic_job.rb
+++ b/app/jobs/project/post_to_magic_job.rb
@@ -1,5 +1,5 @@
 class Project::PostToMagicJob < ApplicationJob
-  queue_as :default
+  queue_as :latency_5m
 
   CHANNEL_ID = "C0A38L9MFEE"
 

--- a/app/jobs/project/resync_devlogs_from_hackatime_job.rb
+++ b/app/jobs/project/resync_devlogs_from_hackatime_job.rb
@@ -1,5 +1,5 @@
 class Project::ResyncDevlogsFromHackatimeJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
   retry_on WithAdvisoryLock::FailedToAcquireLock, wait: :polynomially_longer, attempts: 5
 
   def perform(project)

--- a/app/jobs/project/type_check_job.rb
+++ b/app/jobs/project/type_check_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Project::TypeCheckJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   discard_on ActiveJob::DeserializationError
   retry_on StandardError, wait: :polynomially_longer, attempts: 3

--- a/app/jobs/recalculate_project_durations_job.rb
+++ b/app/jobs/recalculate_project_durations_job.rb
@@ -1,5 +1,5 @@
 class RecalculateProjectDurationsJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform
     Project.find_each(&:recalculate_duration_seconds!)

--- a/app/jobs/refresh_all_users_verification_job.rb
+++ b/app/jobs/refresh_all_users_verification_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RefreshAllUsersVerificationJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform
     User.joins(:identities)

--- a/app/jobs/refresh_approx_balances_job.rb
+++ b/app/jobs/refresh_approx_balances_job.rb
@@ -1,5 +1,5 @@
 class RefreshApproxBalancesJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform
     User.connection.execute(<<~SQL)

--- a/app/jobs/refresh_materialized_all_signups_job.rb
+++ b/app/jobs/refresh_materialized_all_signups_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RefreshMaterializedAllSignupsJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   # The refresh runs every 2 minutes (config/recurring.yml). If a refresh ever
   # takes longer than that, this keeps the next tick from piling a second

--- a/app/jobs/rsvp_geocode_job.rb
+++ b/app/jobs/rsvp_geocode_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RsvpGeocodeJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
   limits_concurrency to: 5, key: "rsvp_geocode", duration: 1.second
 
   def perform(rsvp_id)

--- a/app/jobs/semantic_search/delete_record_job.rb
+++ b/app/jobs/semantic_search/delete_record_job.rb
@@ -2,7 +2,7 @@
 
 module SemanticSearch
   class DeleteRecordJob < ApplicationJob
-    queue_as :default
+    queue_as :latency_5m
 
     def perform(type, record_id)
       SemanticSearch.delete(type, record_id)

--- a/app/jobs/semantic_search/index_record_job.rb
+++ b/app/jobs/semantic_search/index_record_job.rb
@@ -2,7 +2,7 @@
 
 module SemanticSearch
   class IndexRecordJob < ApplicationJob
-    queue_as :default
+    queue_as :latency_5m
 
     def perform(record_class_name, record_id)
       record_class = record_class_name.constantize

--- a/app/jobs/ship_event_payout_refresh_job.rb
+++ b/app/jobs/ship_event_payout_refresh_job.rb
@@ -1,5 +1,5 @@
 class ShipEventPayoutRefreshJob < ApplicationJob
-  queue_as :default
+  queue_as :latency_5m
 
   def perform(ship_event_id = nil)
     Post::ShipEvent.find_by(id: ship_event_id)&.sync_voting_completion! if ship_event_id

--- a/app/jobs/shop/auto_approve_job.rb
+++ b/app/jobs/shop/auto_approve_job.rb
@@ -4,7 +4,7 @@
 # safe to run late: ShopOrder#auto_approvable? re-checks every condition,
 # including that the order is still awaiting review.
 class Shop::AutoApproveJob < ApplicationJob
-  queue_as :default
+  queue_as :latency_5m
 
   # Fulfilment reaches HCB, which goes down and loses its authorization from
   # time to time, so a failure is backed off rather than abandoned. Retrying is

--- a/app/jobs/shop/calculate_fulfillment_payouts_job.rb
+++ b/app/jobs/shop/calculate_fulfillment_payouts_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Shop::CalculateFulfillmentPayoutsJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform(manual: false)
     orders = eligible_orders(manual)

--- a/app/jobs/shop/process_letter_mail_orders_job.rb
+++ b/app/jobs/shop/process_letter_mail_orders_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Shop::ProcessLetterMailOrdersJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   LETTER_TYPES = ShopItem::LetterMail::BULK_BATCHED_TYPES
 

--- a/app/jobs/shop/process_verified_orders_job.rb
+++ b/app/jobs/shop/process_verified_orders_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Shop::ProcessVerifiedOrdersJob < ApplicationJob
-  queue_as :default
+  queue_as :latency_5m
 
   def perform(user_id)
     user = User.find(user_id)

--- a/app/jobs/shop/process_warehouse_orders_job.rb
+++ b/app/jobs/shop/process_warehouse_orders_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Shop::ProcessWarehouseOrdersJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
   def perform
     warehouse_orders = ShopOrder
       .joins(:shop_item)

--- a/app/jobs/shop/refresh_verification_status_job.rb
+++ b/app/jobs/shop/refresh_verification_status_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Shop::RefreshVerificationStatusJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform
     user_ids = ShopOrder.where(aasm_state: "awaiting_verification")

--- a/app/jobs/shop/retry_free_sticker_orders_job.rb
+++ b/app/jobs/shop/retry_free_sticker_orders_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Shop::RetryFreeStickerOrdersJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform
     orders = ShopOrder.where(aasm_state: "pending")

--- a/app/jobs/shop/update_postage_costs_job.rb
+++ b/app/jobs/shop/update_postage_costs_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Shop::UpdatePostageCostsJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform
     orders = ShopOrder.joins(:shop_item)

--- a/app/jobs/shop_order_daily_summary_job.rb
+++ b/app/jobs/shop_order_daily_summary_job.rb
@@ -1,5 +1,5 @@
 class ShopOrderDailySummaryJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   SHOP_ORDER_CHANNEL_ID = "C09N1P69GKZ"
 

--- a/app/jobs/streak_daily_sync_job.rb
+++ b/app/jobs/streak_daily_sync_job.rb
@@ -1,5 +1,5 @@
 class StreakDailySyncJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform
     User.joins(:hackatime_identity)

--- a/app/jobs/streak_sync_job.rb
+++ b/app/jobs/streak_sync_job.rb
@@ -1,5 +1,5 @@
 class StreakSyncJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform(user_id)
     user = User.find_by(id: user_id)

--- a/app/jobs/support_vibecheck_job.rb
+++ b/app/jobs/support_vibecheck_job.rb
@@ -1,5 +1,5 @@
 class SupportVibecheckJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform
     last_vibe = SupportVibes.order(period_end: :desc).first

--- a/app/jobs/track_fullstory_event_job.rb
+++ b/app/jobs/track_fullstory_event_job.rb
@@ -1,5 +1,5 @@
 class TrackFullstoryEventJob < ApplicationJob
-  queue_as :default
+  queue_as :latency_5m
 
   def perform(user_id:, name:, properties:)
     api_key = Rails.application.credentials.dig(:fullstory, :api_key)

--- a/app/jobs/user/data_export_job.rb
+++ b/app/jobs/user/data_export_job.rb
@@ -1,7 +1,7 @@
 require "zip"
 
 class User::DataExportJob < ApplicationJob
-  queue_as :background
+  queue_as :latency_5m
 
   def perform(data_export_id)
     @data_export = User::DataExport.find_by(id: data_export_id)

--- a/app/jobs/user/ensure_hackatime_projects_job.rb
+++ b/app/jobs/user/ensure_hackatime_projects_job.rb
@@ -11,7 +11,7 @@
 # Fans out one seeding job per project so every guard stays in one place: this
 # job decides which projects to look at, that one decides what to do with each.
 class User::EnsureHackatimeProjectsJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform(user_id)
     user = User.find_by(id: user_id)

--- a/app/jobs/user/refresh_verdicts_job.rb
+++ b/app/jobs/user/refresh_verdicts_job.rb
@@ -1,5 +1,5 @@
 class User::RefreshVerdictsJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform
     Secrets::VoteVerdictRefresh.call

--- a/app/jobs/user_geocode_job.rb
+++ b/app/jobs/user_geocode_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UserGeocodeJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
   limits_concurrency to: 5, key: "user_geocode", duration: 1.second
 
   def perform(user_id)

--- a/app/jobs/vote/auto_discard_job.rb
+++ b/app/jobs/vote/auto_discard_job.rb
@@ -1,5 +1,5 @@
 class Vote::AutoDiscardJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform(vote_id)
     vote_auto_discarder = "Secrets::VoteAutoDiscarder".safe_constantize

--- a/app/jobs/vote/cache_reason_embedding_job.rb
+++ b/app/jobs/vote/cache_reason_embedding_job.rb
@@ -1,5 +1,5 @@
 class Vote::CacheReasonEmbeddingJob < ApplicationJob
-  queue_as :default
+  queue_as :literally_whenever
 
   def perform(vote_id)
     vote_reason_embedder = "Secrets::VoteReasonEmbedder".safe_constantize


### PR DESCRIPTION
this looks like a big change, but all it really does is standardize our queues to...
- `latency_10s`
- `latency_5m`
- `literally_whenever`

had a bunch of jobs that used to be `default` and even that made up their own `background` queue- did my best guess on things, but mostly threw stuff in `literally_whenever`- please feel free to change your job's queue_as if i guessed wrong!