### PR TITLE
feat(certification): poll external dashboard for decisions the webhook missed

### DIFF
--- a/app/jobs/external_dashboard/decision_poll_job.rb
+++ b/app/jobs/external_dashboard/decision_poll_job.rb
@@ -1,0 +1,9 @@
+module ExternalDashboard
+  class DecisionPollJob < ApplicationJob
+    queue_as :literally_whenever
+
+    def perform
+      DecisionPollService.call
+    end
+  end
+end

--- a/app/jobs/external_dashboard/outbound_audit_job.rb
+++ b/app/jobs/external_dashboard/outbound_audit_job.rb
@@ -1,0 +1,9 @@
+module ExternalDashboard
+  class OutboundAuditJob < ApplicationJob
+    queue_as :literally_whenever
+
+    def perform
+      OutboundAuditService.call
+    end
+  end
+end

--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -89,6 +89,7 @@ module Certification
     EXTERNAL_CERTIFICATION_ID_PATTERN = /\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/
     PROOF_VIDEO_URL_MAX_LENGTH = 2_048
     PROOF_VIDEO_URL_PATTERN = %r{\Ahttps?://\S+\z}
+    FEEDBACK_MAX_LENGTH = 10_000
 
     def assign_external_certification_id!(cert_id)
       cert_id = cert_id.to_s
@@ -146,7 +147,7 @@ module Certification
       }
     ].freeze
 
-    validates :feedback, length: { maximum: 10_000 }, allow_blank: true
+    validates :feedback, length: { maximum: FEEDBACK_MAX_LENGTH }, allow_blank: true
     validates :proof_video_url, length: { maximum: PROOF_VIDEO_URL_MAX_LENGTH },
                                 format: { with: PROOF_VIDEO_URL_PATTERN, message: "must be an http(s) URL" },
                                 allow_blank: true
@@ -185,6 +186,29 @@ module Certification
     scope :in_global_hardware_queue, -> { joins(:project).merge(::Project.hardware.without_hardware_mission) }
     # The other half: certifications a hardware mission reviews on its own dash.
     scope :in_hardware_mission_queue, -> { joins(:project).merge(::Project.hardware.with_hardware_mission) }
+
+    def self.find_by_external(uuid: nil, external_id: nil)
+      cert = resolve_external(uuid: uuid, external_id: external_id)
+      return nil if cert.nil? || cert.project&.hardware?
+
+      cert
+    end
+
+    def self.resolve_external(uuid:, external_id:)
+      if uuid.present? && uuid.to_s.match?(EXTERNAL_CERTIFICATION_ID_PATTERN)
+        by_uuid = find_by(external_certification_id: uuid)
+        return by_uuid if by_uuid
+      end
+
+      return nil unless external_id.present? && external_id.to_s.match?(ExternalDashboard::Client::EXTERNAL_ID_PATTERN)
+
+      # external_certification_id: nil - a cert that already has a UUID on file
+      # must match on that UUID; the bare-id fallback only resolves certs we
+      # haven't linked yet, so a mismatched/forged uuid can't hijack one that's
+      # already correctly identified.
+      find_by(id: external_id.to_s.to_i, external_certification_id: nil)
+    end
+    private_class_method :resolve_external
 
     def self.available_for(user)
       # Chained AFTER the merge on purpose: `merge` would replace this project_id

--- a/app/services/external_dashboard/alert_throttle.rb
+++ b/app/services/external_dashboard/alert_throttle.rb
@@ -1,0 +1,12 @@
+module ExternalDashboard
+  module AlertThrottle
+    extend self
+
+    def once(key, ttl:)
+      return if Rails.cache.exist?(key)
+
+      Rails.cache.write(key, true, expires_in: ttl)
+      yield
+    end
+  end
+end

--- a/app/services/external_dashboard/decision_poll_service.rb
+++ b/app/services/external_dashboard/decision_poll_service.rb
@@ -4,6 +4,7 @@ module ExternalDashboard
   # one instead of depending on a cursor that could get lost.
   class DecisionPollService
     LOOKBACK = 2.hours
+    UNHEALTHY_ALERT_TTL = 1.hour
 
     def self.call(...) = new(...).call
 
@@ -21,12 +22,42 @@ module ExternalDashboard
 
       tag = dry_run ? " [dry-run]" : ""
       Rails.logger.info "[ExternalDashboard::DecisionPollService]#{tag} fetch=#{result.status} fetched=#{result.ships.size} #{counts.map { |k, v| "#{k}=#{v}" }.join(' ')}"
+      alert_on_unhealthy_run(result, counts) unless dry_run
       counts.merge(fetch_status: result.status)
     end
 
     private
 
     attr_reader :lookback, :now, :dry_run
+
+    UNRESOLVED_OUTCOMES = %i[missing_timestamp not_found error].freeze
+
+    def alert_on_unhealthy_run(result, counts)
+      unless result.status == :ok
+        AlertThrottle.once("external_dashboard:decision_poll:fetch_unhealthy:#{result.status}", ttl: UNHEALTHY_ALERT_TTL) do
+          Sentry.capture_message(
+            "ExternalDashboard::DecisionPollService fetch did not complete",
+            level: :warning,
+            extra: { fetch_status: result.status, fetch_error: result.error, fetched: result.ships.size }
+          )
+        end
+        return
+      end
+
+      decided_count = result.ships.size - counts[:ignored_status]
+      return if decided_count <= 0
+
+      unresolved_count = UNRESOLVED_OUTCOMES.sum { |outcome| counts[outcome] }
+      return if unresolved_count < decided_count * 0.5
+
+      AlertThrottle.once("external_dashboard:decision_poll:high_error_rate", ttl: UNHEALTHY_ALERT_TTL) do
+        Sentry.capture_message(
+          "ExternalDashboard::DecisionPollService is failing to apply most decided ships in its window",
+          level: :warning,
+          extra: { fetched: result.ships.size, decided: decided_count, unresolved: unresolved_count, breakdown: counts }
+        )
+      end
+    end
 
     def process(ship)
       status = ship["status"].to_s
@@ -45,15 +76,17 @@ module ExternalDashboard
 
       apply(ship, cert, target, proof_video_url, decided_at).status
     rescue StandardError => e
-      Rails.logger.warn "[ExternalDashboard::DecisionPollService] ship=#{ship['id']} #{e.class}: #{e.message}"
+      Rails.logger.warn "[ExternalDashboard::DecisionPollService] ship=#{ship['id'].inspect} #{e.class}: #{e.message}"
       :error
     end
 
     def apply(ship, cert, target, proof_video_url, decided_at)
+      reviewer_slack_id = ship.dig("reviewer", "slackId").to_s.presence
       VerdictApplier.call(
         cert: cert,
         target_status: target,
-        reviewer: resolve_reviewer(ship.dig("reviewer", "slackId")),
+        reviewer: resolve_reviewer(reviewer_slack_id),
+        reviewer_slack_id: reviewer_slack_id,
         comment: ship["feedback"].to_s.presence&.truncate(Certification::Ship::FEEDBACK_MAX_LENGTH, omission: ""),
         proof_video_url: proof_video_url,
         external_uuid: ship["id"],

--- a/app/services/external_dashboard/decision_poll_service.rb
+++ b/app/services/external_dashboard/decision_poll_service.rb
@@ -1,0 +1,82 @@
+module ExternalDashboard
+  # No persisted watermark on purpose: the window just slides a fixed
+  # lookback behind "now" every run, so a missed run is caught by the next
+  # one instead of depending on a cursor that could get lost.
+  class DecisionPollService
+    LOOKBACK = 2.hours
+
+    def self.call(...) = new(...).call
+
+    def initialize(lookback: LOOKBACK, now: Time.current, dry_run: false)
+      @lookback = lookback
+      @now = now
+      @dry_run = dry_run
+    end
+
+    def call
+      result = ShipsClient.fetch_all(updated_since: now - lookback, status: "all")
+      counts = Hash.new(0)
+
+      result.ships.each { |ship| counts[process(ship)] += 1 }
+
+      tag = dry_run ? " [dry-run]" : ""
+      Rails.logger.info "[ExternalDashboard::DecisionPollService]#{tag} fetch=#{result.status} fetched=#{result.ships.size} #{counts.map { |k, v| "#{k}=#{v}" }.join(' ')}"
+      counts.merge(fetch_status: result.status)
+    end
+
+    private
+
+    attr_reader :lookback, :now, :dry_run
+
+    def process(ship)
+      status = ship["status"].to_s
+      target = Certification::Ship::EXTERNAL_DECISION_MAP[status]
+      return :ignored_status unless target
+
+      decided_at = parse_time(ship["decidedAt"])
+      return :missing_timestamp unless decided_at
+
+      cert = Certification::Ship.find_by_external(uuid: ship["id"], external_id: ship["externalId"])
+      return :not_found unless cert
+      return :ignored if cert.project.nil? || cert.project.deleted_at.present? || cert.owner&.banned?
+
+      proof_video_url = ship.dig("links", "proofVideo").presence
+      return :invalid if proof_video_url && !valid_proof_video_url?(proof_video_url)
+
+      apply(ship, cert, target, proof_video_url, decided_at).status
+    rescue StandardError => e
+      Rails.logger.warn "[ExternalDashboard::DecisionPollService] ship=#{ship['id']} #{e.class}: #{e.message}"
+      :error
+    end
+
+    def apply(ship, cert, target, proof_video_url, decided_at)
+      VerdictApplier.call(
+        cert: cert,
+        target_status: target,
+        reviewer: resolve_reviewer(ship.dig("reviewer", "slackId")),
+        comment: ship["feedback"].to_s.presence&.truncate(Certification::Ship::FEEDBACK_MAX_LENGTH, omission: ""),
+        proof_video_url: proof_video_url,
+        external_uuid: ship["id"],
+        decided_at: decided_at,
+        dry_run: dry_run
+      )
+    end
+
+    def valid_proof_video_url?(url)
+      url.match?(Certification::Ship::PROOF_VIDEO_URL_PATTERN) && url.length <= Certification::Ship::PROOF_VIDEO_URL_MAX_LENGTH
+    end
+
+    def resolve_reviewer(slack_id)
+      return nil if slack_id.blank?
+
+      user = User.find_by(slack_id: slack_id)
+      user && !user.banned? && user.can_review? ? user : nil
+    end
+
+    def parse_time(iso8601)
+      iso8601.present? ? Time.iso8601(iso8601) : nil
+    rescue ArgumentError
+      nil
+    end
+  end
+end

--- a/app/services/external_dashboard/decision_processor.rb
+++ b/app/services/external_dashboard/decision_processor.rb
@@ -24,7 +24,7 @@ module ExternalDashboard
       return ignored("project is deleted") if cert.project.nil? || cert.project.deleted_at.present?
       return ignored("project owner is banned") if cert.owner&.banned?
       return error(:bad_request, "missing or invalid timestamp") if decision_timestamp.nil?
-      return error(:conflict, "decision predates this review cycle (timestamp=#{payload[:timestamp].inspect})") if cert.pending? && VerdictApplier.stale?(cert: cert, decided_at: decision_timestamp)
+      return error(:conflict, "implausible decision timestamp (timestamp=#{payload[:timestamp].inspect})") if cert.pending? && VerdictApplier.stale?(cert: cert, decided_at: decision_timestamp)
 
       if proof_video_url
         return error(:bad_request, "proofVideoUrl must be an http(s) URL") unless proof_video_url.match?(Certification::Ship::PROOF_VIDEO_URL_PATTERN)
@@ -44,6 +44,7 @@ module ExternalDashboard
         cert: cert,
         target_status: target_status,
         reviewer: reviewer,
+        reviewer_slack_id: certification[:reviewerSlackId].to_s.presence,
         comment: reviewer_comment,
         proof_video_url: proof_video_url,
         external_uuid: certification[:id],
@@ -56,7 +57,7 @@ module ExternalDashboard
       when :idempotent
         ok(decision_payload(outcome.cert, idempotent: true))
       when :stale
-        error(:conflict, "decision predates this review cycle (timestamp=#{payload[:timestamp].inspect})")
+        error(:conflict, "implausible decision timestamp (timestamp=#{payload[:timestamp].inspect})")
       when :divergent
         error(:conflict, "cert #{outcome.cert.id} is already #{outcome.cert.status} locally — refusing to apply remote #{decision_status}")
       else

--- a/app/services/external_dashboard/decision_processor.rb
+++ b/app/services/external_dashboard/decision_processor.rb
@@ -2,8 +2,6 @@ module ExternalDashboard
   class DecisionProcessor
     DECISION_EVENT = "certification.decision".freeze
     TEST_EVENT = "test".freeze
-    COMMENT_MAX_LENGTH = 10_000
-    REPLAY_CLOCK_SKEW = 5.minutes
 
     Result = Struct.new(:status, :body, keyword_init: true)
 
@@ -21,12 +19,12 @@ module ExternalDashboard
       return error(:bad_request, "missing certification object") unless certification.is_a?(Hash)
       return error(:unprocessable_entity, "unsupported status: #{decision_status.inspect}") unless Certification::Ship::EXTERNAL_DECISION_MAP.key?(decision_status)
 
-      cert = find_cert
+      cert = Certification::Ship.find_by_external(uuid: certification[:id], external_id: certification[:externalId])
       return error(:not_found, "cert not found (externalId=#{certification[:externalId].inspect} id=#{certification[:id].inspect})") if cert.nil?
       return ignored("project is deleted") if cert.project.nil? || cert.project.deleted_at.present?
       return ignored("project owner is banned") if cert.owner&.banned?
       return error(:bad_request, "missing or invalid timestamp") if decision_timestamp.nil?
-      return error(:conflict, "decision predates this review cycle (timestamp=#{payload[:timestamp].inspect})") if cert.pending? && stale_decision?(cert)
+      return error(:conflict, "decision predates this review cycle (timestamp=#{payload[:timestamp].inspect})") if cert.pending? && VerdictApplier.stale?(cert: cert, decided_at: decision_timestamp)
 
       if proof_video_url
         return error(:bad_request, "proofVideoUrl must be an http(s) URL") unless proof_video_url.match?(Certification::Ship::PROOF_VIDEO_URL_PATTERN)
@@ -42,19 +40,27 @@ module ExternalDashboard
 
     def apply(cert)
       target_status = Certification::Ship::EXTERNAL_DECISION_MAP.fetch(decision_status)
+      outcome = VerdictApplier.call(
+        cert: cert,
+        target_status: target_status,
+        reviewer: reviewer,
+        comment: reviewer_comment,
+        proof_video_url: proof_video_url,
+        external_uuid: certification[:id],
+        decided_at: decision_timestamp
+      )
 
-      PaperTrail.request(whodunnit: whodunnit) do
-        cert.with_lock do
-          if cert.pending?
-            apply_decision!(cert, target_status)
-            ok(decision_payload(cert, idempotent: false))
-          elsif cert.status.to_sym == target_status
-            cert.assign_external_certification_id!(certification[:id])
-            ok(decision_payload(cert, idempotent: true))
-          else
-            error(:conflict, "cert #{cert.id} is already #{cert.status} locally — refusing to apply remote #{decision_status}")
-          end
-        end
+      case outcome.status
+      when :applied
+        ok(decision_payload(outcome.cert, idempotent: false))
+      when :idempotent
+        ok(decision_payload(outcome.cert, idempotent: true))
+      when :stale
+        error(:conflict, "decision predates this review cycle (timestamp=#{payload[:timestamp].inspect})")
+      when :divergent
+        error(:conflict, "cert #{outcome.cert.id} is already #{outcome.cert.status} locally — refusing to apply remote #{decision_status}")
+      else
+        error(:internal_server_error, "unexpected verdict outcome: #{outcome.status.inspect}")
       end
     end
 
@@ -68,22 +74,6 @@ module ExternalDashboard
 
     def decision_status
       certification[:status].to_s
-    end
-
-    def find_cert
-      uuid = certification[:id].to_s
-      if uuid.match?(Certification::Ship::EXTERNAL_CERTIFICATION_ID_PATTERN)
-        by_uuid = Certification::Ship.find_by(external_certification_id: uuid)
-        return by_uuid if by_uuid
-      end
-
-      cert_id = parse_cert_id
-      cert_id && Certification::Ship.find_by(id: cert_id)
-    end
-
-    def parse_cert_id
-      raw = certification[:externalId].to_s
-      raw.match?(Client::EXTERNAL_ID_PATTERN) ? raw.to_i : nil
     end
 
     def reviewer
@@ -102,25 +92,12 @@ module ExternalDashboard
       end
     end
 
-    def stale_decision?(cert)
-      decision_timestamp.present? && decision_timestamp < (cert.created_at - REPLAY_CLOCK_SKEW)
-    end
-
-    def whodunnit
-      reviewer&.id&.to_s || "external_dashboard"
-    end
-
     def reviewer_comment
-      certification[:reviewerComment].to_s.presence&.truncate(COMMENT_MAX_LENGTH, omission: "")
+      certification[:reviewerComment].to_s.presence&.truncate(Certification::Ship::FEEDBACK_MAX_LENGTH, omission: "")
     end
 
     def proof_video_url
       certification[:proofVideoUrl].to_s.presence
-    end
-
-    def apply_decision!(cert, target_status)
-      cert.update!(status: target_status, feedback: reviewer_comment, reviewer_id: reviewer&.id, proof_video_url: proof_video_url)
-      cert.assign_external_certification_id!(certification[:id])
     end
 
     def decision_payload(cert, idempotent:)

--- a/app/services/external_dashboard/outbound_audit_service.rb
+++ b/app/services/external_dashboard/outbound_audit_service.rb
@@ -14,6 +14,7 @@ module ExternalDashboard
 
     def call
       result = ShipsClient.fetch_all(updated_since: now - window, status: "all")
+      alert_on_unhealthy_fetch(result) unless result.status == :ok
       return { fetch_status: result.status, healed: 0, backfill: nil } if result.status == :not_configured
 
       healed = heal_missing_uuids(result.ships)
@@ -27,19 +28,33 @@ module ExternalDashboard
 
     attr_reader :window, :now
 
+    def alert_on_unhealthy_fetch(result)
+      Sentry.capture_message(
+        "ExternalDashboard::OutboundAuditService fetch did not complete",
+        level: :warning,
+        extra: { fetch_status: result.status, fetch_error: result.error, fetched: result.ships.size }
+      )
+    end
+
     def heal_missing_uuids(ships)
       by_external_id = ships.index_by { |ship| ship["externalId"].to_s }
       healed = 0
 
-      Certification::Ship.where(external_certification_id: nil).find_each do |cert|
+      Certification::Ship.where(external_certification_id: nil).includes(:project, :project_with_deleted).find_each do |cert|
         row = by_external_id[cert.id.to_s]
         next unless row
         next if cert.project&.hardware?
+        next unless matches_project_name?(cert, row)
 
         healed += 1 if cert.assign_external_certification_id!(row["id"]) == :persisted
       end
 
       healed
+    end
+
+    def matches_project_name?(cert, row)
+      remote_name = row.dig("project", "name").to_s.presence
+      remote_name.present? && remote_name == cert.project&.title
     end
   end
 end

--- a/app/services/external_dashboard/outbound_audit_service.rb
+++ b/app/services/external_dashboard/outbound_audit_service.rb
@@ -1,0 +1,45 @@
+module ExternalDashboard
+  # Heals UUIDs directly from a wide /ships pull, then hands off to
+  # ShipBackfillService for whatever's still missing (which also covers
+  # missed YSWS returns - it already retries those unconditionally).
+  class OutboundAuditService
+    WINDOW = 7.days
+
+    def self.call(...) = new(...).call
+
+    def initialize(window: WINDOW, now: Time.current)
+      @window = window
+      @now = now
+    end
+
+    def call
+      result = ShipsClient.fetch_all(updated_since: now - window, status: "all")
+      return { fetch_status: result.status, healed: 0, backfill: nil } if result.status == :not_configured
+
+      healed = heal_missing_uuids(result.ships)
+      backfill = ShipBackfillService.call
+
+      Rails.logger.info "[ExternalDashboard::OutboundAuditService] fetch=#{result.status} fetched=#{result.ships.size} healed=#{healed} backfill_run=#{backfill.run_id}"
+      { fetch_status: result.status, healed: healed, backfill: backfill }
+    end
+
+    private
+
+    attr_reader :window, :now
+
+    def heal_missing_uuids(ships)
+      by_external_id = ships.index_by { |ship| ship["externalId"].to_s }
+      healed = 0
+
+      Certification::Ship.where(external_certification_id: nil).find_each do |cert|
+        row = by_external_id[cert.id.to_s]
+        next unless row
+        next if cert.project&.hardware?
+
+        healed += 1 if cert.assign_external_certification_id!(row["id"]) == :persisted
+      end
+
+      healed
+    end
+  end
+end

--- a/app/services/external_dashboard/ship_backfill_service.rb
+++ b/app/services/external_dashboard/ship_backfill_service.rb
@@ -7,8 +7,9 @@ module ExternalDashboard
     def self.call(scope: nil, rate_per_second: DEFAULT_RATE_PER_SECOND)
       return Result.new(status: :not_configured, enqueued: 0, error: Client::NOT_CONFIGURED_ERROR) unless Client.configured?
 
-      active_returns = Certification::Ship.pending.where.not(returned_by_id: nil).where.not(project_id: hardware_project_ids)
-      scope ||= Certification::Ship.where(external_certification_id: nil).where.not(project_id: hardware_project_ids).where.not(id: active_returns.select(:id))
+      hw_project_ids = hardware_project_ids
+      active_returns = Certification::Ship.pending.where.not(returned_by_id: nil).where.not(project_id: hw_project_ids)
+      scope ||= Certification::Ship.where(external_certification_id: nil).where.not(project_id: hw_project_ids).where.not(id: active_returns.select(:id))
       link_ship_events(scope)
       cert_ids = scope.pluck(:id)
       return_ids = active_returns.where.not(external_certification_id: nil).pluck(:id)
@@ -43,7 +44,7 @@ module ExternalDashboard
     end
 
     def self.hardware_project_ids
-      Project.unscoped.where.not(hardware_stage: nil).select(:id)
+      Project.unscoped.where.not(hardware_stage: nil).pluck(:id)
     end
     private_class_method :hardware_project_ids
 

--- a/app/services/external_dashboard/ship_backfill_service.rb
+++ b/app/services/external_dashboard/ship_backfill_service.rb
@@ -7,8 +7,8 @@ module ExternalDashboard
     def self.call(scope: nil, rate_per_second: DEFAULT_RATE_PER_SECOND)
       return Result.new(status: :not_configured, enqueued: 0, error: Client::NOT_CONFIGURED_ERROR) unless Client.configured?
 
-      active_returns = Certification::Ship.pending.where.not(returned_by_id: nil)
-      scope ||= Certification::Ship.where(external_certification_id: nil).where.not(id: active_returns.select(:id))
+      active_returns = Certification::Ship.pending.where.not(returned_by_id: nil).where.not(project_id: hardware_project_ids)
+      scope ||= Certification::Ship.where(external_certification_id: nil).where.not(project_id: hardware_project_ids).where.not(id: active_returns.select(:id))
       link_ship_events(scope)
       cert_ids = scope.pluck(:id)
       return_ids = active_returns.where.not(external_certification_id: nil).pluck(:id)
@@ -41,6 +41,11 @@ module ExternalDashboard
       reset_external_ids!
       call(rate_per_second: rate_per_second)
     end
+
+    def self.hardware_project_ids
+      Project.unscoped.where.not(hardware_stage: nil).select(:id)
+    end
+    private_class_method :hardware_project_ids
 
     def self.link_ship_events(scope)
       linked = 0

--- a/app/services/external_dashboard/ship_webhook_service.rb
+++ b/app/services/external_dashboard/ship_webhook_service.rb
@@ -124,14 +124,24 @@ module ExternalDashboard
 
       case response.status
       when 200..299
+        return missing_cert_id_result(response.status, body) unless valid_cert_id?(cert_id)
         Result.new(status: :ok, cert_id: cert_id, http_status: response.status)
       when 409
+        return missing_cert_id_result(response.status, body) unless valid_cert_id?(cert_id)
         Result.new(status: :duplicate, cert_id: cert_id, http_status: response.status)
       when 400..499
         Result.new(status: :client_error, http_status: response.status, error: Client.error_from(body))
       else
         Result.new(status: :server_error, http_status: response.status, error: Client.error_from(body))
       end
+    end
+
+    def valid_cert_id?(cert_id)
+      cert_id.is_a?(String) && cert_id.match?(Certification::Ship::EXTERNAL_CERTIFICATION_ID_PATTERN)
+    end
+
+    def missing_cert_id_result(status, body)
+      Result.new(status: :server_error, http_status: status, error: "response missing a valid certId: #{Client.error_from(body) || "(unparseable body)"}")
     end
   end
 end

--- a/app/services/external_dashboard/ships_client.rb
+++ b/app/services/external_dashboard/ships_client.rb
@@ -5,6 +5,7 @@ module ExternalDashboard
     PATH = "/api/v1/certifications/ships".freeze
     DEFAULT_LIMIT = 1000
     MAX_PAGES = 25
+    MAX_BODY_BYTES = 10.megabytes
 
     Result = Struct.new(:ships, :status, :error, keyword_init: true)
 
@@ -27,13 +28,22 @@ module ExternalDashboard
 
       MAX_PAGES.times do
         response = conn.get(PATH, page_params(cursor: cursor, until_param: until_param))
-        body = Client.parse_json(response.body)
+        raw_body = response.body.to_s
 
-        unless response.status.between?(200, 299)
-          return partial_or_error(ships, "http=#{response.status} error=#{Client.error_from(body)}")
+        if raw_body.bytesize > MAX_BODY_BYTES
+          return partial_or_error(ships, "response body exceeded #{MAX_BODY_BYTES} bytes, refusing to parse")
         end
 
-        ships.concat(Array(body["ships"]))
+        body = Client.parse_json(raw_body)
+
+        unless response.status.between?(200, 299)
+          return partial_or_error(ships, "http=#{response.status} error=#{Client.error_from(body).inspect}")
+        end
+
+
+        return partial_or_error(ships, "malformed response body (no ships array)") unless body.is_a?(Hash) && body["ships"].is_a?(Array)
+
+        ships.concat(body["ships"])
         until_param ||= body.dig("window", "to")
         more = body["hasMore"] ? true : false
         cursor = body["nextCursor"]

--- a/app/services/external_dashboard/ships_client.rb
+++ b/app/services/external_dashboard/ships_client.rb
@@ -1,0 +1,69 @@
+module ExternalDashboard
+  # Paginated, non-destructive GET /api/v1/certifications/ships - unlike
+  # /certifications/approved?refetch=true, safe to call on a schedule.
+  class ShipsClient
+    PATH = "/api/v1/certifications/ships".freeze
+    DEFAULT_LIMIT = 1000
+    MAX_PAGES = 25
+
+    Result = Struct.new(:ships, :status, :error, keyword_init: true)
+
+    def self.fetch_all(...) = new(...).fetch_all
+
+    def initialize(updated_since:, status: "all", limit: DEFAULT_LIMIT)
+      @updated_since = updated_since
+      @status = status
+      @limit = limit
+    end
+
+    def fetch_all
+      return Result.new(ships: [], status: :not_configured, error: Client::NOT_CONFIGURED_ERROR) unless Client.configured?
+
+      ships = []
+      cursor = nil
+      until_param = nil
+      more = false
+      conn = Client.connection
+
+      MAX_PAGES.times do
+        response = conn.get(PATH, page_params(cursor: cursor, until_param: until_param))
+        body = Client.parse_json(response.body)
+
+        unless response.status.between?(200, 299)
+          return partial_or_error(ships, "http=#{response.status} error=#{Client.error_from(body)}")
+        end
+
+        ships.concat(Array(body["ships"]))
+        until_param ||= body.dig("window", "to")
+        more = body["hasMore"] ? true : false
+        cursor = body["nextCursor"]
+        break unless more && cursor.present?
+      end
+
+      return partial_or_error(ships, "hit #{MAX_PAGES}-page cap or malformed pagination with more remaining") if more
+
+      Result.new(ships: ships, status: :ok)
+    rescue Faraday::Error => e
+      partial_or_error(ships, "#{e.class}: #{e.message}")
+    end
+
+    private
+
+    attr_reader :updated_since, :status, :limit
+
+    def page_params(cursor:, until_param:)
+      {
+        updatedSince: updated_since.iso8601,
+        status: status,
+        limit: limit,
+        until: until_param,
+        cursor: cursor
+      }.compact
+    end
+
+    def partial_or_error(ships, reason)
+      Rails.logger.warn "[ExternalDashboard::ShipsClient] #{reason}"
+      Result.new(ships: ships, status: ships.any? ? :partial : :error, error: reason)
+    end
+  end
+end

--- a/app/services/external_dashboard/verdict_applier.rb
+++ b/app/services/external_dashboard/verdict_applier.rb
@@ -11,13 +11,16 @@ module ExternalDashboard
     def self.call(...) = new(...).call
 
     def self.stale?(cert:, decided_at:)
-      decided_at.present? && decided_at < (cert.created_at - REPLAY_CLOCK_SKEW)
+      return false if decided_at.blank?
+
+      decided_at < (cert.created_at - REPLAY_CLOCK_SKEW) || decided_at > (Time.current + REPLAY_CLOCK_SKEW)
     end
 
-    def initialize(cert:, target_status:, reviewer: nil, comment: nil, proof_video_url: nil, external_uuid: nil, decided_at: nil, dry_run: false)
+    def initialize(cert:, target_status:, reviewer: nil, reviewer_slack_id: nil, comment: nil, proof_video_url: nil, external_uuid: nil, decided_at: nil, dry_run: false)
       @cert = cert
       @target_status = target_status
       @reviewer = reviewer
+      @reviewer_slack_id = reviewer_slack_id
       @comment = comment
       @proof_video_url = proof_video_url
       @external_uuid = external_uuid
@@ -38,7 +41,7 @@ module ExternalDashboard
 
     private
 
-    attr_reader :cert, :target_status, :reviewer, :comment, :proof_video_url, :external_uuid, :decided_at, :dry_run
+    attr_reader :cert, :target_status, :reviewer, :reviewer_slack_id, :comment, :proof_video_url, :external_uuid, :decided_at, :dry_run
 
     def apply_locked
       return stale_outcome if cert.pending? && self.class.stale?(cert: cert, decided_at: decided_at)
@@ -56,12 +59,19 @@ module ExternalDashboard
     end
 
     def apply!
-      cert.update!(status: target_status, feedback: comment, reviewer_id: reviewer&.id, proof_video_url: proof_video_url)
+      cert.update!(status: target_status, feedback: comment, reviewer_id: reviewer&.id, proof_video_url: proof_video_url, decided_at: decided_at)
       cert.assign_external_certification_id!(external_uuid)
+      log_dropped_reviewer
+    end
+
+    def log_dropped_reviewer
+      return if reviewer || reviewer_slack_id.blank?
+
+      Rails.logger.warn "[ExternalDashboard::VerdictApplier]#{dry_run_tag} cert=#{cert.id} reviewerSlackId=#{reviewer_slack_id} did not resolve to a local reviewer - stardust not awarded"
     end
 
     def stale_outcome
-      Rails.logger.warn "[ExternalDashboard::VerdictApplier]#{dry_run_tag} cert=#{cert.id} decision predates this review cycle (decided_at=#{decided_at})"
+      Rails.logger.warn "[ExternalDashboard::VerdictApplier]#{dry_run_tag} cert=#{cert.id} implausible decision timestamp (decided_at=#{decided_at})"
       Outcome.new(status: :stale, cert: cert)
     end
 
@@ -71,15 +81,13 @@ module ExternalDashboard
 
       # The poller re-checks every cert in its lookback window on every run, so
       # an unresolved divergence would otherwise re-page on every cycle.
-      alert_key = "external_dashboard:verdict_applier:divergence:#{cert.id}:#{cert.status}:#{target_status}"
-      return if Rails.cache.exist?(alert_key)
-
-      Rails.cache.write(alert_key, true, expires_in: DIVERGENCE_ALERT_TTL)
-      Sentry.capture_message(
-        DIVERGENCE_SENTRY_MESSAGE,
-        level: :warning,
-        extra: { cert_id: cert.id, local_status: cert.status, remote_status: target_status.to_s }
-      )
+      AlertThrottle.once("external_dashboard:verdict_applier:divergence:#{cert.id}:#{cert.status}:#{target_status}", ttl: DIVERGENCE_ALERT_TTL) do
+        Sentry.capture_message(
+          DIVERGENCE_SENTRY_MESSAGE,
+          level: :warning,
+          extra: { cert_id: cert.id, local_status: cert.status, remote_status: target_status.to_s }
+        )
+      end
     end
 
     def dry_run_tag

--- a/app/services/external_dashboard/verdict_applier.rb
+++ b/app/services/external_dashboard/verdict_applier.rb
@@ -1,0 +1,93 @@
+module ExternalDashboard
+  # Shared by the inbound decision webhook and the reconciliation poller, so
+  # there's one implementation of the lock/idempotency/divergence logic.
+  class VerdictApplier
+    REPLAY_CLOCK_SKEW = 5.minutes
+    DIVERGENCE_SENTRY_MESSAGE = "ExternalDashboard verdict diverges from local decision".freeze
+    DIVERGENCE_ALERT_TTL = 1.day
+
+    Outcome = Struct.new(:status, :cert, keyword_init: true)
+
+    def self.call(...) = new(...).call
+
+    def self.stale?(cert:, decided_at:)
+      decided_at.present? && decided_at < (cert.created_at - REPLAY_CLOCK_SKEW)
+    end
+
+    def initialize(cert:, target_status:, reviewer: nil, comment: nil, proof_video_url: nil, external_uuid: nil, decided_at: nil, dry_run: false)
+      @cert = cert
+      @target_status = target_status
+      @reviewer = reviewer
+      @comment = comment
+      @proof_video_url = proof_video_url
+      @external_uuid = external_uuid
+      @decided_at = decided_at
+      @dry_run = dry_run
+    end
+
+    def call
+      outcome = nil
+      PaperTrail.request(whodunnit: whodunnit) do
+        ActiveRecord::Base.transaction(requires_new: true) do
+          cert.with_lock { outcome = apply_locked }
+          raise ActiveRecord::Rollback if dry_run
+        end
+      end
+      outcome
+    end
+
+    private
+
+    attr_reader :cert, :target_status, :reviewer, :comment, :proof_video_url, :external_uuid, :decided_at, :dry_run
+
+    def apply_locked
+      return stale_outcome if cert.pending? && self.class.stale?(cert: cert, decided_at: decided_at)
+
+      if cert.pending?
+        apply!
+        Outcome.new(status: :applied, cert: cert)
+      elsif cert.status.to_sym == target_status
+        cert.assign_external_certification_id!(external_uuid)
+        Outcome.new(status: :idempotent, cert: cert)
+      else
+        log_divergence
+        Outcome.new(status: :divergent, cert: cert)
+      end
+    end
+
+    def apply!
+      cert.update!(status: target_status, feedback: comment, reviewer_id: reviewer&.id, proof_video_url: proof_video_url)
+      cert.assign_external_certification_id!(external_uuid)
+    end
+
+    def stale_outcome
+      Rails.logger.warn "[ExternalDashboard::VerdictApplier]#{dry_run_tag} cert=#{cert.id} decision predates this review cycle (decided_at=#{decided_at})"
+      Outcome.new(status: :stale, cert: cert)
+    end
+
+    def log_divergence
+      Rails.logger.warn "[ExternalDashboard::VerdictApplier]#{dry_run_tag} cert=#{cert.id} already #{cert.status} locally — refusing remote #{target_status}"
+      return if dry_run
+
+      # The poller re-checks every cert in its lookback window on every run, so
+      # an unresolved divergence would otherwise re-page on every cycle.
+      alert_key = "external_dashboard:verdict_applier:divergence:#{cert.id}:#{cert.status}:#{target_status}"
+      return if Rails.cache.exist?(alert_key)
+
+      Rails.cache.write(alert_key, true, expires_in: DIVERGENCE_ALERT_TTL)
+      Sentry.capture_message(
+        DIVERGENCE_SENTRY_MESSAGE,
+        level: :warning,
+        extra: { cert_id: cert.id, local_status: cert.status, remote_status: target_status.to_s }
+      )
+    end
+
+    def dry_run_tag
+      dry_run ? " [dry-run]" : ""
+    end
+
+    def whodunnit
+      reviewer&.id&.to_s || "external_dashboard"
+    end
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -199,3 +199,15 @@ production:
     schedule: every 5 minutes
     concurrency: 1
     description: "Drain Redis buffer of extension usage events into the database"
+
+  external_dashboard_decision_poll:
+    class: ExternalDashboard::DecisionPollJob
+    schedule: every 15 minutes
+    concurrency: 1
+    description: "Catch up on certification decisions the inbound webhook may have missed"
+
+  external_dashboard_outbound_audit:
+    class: ExternalDashboard::OutboundAuditJob
+    schedule: every day at 4am UTC
+    concurrency: 1
+    description: "Recover missing certification UUIDs from the dashboard and retry outbound pushes/returns that never landed"


### PR DESCRIPTION
## what's this do?

Finally add polling (yay!!!) 

Enqueues a job every 15 minutes that looks over stuff that was updated in the past 2hrs and keeps a rolling window

Enqueues a job everyday at 4 AM UTC that heals UUIDs for stuff Fiona already has but we lost track of and retries whatever never made it over (including GOI returns).

<!-- ## show it works --> 
<!-- skipped due to lack of visual changes --> 

## ai?
Claude 
