### PR TITLE
Add reviewer, feedback, and repo to hardware approval feed

### DIFF
--- a/app/models/concerns/certification/reviewable.rb
+++ b/app/models/concerns/certification/reviewable.rb
@@ -131,10 +131,12 @@ module Certification
     def post_approval_to_hardware_feed!
       return unless approved?
 
-      locals = notification_locals.slice(:project_title, :project_url)
+      locals = notification_locals.slice(:project_title, :project_url, :reviewer_name, :feedback)
       locals[:review_type] = is_a?(Certification::FundingRequest) ? "design" : "build"
       locals[:owner_slack_id] = owner&.slack_id
       locals[:owner_name] = owner&.display_name
+      locals[:reviewer_slack_id] = reviewer&.slack_id
+      locals[:repo_url] = project.repo_url
 
       if is_a?(Certification::FundingRequest)
         locals[:awards_kit] = awards_design_kit?

--- a/app/views/notifications/hardware/approval_feed.slack_message.slocks
+++ b/app/views/notifications/hardware/approval_feed.slack_message.slocks
@@ -1,5 +1,6 @@
 emoji = ":stardance_star:"
 owner_mention = owner_slack_id.present? ? "<@#{owner_slack_id}>" : owner_name
+reviewer_mention = reviewer_slack_id.present? ? "<@#{reviewer_slack_id}>" : reviewer_name
 
 if review_type == "design"
   amount_line = if awards_kit
@@ -14,3 +15,9 @@ if review_type == "design"
 else
   section "#{emoji} *Build approved:* *<#{project_url}|#{project_title}>* by #{owner_mention}", markdown: true
 end
+
+section "*Reviewed by:* #{reviewer_mention}", markdown: true if reviewer_mention.present?
+
+section "*Feedback:* #{feedback}", markdown: true if feedback.present?
+
+section "*GitHub:* <#{repo_url}|#{repo_url}>", markdown: true if repo_url.present?


### PR DESCRIPTION
## Summary
- Shows who approved the submission (with Slack mention)
- Includes reviewer feedback when present
- Links to the project's GitHub repo

Follow-up to #1250.

## Test plan
- [ ] Approve a hardware funding request → message shows reviewer, feedback, and repo link
- [ ] Approve a hardware build ship → same details shown
- [ ] Approve with no feedback → feedback section omitted
- [ ] Approve a project with no repo URL → GitHub section omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwnMDvqYuYKqReQajD3Vik