### PR TITLE
feat(streak): stop showing stickers after a sticky streak breaks

### DIFF
--- a/app/models/concerns/user/streakable.rb
+++ b/app/models/concerns/user/streakable.rb
@@ -163,7 +163,7 @@ module User::Streakable
   # Sticky Streak decoration for one calendar day: which challenge day it is,
   # the sticker it pays out, and whether it is ready to claim.
   def sticky_day_fields(sticky, date)
-    return { sticky_day: nil, sticky_reward: nil, sticky_claimable: false } unless sticky&.covers?(date)
+    return { sticky_day: nil, sticky_reward: nil, sticky_claimable: false } unless sticky&.decorates?(date)
 
     day = sticky.day_for(date)
     { sticky_day: day, sticky_reward: sticky.rewards_by_day[day], sticky_claimable: sticky.claimable_day?(day) }

--- a/app/models/sticky_streak.rb
+++ b/app/models/sticky_streak.rb
@@ -55,6 +55,17 @@ class StickyStreak < ApplicationRecord
 
   def covers?(date) = (started_on..last_date).cover?(date)
 
+  # Dates the run still dresses up in the calendar. A missed day ends the
+  # challenge, so it and everything after it go back to being ordinary streak
+  # days rather than showing stickers that can never be earned. Derived from
+  # missed_day like everything else, so a late Hackatime backfill that rescues
+  # the day brings the stickers back with it.
+  def decorates?(date)
+    return false unless covers?(date)
+
+    missed_day.nil? || day_for(date) < missed_day
+  end
+
   # The day the user is on right now, clamped into the window.
   def current_day = day_for(today).clamp(1, LENGTH)
 

--- a/test/controllers/home/discover_rail_streak_test.rb
+++ b/test/controllers/home/discover_rail_streak_test.rb
@@ -76,6 +76,28 @@ class Home::DiscoverRailStreakTest < ActionDispatch::IntegrationTest
     assert_select ".streak-widget__week .streak-mark__star", minimum: 1
   end
 
+  test "a broken run goes back to plain stars from the miss onwards" do
+    today = @user.streak_today_date
+    streak = StickyStreak.create!(user: @user, started_on: today - 3)
+    # Day 1 kept, day 2 missed, so days 2 and on are no longer part of the run.
+    StreakActivity.create!(user: @user, activity_date: streak.date_for(1),
+                           coded_seconds: StreakActivity::DAILY_GOAL_SECONDS)
+    StickyStreakReward.create!(day_number: 1, shop_item: sticker)
+    StickyStreakReward.create!(day_number: 3, shop_item: sticker)
+
+    get streak_home_discover_rail_path
+
+    assert_response :success
+    assert_predicate streak, :failed?
+    assert_select ".streak-widget__cal-grid .streak-mark__sticker", 1,
+                  "only the day banked before the miss keeps its sticker"
+    assert_select ".streak-widget__week .streak-mark__sticker", { count: 0 },
+                  "this week is all past the miss, so it is ordinary streak days"
+    assert_select ".streak-widget__week .streak-mark__star", minimum: 1
+    assert_select ".streak-mark--unknown", { count: 0 },
+                  "a dead day must not render as a sticker slot waiting for art"
+  end
+
   test "clicking a sticker opens the shared zoom dialog" do
     today = @user.streak_today_date
     StickyStreak.create!(user: @user, started_on: today)

--- a/test/models/sticky_streak_test.rb
+++ b/test/models/sticky_streak_test.rb
@@ -93,6 +93,47 @@ class StickyStreakTest < ActiveSupport::TestCase
     assert_equal [ 1 ], @streak.claimable_days
   end
 
+  test "the calendar stops dressing up days from the miss onwards" do
+    complete_days(1, 2)
+    log_seconds(3, StreakActivity::DAILY_GOAL_SECONDS - 1)
+    complete_days(4)
+
+    assert @streak.decorates?(@streak.date_for(1)), "days before the miss keep their sticker"
+    assert @streak.decorates?(@streak.date_for(2))
+    assert_not @streak.decorates?(@streak.date_for(3)), "the day that broke the run goes plain"
+    assert_not @streak.decorates?(@streak.date_for(4)),
+               "a day coded after the run died is an ordinary streak day again"
+    assert_not @streak.decorates?(@streak.date_for(StickyStreak::LENGTH))
+  end
+
+  test "a live run dresses up every day in its window and nothing outside it" do
+    complete_days(1, 2, 3, 4)
+
+    assert_not @streak.failed?
+    (1..StickyStreak::LENGTH).each do |day|
+      assert @streak.decorates?(@streak.date_for(day)), "day #{day} should still be part of the run"
+    end
+    assert_not @streak.decorates?(@streak.started_on - 1)
+    assert_not @streak.decorates?(@streak.last_date + 1)
+  end
+
+  test "crediting the missed day brings the stickers back" do
+    complete_days(1, 2, 4)
+    log_seconds(3, StreakActivity::DAILY_GOAL_SECONDS - 1)
+
+    assert_not @streak.decorates?(@streak.date_for(4))
+
+    StreakActivity.credit!(
+      user: @user, date: @streak.date_for(3),
+      granted_by: create_user(slack_id: "U-sticky-fixer", display_name: "stickyfixer"),
+      reason: "Hackatime lost the day"
+    )
+
+    repaired = StickyStreak.find(@streak.id)
+    assert repaired.decorates?(@streak.date_for(3))
+    assert repaired.decorates?(@streak.date_for(4))
+  end
+
   test "recording a claim closes the day" do
     complete_days(1)
     StickyStreakReward.create!(day_number: 1, shop_item: @item)


### PR DESCRIPTION
## what's this do?

previously it showed the stickers after your streak broke. now it doesn't, to reduce confusion

## show it works

trust bro

## ai?

claude
