### PR TITLE
fix(certification): reconcile deleted/banned verdicts and stranded return backfills

### DIFF
--- a/app/controllers/admin/certification/ysws_controller.rb
+++ b/app/controllers/admin/certification/ysws_controller.rb
@@ -477,7 +477,8 @@ class Admin::Certification::YswsController < Admin::Certification::ApplicationCo
         .where(project_id: @review.project_id, status: :approved)
         .lock
       approved_cert = approved_certs.find_by(id: @review.ship_cert_id) ||
-                      approved_certs.find_by(post_ship_event_id: @review.post_ship_event_id)
+                      approved_certs.find_by(post_ship_event_id: @review.post_ship_event_id) ||
+                      approved_certs.order(Arel.sql("decided_at DESC NULLS LAST"), id: :desc).first
 
       new_cert = ::Certification::Ship.create!(
         project_id: @review.project_id,
@@ -489,6 +490,18 @@ class Admin::Certification::YswsController < Admin::Certification::ApplicationCo
 
       if approved_cert&.transfer_external_certification_id_to!(new_cert)
         ::ExternalDashboard::CertReturnJob.perform_later(new_cert.id)
+      elsif approved_cert
+        # Nothing to hand over yet, so the return can't be sent and used to just vanish.
+        # Pushing the approved cert gets a UUID back off the dashboard's duplicate
+        # response, and the job chains the return itself once it lands.
+        ::ExternalDashboard::ShipWebhookJob.perform_later(approved_cert.id)
+      else
+        Sentry.capture_message(
+          "YSWS return has no approved ship cert to chain from",
+          level: :error,
+          tags: { category: "certification.ysws" },
+          extra: { ysws_review_id: @review.id, project_id: @review.project_id, new_cert_id: new_cert.id }
+        )
       end
     end
 

--- a/app/models/certification/ship.rb
+++ b/app/models/certification/ship.rb
@@ -462,12 +462,18 @@ module Certification
     # Stardust earned per completed review
     REVIEW_BOUNTY = 1.25 # This will be updated once we add the project types.
 
+    # Set when a verdict is mirrored back from the external dashboard for a project we
+    # can't act on any more - deleted, or the owner is banned. The status still gets
+    # recorded so both queues agree on what happened, but nothing downstream fires: no
+    # bounty, no project transition, no DM to the builder.
+    attr_accessor :record_verdict_only
+
     before_save :stamp_claimed_at, if: -> { will_save_change_to_reviewer_id? && reviewer_id.present? && claimed_at.nil? }
     before_save :stamp_decided_at, if: -> { will_save_change_to_status? && status_change&.last.in?(DECIDED_STATUSES) && decided_at.nil? }
-    before_save :assign_stardust_earned, if: -> { will_save_change_to_status? && status_change&.last.in?(DECIDED_STATUSES) && reviewer_id.present? }
-    after_save :apply_verdict_to_project!, if: :saved_change_to_status?
-    after_save_commit :notify_owner!, if: -> { saved_change_to_status? && decided? }
-    after_save_commit :post_verdict_to_hardware_review_channel!, if: -> { saved_change_to_status? && decided? && project&.hardware? }
+    before_save :assign_stardust_earned, if: -> { !record_verdict_only && will_save_change_to_status? && status_change&.last.in?(DECIDED_STATUSES) && reviewer_id.present? }
+    after_save :apply_verdict_to_project!, if: -> { saved_change_to_status? && !record_verdict_only }
+    after_save_commit :notify_owner!, if: -> { saved_change_to_status? && decided? && !record_verdict_only }
+    after_save_commit :post_verdict_to_hardware_review_channel!, if: -> { saved_change_to_status? && decided? && project&.hardware? && !record_verdict_only }
     after_create_commit :post_submission_to_hardware_review_channel!, if: -> { project&.hardware? }
 
     # Timeline cards for decided reviews sort by when the verdict landed.

--- a/app/services/external_dashboard/decision_poll_service.rb
+++ b/app/services/external_dashboard/decision_poll_service.rb
@@ -69,7 +69,6 @@ module ExternalDashboard
 
       cert = Certification::Ship.find_by_external(uuid: ship["id"], external_id: ship["externalId"])
       return :not_found unless cert
-      return :ignored if cert.project.nil? || cert.project.deleted_at.present? || cert.owner&.banned?
 
       proof_video_url = ship.dig("links", "proofVideo").presence
       return :invalid if proof_video_url && !valid_proof_video_url?(proof_video_url)

--- a/app/services/external_dashboard/decision_processor.rb
+++ b/app/services/external_dashboard/decision_processor.rb
@@ -21,8 +21,6 @@ module ExternalDashboard
 
       cert = Certification::Ship.find_by_external(uuid: certification[:id], external_id: certification[:externalId])
       return error(:not_found, "cert not found (externalId=#{certification[:externalId].inspect} id=#{certification[:id].inspect})") if cert.nil?
-      return ignored("project is deleted") if cert.project.nil? || cert.project.deleted_at.present?
-      return ignored("project owner is banned") if cert.owner&.banned?
       return error(:bad_request, "missing or invalid timestamp") if decision_timestamp.nil?
       return error(:conflict, "implausible decision timestamp (timestamp=#{payload[:timestamp].inspect})") if cert.pending? && VerdictApplier.stale?(cert: cert, decided_at: decision_timestamp)
 
@@ -110,11 +108,6 @@ module ExternalDashboard
 
     def ok(body)
       Result.new(status: :ok, body: body)
-    end
-
-    def ignored(reason)
-      Rails.logger.warn "[ExternalDashboard::DecisionProcessor] ignored decision: #{reason}"
-      Result.new(status: :ok, body: { ignored: reason })
     end
 
     def error(status_sym, message)

--- a/app/services/external_dashboard/ship_backfill_service.rb
+++ b/app/services/external_dashboard/ship_backfill_service.rb
@@ -13,17 +13,21 @@ module ExternalDashboard
       link_ship_events(scope)
       cert_ids = scope.pluck(:id)
       return_ids = active_returns.where.not(external_certification_id: nil).pluck(:id)
-      run_id = BackfillRun.start(enqueued: cert_ids.size + return_ids.size)
+      # A return whose UUID never got handed over lands in neither list above, so it used
+      # to sit here forever. Push the approved cert still holding that UUID instead and
+      # ShipWebhookJob chains the return off it.
+      chain_ids = stranded_return_predecessors(active_returns, hw_project_ids)
+      run_id = BackfillRun.start(enqueued: cert_ids.size + return_ids.size + chain_ids.size)
 
-      cert_ids.each_with_index do |cert_id, index|
+      (cert_ids + chain_ids).each_with_index do |cert_id, index|
         delay = (index.to_f / rate_per_second).seconds
         ExternalDashboard::ShipWebhookJob.set(wait: delay).perform_later(cert_id, backfill_run_id: run_id)
       end
 
       return_ids.each { |cert_id| ExternalDashboard::CertReturnJob.perform_later(cert_id, backfill_run_id: run_id) }
 
-      Rails.logger.info "[ExternalDashboard::ShipBackfillService] run=#{run_id} enqueued=#{cert_ids.size} returns=#{return_ids.size} rate=#{rate_per_second}/s"
-      Result.new(status: :ok, run_id: run_id, enqueued: cert_ids.size + return_ids.size)
+      Rails.logger.info "[ExternalDashboard::ShipBackfillService] run=#{run_id} enqueued=#{cert_ids.size} chained=#{chain_ids.size} returns=#{return_ids.size} rate=#{rate_per_second}/s"
+      Result.new(status: :ok, run_id: run_id, enqueued: cert_ids.size + return_ids.size + chain_ids.size)
     end
 
     def self.report(run_id)
@@ -47,6 +51,19 @@ module ExternalDashboard
       Project.unscoped.where.not(hardware_stage: nil).pluck(:id)
     end
     private_class_method :hardware_project_ids
+
+    def self.stranded_return_predecessors(active_returns, hw_project_ids)
+      events = active_returns.where(external_certification_id: nil)
+                             .where.not(post_ship_event_id: nil)
+                             .select(:post_ship_event_id)
+
+      Certification::Ship.approved
+                         .where.not(external_certification_id: nil)
+                         .where.not(project_id: hw_project_ids)
+                         .where(post_ship_event_id: events)
+                         .pluck(:id)
+    end
+    private_class_method :stranded_return_predecessors
 
     def self.link_ship_events(scope)
       linked = 0

--- a/app/services/external_dashboard/ship_webhook_service.rb
+++ b/app/services/external_dashboard/ship_webhook_service.rb
@@ -31,14 +31,14 @@ module ExternalDashboard
 
     attr_reader :cert
 
+    # Only the fields the dashboard actually rejects a payload for. description, readme
+    # and username are optional over there, so gating on them just skipped certs that
+    # would have ingested fine.
     def missing_required_fields
       @missing_required_fields ||= {
         "projectName" => project.title,
-        "description" => project.description,
         "demo" => project.demo_url,
-        "repo" => project.repo_url,
-        "readme" => project.readme_url,
-        "username" => cert.owner&.display_name
+        "repo" => project.repo_url
       }.select { |_field, value| value.blank? }.keys
     end
 

--- a/app/services/external_dashboard/verdict_applier.rb
+++ b/app/services/external_dashboard/verdict_applier.rb
@@ -59,9 +59,25 @@ module ExternalDashboard
     end
 
     def apply!
+      reason = record_only_reason
+      cert.record_verdict_only = reason.present?
       cert.update!(status: target_status, feedback: comment, reviewer_id: reviewer&.id, proof_video_url: proof_video_url, decided_at: decided_at)
       cert.assign_external_certification_id!(external_uuid)
-      log_dropped_reviewer
+      reason ? log_record_only(reason) : log_dropped_reviewer
+    end
+
+    # Both of these used to drop the verdict on the floor, which left the cert pending
+    # here forever while the dashboard had it decided - and the poller re-skipped it on
+    # every run, so nothing ever reconciled it. Record the status, skip what's downstream.
+    def record_only_reason
+      return "project deleted" if cert.project.nil? || cert.project.deleted_at.present?
+      return "owner banned" if cert.owner&.banned?
+
+      nil
+    end
+
+    def log_record_only(reason)
+      Rails.logger.info "[ExternalDashboard::VerdictApplier]#{dry_run_tag} cert=#{cert.id} verdict recorded only (#{reason})"
     end
 
     def log_dropped_reviewer


### PR DESCRIPTION
## what's this do?

project verdicts used to get rejected if the project author was banned or the project was deleted this undoes that

<!-- screen recording, screenshots, test output— whatever makes sense for the change -->

## ai?

Claude
