### PR TITLE
Update _empty_state.html.erb to fix grammatical error

### DIFF
--- a/app/views/votes/_empty_state.html.erb
+++ b/app/views/votes/_empty_state.html.erb
@@ -7,7 +7,7 @@
   elsif rating_closed
     "Sign up for Stardance to build and ship your own projects, then rate what others have made!"
   else
-    "No projects ready to vote on right now. This is either a really good or bad. Nothing in between"
+    "No projects ready to vote on right now. This is either a really good or bad thing. Nothing in between"
   end
   action_label = current_user ? "My projects" : ("Sign up" if rating_closed)
   action_path = current_user ? profile_projects_path(current_user.display_name) : (root_path if rating_closed)


### PR DESCRIPTION
The current version currently states "This is either a really good or bad." which is missing a noun.

## what's this do?

<!-- a sentence or two! -->
This fixes a grammatical error that users most commonly see when they don't have any more projects to vote for and open up the Rate page. Previously, it stated "No projects ready to vote on right now. This is either a really good or bad. Nothing in between," which is missing a noun (like the word 'thing') after the word 'bad.'

## show it works

<!-- screen recording, screenshots, test output— whatever makes sense for the change -->
Since this is just a grammatical change, I do not think that this section applies. Look at the change:

\- "No projects ready to vote on right now. This is either a really good or bad. Nothing in between"
\+ "No projects ready to vote on right now. This is either a really good or bad thing. Nothing in between"

## ai?

<!-- did you use AI tools? which ones? no judgment, we just wanna know. see AI_POLICY.md for details -->
No, I did not use any AI tools.
