### PR TITLE
fix(certifications): Add proper UUID linking for ships returned before getting assigned a UUID

### DIFF
--- a/app/jobs/external_dashboard/ship_webhook_job.rb
+++ b/app/jobs/external_dashboard/ship_webhook_job.rb
@@ -37,22 +37,11 @@ module ExternalDashboard
       end
 
       def chain_pending_return(cert, backfill_run_id)
-        return unless cert.approved? && cert.external_certification_id.present?
-        return if cert.post_ship_event_id.nil?
-
-        project = cert.project
-        return unless project
-
-        active_return = project.ship_reviews.pending.where.not(returned_by_id: nil)
-                               .find_by(post_ship_event_id: cert.post_ship_event_id)
+        active_return = cert.chain_pending_return
         return unless active_return
 
-        Certification::Ship.transaction do
-          if cert.transfer_external_certification_id_to!(active_return)
-            BackfillRun.record_enqueued(backfill_run_id)
-            ExternalDashboard::CertReturnJob.perform_later(active_return.id, backfill_run_id: backfill_run_id)
-          end
-        end
+        BackfillRun.record_enqueued(backfill_run_id)
+        ExternalDashboard::CertReturnJob.perform_later(active_return.id, backfill_run_id: backfill_run_id)
       end
   end
 end

--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -120,6 +120,19 @@ module Certification
       false
     end
 
+    def chain_pending_return
+      return nil unless approved? && external_certification_id.present? && post_ship_event_id.present?
+
+      proj = project
+      return nil unless proj
+
+      active_return = proj.ship_reviews.pending.where.not(returned_by_id: nil)
+                          .find_by(post_ship_event_id: post_ship_event_id)
+      return nil unless active_return
+
+      transfer_external_certification_id_to!(active_return) ? active_return : nil
+    end
+
     ACCEPTED_VIDEO_TYPES = %w[video/mp4 video/webm video/quicktime].freeze
 
     # Canned request-changes responses offered on the review form. The opener

--- a/app/services/external_dashboard/outbound_audit_service.rb
+++ b/app/services/external_dashboard/outbound_audit_service.rb
@@ -45,11 +45,20 @@ module ExternalDashboard
         next unless row
         next if cert.project&.hardware?
         next unless matches_project_name?(cert, row)
+        next unless cert.assign_external_certification_id!(row["id"]) == :persisted
 
-        healed += 1 if cert.assign_external_certification_id!(row["id"]) == :persisted
+        healed += 1
+        chain_pending_return(cert)
       end
 
       healed
+    end
+
+    def chain_pending_return(cert)
+      active_return = cert.chain_pending_return
+      return unless active_return
+
+      ExternalDashboard::CertReturnJob.perform_later(active_return.id)
     end
 
     def matches_project_name?(cert, row)

--- a/app/services/external_dashboard/ship_webhook_service.rb
+++ b/app/services/external_dashboard/ship_webhook_service.rb
@@ -54,19 +54,16 @@ module ExternalDashboard
       cert.owner&.slack_id.presence
     end
 
+    BACKFILL_ONLY_KEYS = %i[status createdAt decidedAt reviewerSlackId].freeze
+
     def payload
-      base_payload.merge(cert.pending? ? pending_payload : decision_payload).compact
+      built = base_payload.merge(cert.pending? ? pending_payload : decision_payload)
+      built = built.except(*BACKFILL_ONLY_KEYS) unless @backfill
+      built.compact
     end
 
-    # The dashboard treats explicit status/createdAt on a live ingest as a
-    # backfilled cert, so pending ones only carry them on backfill pushes.
     def pending_payload
-      return {} unless @backfill
-
-      {
-        status: "pending",
-        createdAt: cert.created_at&.iso8601
-      }
+      { status: "pending", createdAt: cert.created_at&.iso8601 }
     end
 
     def base_payload
@@ -80,7 +77,8 @@ module ExternalDashboard
         updatedProject: project.update_description.presence,
         submittedBy: submitted_by.presence,
         links: links.presence,
-        metadata: { devTime: dev_time_seconds }
+        metadata: { devTime: dev_time_seconds },
+        backfill: (true if @backfill)
       }
     end
 


### PR DESCRIPTION
## what's this do?

Some backfill retries were failing because the payload didn't include `backfill : true` which is required when giving the external dashboard `createdAt` and `status` so stuff that was missing a UUID couldn't get one. This PR also links UUID for YSWS returns that happened to ships before they were assigned one as normally it wasn't linked and ended up with the cert orphaned.


<!-- ## show it works -->
<!-- skipped due to lack of visual changes --> 
<!-- screen recording, screenshots, test output— whatever makes sense for the change -->

## ai?

Claude 
