### PR TITLE
turns off turbo on goi review page

### DIFF
--- a/app/views/admin/certification/ysws/index.html.erb
+++ b/app/views/admin/certification/ysws/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "YSWS Review Queue" %>
 
-<main class="ysws-queue" role="main"
+<main class="ysws-queue" role="main" data-turbo="false"
       data-controller="certification--ysws--queue-search"
       data-certification--ysws--queue-search-url-value="<%= admin_certification_ysws_reviews_path %>">
   <header class="ysws-queue__header">


### PR DESCRIPTION
This likely leaves things like the search bar broken, but i'm adding it as a temporary fix instead of just a `target: "_top"` because most of this page probably shouldn't be using turbo & i'm just setting this as the new baseline