### PR TITLE
fix(ysws): fix n+1 by moving preload into controller and out of view …

### DIFF
--- a/app/controllers/admin/certification/ysws_controller.rb
+++ b/app/controllers/admin/certification/ysws_controller.rb
@@ -80,7 +80,7 @@ class Admin::Certification::YswsController < Admin::Certification::ApplicationCo
 
   def show
     @review = ::Certification::Ysws
-      .includes(:project, :user, :reviewer, :mac_analysis, devlog_reviews: { post_devlog: [ :post, :attachments_attachments ] })
+      .includes(:project, :user, :reviewer, :ship_cert, :mac_analysis, devlog_reviews: { post_devlog: [ :post, :attachments_attachments ] })
       .find(params[:id])
     authorize @review
 
@@ -92,6 +92,9 @@ class Admin::Certification::YswsController < Admin::Certification::ApplicationCo
     # Claim this review for the current admin so it drops off everyone else's
     # queue. Already-decided reviews (reached via "prior reviews" history
     # links) are read-only and aren't claimed.
+    @ship_cert = @review.effective_ship_cert
+    @ship_cert_from_earlier_ship = @review.ship_cert_from_earlier_ship?
+
     if @review.pending?
       claimed = ::Certification::Ysws.atomic_claim!(@review.id, current_user)
       if claimed.nil?

--- a/app/views/admin/certification/ysws/show.html.erb
+++ b/app/views/admin/certification/ysws/show.html.erb
@@ -111,12 +111,11 @@
       <!-- Ship Cert Video Section -->
       <section class="review-card video-card">
         <h3>Ship Cert Video</h3>
-        <% ship_cert = @review.effective_ship_cert %>
-        <% if (ship_cert_video_src = certification_verdict_video_src(ship_cert)) %>
-          <% if @review.ship_cert_from_earlier_ship? %>
+        <% if (ship_cert_video_src = certification_verdict_video_src(@ship_cert)) %>
+          <% if @ship_cert_from_earlier_ship %>
             <p class="video-card__source-note">
-              No video for reships — showing video from last ship<% if ship_cert.decided_at %>
-                <span class="video-card__source-date">(certified <%= ship_cert.decided_at.strftime("%b %-d, %Y") %>)</span>
+              No video for reships — showing video from last ship<% if @ship_cert.decided_at %>
+                <span class="video-card__source-date">(certified <%= @ship_cert.decided_at.strftime("%b %-d, %Y") %>)</span>
               <% end %>
             </p>
           <% end %>


### PR DESCRIPTION
…layer

any data loading should happen [in the controller](https://guides.rubyonrails.org/getting_started.html#model-view-controller-basics)!

In general if you see something like `<%= thing = user.thing %>` in the view, it's a good sign there is an n+1 issue!