### PR TITLE
fix(ysws): filter hardware projects by hardware_stage instead of AI classifier

### DIFF
--- a/app/controllers/admin/certification/ysws_controller.rb
+++ b/app/controllers/admin/certification/ysws_controller.rb
@@ -48,7 +48,10 @@ class Admin::Certification::YswsController < Admin::Certification::ApplicationCo
     queue = ::Certification::Ysws.pending.unclaimed_or_claimed_by(current_user)
     queue = queue.with_integrity_check if @with_integrity
 
-    @type_counts = queue.joins(:project).group("projects.project_type").count
+    software_counts = queue.joins(:project).where(projects: { hardware_stage: nil }).group("projects.project_type").count
+    hardware_count = queue.joins(:project).where.not(projects: { hardware_stage: nil }).count
+    software_counts.delete("Hardware")
+    @type_counts = software_counts.merge("Hardware" => hardware_count).reject { |_k, v| v.zero? }
 
     scope =
       if @search.present?

--- a/app/models/certification/ysws.rb
+++ b/app/models/certification/ysws.rb
@@ -112,9 +112,14 @@ module Certification
     }
 
     scope :by_project_type, ->(type) {
-      type == "unclassified" \
-        ? joins(:project).where(projects: { project_type: nil })
-        : joins(:project).where(projects: { project_type: type })
+      case type
+      when "Hardware"
+        joins(:project).where.not(projects: { hardware_stage: nil })
+      when "unclassified"
+        joins(:project).where(projects: { project_type: nil, hardware_stage: nil })
+      else
+        joins(:project).where(projects: { project_type: type, hardware_stage: nil })
+      end
     }
 
     # Project reviews completed from `time` onwards, with a reviewer attached — the

--- a/app/views/admin/certification/ysws/_queue_table.html.erb
+++ b/app/views/admin/certification/ysws/_queue_table.html.erb
@@ -79,7 +79,7 @@
                 <% end %>
               </td>
               <td data-label="Type">
-                <%= review.project&.project_type.presence || tag.span("—", class: "ysws-queue__placeholder") %>
+                <%= review.project&.hardware? ? "Hardware" : (review.project&.project_type.presence || tag.span("—", class: "ysws-queue__placeholder")) %>
               </td>
               <td data-label="Project">
                 <% if review.project %>


### PR DESCRIPTION
## what do

stop using ai classifier and use state machine for accurate tracking

## ai?

openai model 1 (opus 4.6)