### PR TITLE
feat(fraud): Improve fraud subject review pages

### DIFF
--- a/app/assets/stylesheets/pages/admin/_fraud_subjects.scss
+++ b/app/assets/stylesheets/pages/admin/_fraud_subjects.scss
@@ -68,8 +68,24 @@
   }
 
   .fraud-subject-card__identity {
+    align-items: center;
+    display: flex;
+    gap: var(--space-xs);
+  }
+
+  .fraud-subject-card__avatar {
+    border: 2px solid var(--color-set-2-fg-secondary);
+    border-radius: 50%;
+    flex: 0 0 auto;
+    height: 3rem;
+    object-fit: cover;
+    width: 3rem;
+  }
+
+  .fraud-subject-card__identity-copy {
     align-items: baseline;
     display: flex;
+    flex-wrap: wrap;
     gap: var(--space-xs);
   }
 
@@ -216,6 +232,21 @@
   .fraud-subject__item--resolved {
     border-left: 6px solid var(--color-brand-mint);
     color: var(--color-set-3-fg-secondary);
+  }
+
+  .fraud-subject__identity {
+    align-items: flex-start;
+    display: flex;
+    gap: var(--space-m);
+  }
+
+  .fraud-subject__avatar {
+    border: 2px solid var(--color-set-3-fg-secondary);
+    border-radius: 50%;
+    flex: 0 0 auto;
+    height: 6rem;
+    object-fit: cover;
+    width: 6rem;
   }
 
   .fraud-subject__facts {
@@ -389,6 +420,93 @@
   // so the rejection form has room without stretching the buttons beside it.
   .fraud-subject__reject[open] {
     flex-basis: 100%;
+  }
+
+  .fraud-subject__bulk-actions {
+    align-items: flex-start;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+    margin-bottom: var(--space-m);
+  }
+
+  .fraud-subject__bulk-reject[open] {
+    flex-basis: 100%;
+  }
+
+  .fraud-subject__bulk-reject-form {
+    background: var(--color-set-2-bg);
+    border: 2px solid var(--color-brand-salmon);
+    border-radius: var(--profile-radius);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    margin-top: var(--space-xs);
+    max-width: 42rem;
+    padding: var(--space-m);
+  }
+
+  .fraud-subject__projects {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-s);
+  }
+
+  .fraud-subject__project {
+    background: var(--color-set-2-bg);
+    border: 2px solid var(--color-set-2-fg-secondary);
+    border-radius: var(--profile-radius);
+    padding: var(--space-m);
+  }
+
+  .fraud-subject__mapping-title {
+    font-size: var(--font-size-s);
+    margin: var(--space-m) 0 var(--space-xs);
+  }
+
+  .fraud-subject__key-mappings {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xxs);
+    margin: 0;
+  }
+
+  .fraud-subject__key-mapping {
+    align-items: baseline;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+
+    dd {
+      color: var(--color-set-3-fg-secondary);
+      margin: 0;
+    }
+  }
+
+  .fraud-subject__approved-orders {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xxs);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .fraud-subject__approved-order {
+    align-items: center;
+    background: var(--color-set-2-bg);
+    border: 2px solid var(--color-set-2-fg-secondary);
+    border-radius: var(--profile-radius);
+    display: flex;
+    gap: var(--space-m);
+    justify-content: space-between;
+    padding: var(--space-xs) var(--space-s);
+  }
+
+  @media (max-width: 40rem) {
+    .fraud-subject__identity {
+      flex-direction: column;
+    }
   }
 }
 

--- a/app/controllers/admin/fraud/subjects_controller.rb
+++ b/app/controllers/admin/fraud/subjects_controller.rb
@@ -21,10 +21,49 @@ class Admin::Fraud::SubjectsController < Admin::ApplicationController
 
     @flags = Admin::Fraud::SubjectQueue.flags_for(@user)
     @orders = Admin::Fraud::SubjectQueue.orders_for(@user)
+    @approvable_orders = @orders.select(&:approvable?)
     @integrity_checks = Admin::Fraud::SubjectQueue.integrity_checks_for(@user)
+    @projects_for_rejection = @user.projects.with_deleted.distinct.order(created_at: :desc)
+
+    approved_scope = @user.shop_orders.where(aasm_state: %w[awaiting_periodical_fulfillment fulfilled])
+    @approved_orders_count = approved_scope.count
+    @approved_orders = approved_scope.includes(:shop_item).order(created_at: :desc).limit(10)
 
     # Only Hackatime projects tied to a Stardance project can be deep-linked
     # into Telescreen's per-project view; the rest have no project to name.
     @hackatime_projects = @user.hackatime_projects.where.not(project_id: nil).includes(:project)
+    @project_summaries = project_summaries_for(@user)
+  end
+
+  private
+
+  def project_summaries_for(user)
+    ship_posts = Post.of_ship_events.where(user_id: user.id).includes(:ship_event).order(created_at: :desc).to_a
+    project_ids = ship_posts.map(&:project_id).compact.uniq
+    projects = Project.with_deleted.where(id: project_ids).index_by(&:id)
+    devlogs_by_project = Post.of_devlogs(join: true)
+                              .where(user_id: user.id, project_id: project_ids, post_devlogs: { deleted_at: nil })
+                              .includes(:devlog)
+                              .group_by(&:project_id)
+
+    ship_posts.group_by(&:project_id).filter_map do |project_id, submissions|
+      project = projects[project_id]
+      next unless project
+
+      key_seconds = Hash.new(0)
+      devlogs_by_project.fetch(project_id, []).each do |post|
+        keys = post.devlog.hackatime_projects_key_snapshot.to_s.split(",").map(&:strip).reject(&:blank?).sort
+        label = keys.any? ? keys.join(" + ") : "No key snapshot"
+        key_seconds[label] += post.devlog.duration_seconds.to_i
+      end
+
+      {
+        project:,
+        submissions: submissions.map(&:ship_event),
+        payout: submissions.sum { |post| post.ship_event.payout.to_f },
+        key_seconds: key_seconds.sort_by { |_, seconds| -seconds },
+        total_seconds: key_seconds.values.sum
+      }
+    end
   end
 end

--- a/app/controllers/admin/shop/orders_controller.rb
+++ b/app/controllers/admin/shop/orders_controller.rb
@@ -2,7 +2,7 @@ class Admin::Shop::OrdersController < Admin::ApplicationController
   include FraudSubjectVerdict
 
   before_action :set_paper_trail_whodunnit
-  before_action :set_order, except: [ :index, :bulk_approve ]
+  before_action :set_order, except: [ :index, :bulk_approve, :bulk_reject ]
 
   # Filter/search params that should survive navigation between the status
   # chips, the group-by-user toggle, and pagination. Centralised here so the
@@ -431,6 +431,36 @@ class Admin::Shop::OrdersController < Admin::ApplicationController
     redirect_back fallback_location: admin_shop_orders_path
   end
 
+  def bulk_reject
+    authorize ShopOrder, :reject?
+
+    orders = ShopOrder.includes(:reviews, :accessory_orders).where(id: params[:order_ids])
+
+    if orders.empty?
+      redirect_back fallback_location: admin_shop_orders_path, alert: "No orders to reject." and return
+    end
+
+    rejected, failed = orders.map { |order|
+      Admin::ShopOrderRejector.new(
+        order,
+        actor: current_user,
+        reason: params[:reason],
+        internal_reason: params[:internal_rejection_reason],
+        joe_case_url: params[:joe_case_url],
+        fraud_project_id: params[:fraud_related_project_id]
+      ).call
+    }.partition(&:rejected?)
+
+    if rejected.any?
+      flash[:notice] = "Rejected #{helpers.pluralize(rejected.size, 'order')}: #{rejected.map { |result| "##{result.order.id}" }.to_sentence}"
+    end
+    if failed.any?
+      flash[:alert] = failed.map { |result| "##{result.order.id}: #{result.message}" }.join(" ")
+    end
+
+    redirect_back fallback_location: admin_shop_orders_path
+  end
+
   def review_order
     authorize @order, :review_order?
 
@@ -483,62 +513,21 @@ class Admin::Shop::OrdersController < Admin::ApplicationController
   def reject
     authorize @order, :reject?
 
-    if @order.requires_additional_review?
-      redirect_to admin_shop_order_path(@order), alert: "This is a high-value order and requires 2 fraud dept reviews before rejection (#{@order.reviews.count}/2 so far)." and return
-    end
+    result = Admin::ShopOrderRejector.new(
+      @order,
+      actor: current_user,
+      reason: params[:reason],
+      internal_reason: params[:internal_rejection_reason],
+      joe_case_url: params[:joe_case_url],
+      fraud_project_id: params[:fraud_related_project_id]
+    ).call
 
-    reason = params[:reason].presence || "No reason provided"
+    if result.rejected?
+      return render_fraud_subject_verdict(@order, result.message) if fraud_subject
 
-    if current_user.fraud_dept?
-      internal_reason = params[:internal_rejection_reason]
-      joe_case_url = params[:joe_case_url]
-      fraud_project_id = params[:fraud_related_project_id]
+      redirect_to shop_orders_return_path, notice: result.message
     else
-      internal_reason = reason
-      joe_case_url = nil
-      fraud_project_id = 1
-    end
-    old_state = @order.aasm_state
-
-    @order.internal_rejection_reason = internal_reason
-    @order.joe_case_url = joe_case_url.presence
-    @order.fraud_related_project_id = fraud_project_id.presence
-
-    if @order.mark_rejected(reason) && @order.save
-      ::PaperTrail::Version.create!(
-        item_type: "ShopOrder",
-        item_id: @order.id,
-        event: "update",
-        whodunnit: current_user.id,
-        object_changes: {
-          aasm_state: [ old_state, @order.aasm_state ],
-          rejection_reason: [ nil, reason ],
-          internal_rejection_reason: [ nil, internal_reason ],
-          joe_case_url: [ nil, joe_case_url.presence ],
-          fraud_related_project_id: [ nil, fraud_project_id.presence ]
-        }.compact_blank
-      )
-
-      n = @order.accessory_orders.select(&:may_mark_rejected?).count { |a|
-        old = a.aasm_state
-        a.internal_rejection_reason = internal_reason
-        a.joe_case_url = joe_case_url.presence
-        a.fraud_related_project_id = fraud_project_id.presence
-        next unless a.mark_rejected(reason) && a.save
-        ::PaperTrail::Version.create!(
-          item_type: "ShopOrder", item_id: a.id, event: "update", whodunnit: current_user.id,
-          object_changes: { aasm_state: [ old, a.aasm_state ], rejection_reason: [ nil, reason ], parent_order_cancelled: [ nil, @order.id ] }
-        )
-      }
-
-      notice = "Order rejected"
-      notice += " (#{n} #{'accessory'.pluralize(n)} also rejected)" if n > 0
-
-      return render_fraud_subject_verdict(@order, notice) if fraud_subject
-
-      redirect_to shop_orders_return_path, notice: notice
-    else
-      redirect_to admin_shop_order_path(@order), alert: "Failed to reject order: #{@order.errors.full_messages.join(', ')}"
+      redirect_to admin_shop_order_path(@order), alert: result.message
     end
   end
 

--- a/app/controllers/admin/users/order_rejections_controller.rb
+++ b/app/controllers/admin/users/order_rejections_controller.rb
@@ -2,45 +2,22 @@ class Admin::Users::OrderRejectionsController < Admin::ApplicationController
   def create
     @user = User.find(params[:user_id])
     authorize @user, :reject_orders?
-    reason = params[:reason].presence || "Rejected by fraud department"
-    internal_reason = params[:internal_rejection_reason].presence
-    fraud_project_id = params[:fraud_related_project_id].presence
-    joe_case_url = params[:joe_case_url].presence
-
     orders = @user.shop_orders.where(aasm_state: %w[pending awaiting_periodical_fulfillment])
-    count = 0
-    errors = []
+    rejected, failed = orders.map { |order|
+      Admin::ShopOrderRejector.new(
+        order,
+        actor: current_user,
+        reason: params[:reason].presence || "Rejected by fraud department",
+        internal_reason: params[:internal_rejection_reason],
+        fraud_project_id: params[:fraud_related_project_id],
+        joe_case_url: params[:joe_case_url]
+      ).call
+    }.partition(&:rejected?)
 
-    orders.each do |order|
-      old_state = order.aasm_state
-      order.internal_rejection_reason = internal_reason
-      order.fraud_related_project_id = fraud_project_id
-      order.joe_case_url = joe_case_url
-
-      if order.mark_rejected(reason) && order.save
-        ::PaperTrail::Version.create!(
-          item_type: "ShopOrder",
-          item_id: order.id,
-          event: "update",
-          whodunnit: current_user.id,
-          object_changes: {
-            aasm_state: [ old_state, order.aasm_state ],
-            rejection_reason: [ nil, reason ],
-            internal_rejection_reason: [ nil, internal_reason ],
-            fraud_related_project_id: [ nil, fraud_project_id ],
-            joe_case_url: [ nil, joe_case_url ]
-          }.compact_blank
-        )
-        count += 1
-      else
-        errors.concat(order.errors.full_messages)
-      end
-    end
-
-    if errors.any?
-      flash[:alert] = "Rejected #{count} order(s), but #{orders.size - count} failed: #{errors.uniq.to_sentence}."
+    if failed.any?
+      flash[:alert] = "Rejected #{rejected.size} order(s), but #{failed.size} failed: #{failed.map(&:message).uniq.to_sentence}."
     else
-      flash[:notice] = "Rejected #{count} order(s) for #{@user.display_name}."
+      flash[:notice] = "Rejected #{rejected.size} order(s) for #{@user.display_name}."
     end
     redirect_to admin_user_path(@user)
   end

--- a/app/services/admin/fraud/subject_queue.rb
+++ b/app/services/admin/fraud/subject_queue.rb
@@ -4,21 +4,20 @@ module Admin
     # person at a time instead of three separate queues that keep handing them
     # the same person.
     #
-    # Three sources feed it: flags (Project::Report on a reason the fraud team
-    # owns), shop orders awaiting a verdict, and pending integrity checks. Each
-    # item scores its age in days times a weight, and a person's priority is
+    # Two sources feed the default queue: reports on reasons the fraud team owns
+    # and shop orders awaiting a verdict. Integrity checks stay available on a
+    # person's detail page, but do not put someone into this queue by themselves.
+    # Each item scores its age in days times a weight, and a person's priority is
     # their single highest-scoring item. Highest wins.
     #
-    # MAX rather than SUM: one genuinely old flag should outrank a pile of fresh
-    # integrity checks, and nobody should reach the top of the queue on volume
-    # alone.
+    # MAX rather than SUM: one genuinely old report should outrank a pile of
+    # fresh orders, and nobody should reach the top of the queue on volume alone.
     class SubjectQueue
       FLAG_WEIGHT = 3.0
       ORDER_WEIGHT = 2.0
-      INTEGRITY_WEIGHT = 1.0
 
-      Subject = Data.define(:user_id, :priority, :flag_count, :order_count, :integrity_count, :oldest_at) do
-        def item_count = flag_count + order_count + integrity_count
+      Subject = Data.define(:user_id, :priority, :flag_count, :order_count, :oldest_at) do
+        def item_count = flag_count + order_count
       end
 
       # One row per person with work waiting, ordered by priority. Banned people
@@ -33,7 +32,6 @@ module Admin
                 MAX(fraud_items.weight * EXTRACT(EPOCH FROM (NOW() - fraud_items.created_at)) / 86400.0) AS priority,
                 COUNT(*) FILTER (WHERE fraud_items.kind = 'flag') AS flag_count,
                 COUNT(*) FILTER (WHERE fraud_items.kind = 'order') AS order_count,
-                COUNT(*) FILTER (WHERE fraud_items.kind = 'integrity') AS integrity_count,
                 MIN(fraud_items.created_at) AS oldest_at
               SQL
               .order(Arel.sql("priority DESC"))
@@ -46,7 +44,6 @@ module Admin
             priority: row.priority.to_f,
             flag_count: row.flag_count,
             order_count: row.order_count,
-            integrity_count: row.integrity_count,
             oldest_at: row.oldest_at
           )
         end
@@ -73,9 +70,9 @@ module Admin
           .select("posts.user_id AS user_id, certification_integrities.created_at AS created_at")
       end
 
-      # The same three sources, narrowed to one person. The subject page and the
-      # verdict responses both read them from here so a filter can never drift
-      # between the queue and the page it opens.
+      # The review sources narrowed to one person. The subject page and verdict
+      # responses read them from here so filters cannot drift between the queue
+      # and the page it opens.
       def self.flags_for(user)
         ::Project::Report.pending
           .where(project: user.projects, reason: ::Project::Report::FRAUD_REVIEW_REASONS)
@@ -101,8 +98,7 @@ module Admin
       def self.items_sql
         [
           branch_sql(flags, "flag", FLAG_WEIGHT),
-          branch_sql(orders, "order", ORDER_WEIGHT),
-          branch_sql(integrity_checks, "integrity", INTEGRITY_WEIGHT)
+          branch_sql(orders, "order", ORDER_WEIGHT)
         ].join(" UNION ALL ")
       end
 

--- a/app/services/admin/shop_order_rejector.rb
+++ b/app/services/admin/shop_order_rejector.rb
@@ -1,0 +1,70 @@
+module Admin
+  class ShopOrderRejector
+    Result = Data.define(:order, :rejected, :message) do
+      def rejected? = rejected
+    end
+
+    def initialize(order, actor:, reason: nil, internal_reason: nil, joe_case_url: nil, fraud_project_id: nil)
+      @order = order
+      @actor = actor
+      @reason = reason.presence || "No reason provided"
+      fraud_reviewer = actor.admin? || actor.fraud_dept?
+      @internal_reason = fraud_reviewer ? internal_reason.presence : @reason
+      @joe_case_url = fraud_reviewer ? joe_case_url.presence : nil
+      @fraud_project_id = fraud_reviewer ? fraud_project_id.presence : 1
+    end
+
+    def call
+      return failure("This is a high-value order and requires 2 fraud dept reviews before rejection (#{order.reviews.count}/2 so far).") if order.requires_additional_review?
+
+      old_state = order.aasm_state
+      order.internal_rejection_reason = internal_reason
+      order.joe_case_url = joe_case_url
+      order.fraud_related_project_id = fraud_project_id
+
+      return failure("Failed to reject order: #{order.errors.full_messages.join(', ')}") unless order.mark_rejected(reason) && order.save
+
+      record_version(order, old_state)
+      accessory_count = reject_accessories
+      message = "Order ##{order.id} rejected"
+      message += " (#{accessory_count} #{'accessory'.pluralize(accessory_count)} also rejected)" if accessory_count.positive?
+      success(message)
+    end
+
+    private
+
+    attr_reader :order, :actor, :reason, :internal_reason, :joe_case_url, :fraud_project_id
+
+    def reject_accessories
+      order.accessory_orders.select(&:may_mark_rejected?).count do |accessory|
+        old_state = accessory.aasm_state
+        accessory.internal_rejection_reason = internal_reason
+        accessory.joe_case_url = joe_case_url
+        accessory.fraud_related_project_id = fraud_project_id
+        next false unless accessory.mark_rejected(reason) && accessory.save
+
+        record_version(accessory, old_state, parent_order_cancelled: [ nil, order.id ])
+        true
+      end
+    end
+
+    def record_version(rejected_order, old_state, extra_changes = {})
+      ::PaperTrail::Version.create!(
+        item_type: "ShopOrder",
+        item_id: rejected_order.id,
+        event: "update",
+        whodunnit: actor.id,
+        object_changes: {
+          aasm_state: [ old_state, rejected_order.aasm_state ],
+          rejection_reason: [ nil, reason ],
+          internal_rejection_reason: [ nil, internal_reason ],
+          joe_case_url: [ nil, joe_case_url ],
+          fraud_related_project_id: [ nil, fraud_project_id ]
+        }.merge(extra_changes).compact_blank
+      )
+    end
+
+    def success(message) = Result.new(order:, rejected: true, message:)
+    def failure(message) = Result.new(order:, rejected: false, message:)
+  end
+end

--- a/app/views/admin/fraud/subjects/_approved_orders.html.erb
+++ b/app/views/admin/fraud/subjects/_approved_orders.html.erb
@@ -1,0 +1,26 @@
+<section class="fraud-subject__section" aria-labelledby="fraud-subject-approved-orders">
+  <h2 class="fraud-subject__section-title" id="fraud-subject-approved-orders">
+    Previously approved orders
+    <span class="fraud-subject__section-count"><%= approved_orders_count %></span>
+  </h2>
+
+  <% if approved_orders.any? %>
+    <ul class="fraud-subject__approved-orders">
+      <% approved_orders.each do |order| %>
+        <li class="fraud-subject__approved-order">
+          <span>
+            <strong><%= order.quantity %> × <%= order.shop_item.name %></strong>
+            <span class="fraud-subject__fact-note">#<%= order.id %> · <%= order.aasm_state.humanize %></span>
+          </span>
+          <%= link_to "Open order", admin_shop_order_path(order), class: "fraud-subject__item-action" %>
+        </li>
+      <% end %>
+    </ul>
+
+    <% if approved_orders_count > approved_orders.size %>
+      <p class="fraud-subject__fact-note">Showing the latest <%= approved_orders.size %>.</p>
+    <% end %>
+  <% else %>
+    <p class="fraud-subject__empty">No previously approved orders.</p>
+  <% end %>
+</section>

--- a/app/views/admin/fraud/subjects/_identity.html.erb
+++ b/app/views/admin/fraud/subjects/_identity.html.erb
@@ -3,46 +3,50 @@
 <section class="fraud-subject__section" aria-labelledby="fraud-subject-identity">
   <h2 class="fraud-subject__section-title" id="fraud-subject-identity">Identity</h2>
 
-  <dl class="fraud-subject__facts">
-    <div class="fraud-subject__fact">
-      <dt class="fraud-subject__fact-label">Name</dt>
-      <dd class="fraud-subject__fact-value"><%= user.display_name.presence || dash %></dd>
-    </div>
+  <div class="fraud-subject__identity">
+    <%= image_tag user.avatar, alt: "", class: "fraud-subject__avatar" %>
 
-    <div class="fraud-subject__fact">
-      <dt class="fraud-subject__fact-label">User ID</dt>
-      <dd class="fraud-subject__fact-value">#<%= user.id %></dd>
-    </div>
+    <dl class="fraud-subject__facts">
+      <div class="fraud-subject__fact">
+        <dt class="fraud-subject__fact-label">Name</dt>
+        <dd class="fraud-subject__fact-value"><%= user.display_name.presence || dash %></dd>
+      </div>
 
-    <div class="fraud-subject__fact">
-      <dt class="fraud-subject__fact-label">Email</dt>
-      <dd class="fraud-subject__fact-value"><%= user.email.presence || dash %></dd>
-    </div>
+      <div class="fraud-subject__fact">
+        <dt class="fraud-subject__fact-label">User ID</dt>
+        <dd class="fraud-subject__fact-value">#<%= user.id %></dd>
+      </div>
 
-    <div class="fraud-subject__fact">
-      <dt class="fraud-subject__fact-label">Slack ID</dt>
-      <dd class="fraud-subject__fact-value"><%= user.slack_id.presence || dash %></dd>
-    </div>
+      <div class="fraud-subject__fact">
+        <dt class="fraud-subject__fact-label">Email</dt>
+        <dd class="fraud-subject__fact-value"><%= user.email.presence || dash %></dd>
+      </div>
 
-    <div class="fraud-subject__fact">
-      <dt class="fraud-subject__fact-label">Verification</dt>
-      <dd class="fraud-subject__fact-value"><%= user.verification_status.humanize %></dd>
-    </div>
+      <div class="fraud-subject__fact">
+        <dt class="fraud-subject__fact-label">Slack ID</dt>
+        <dd class="fraud-subject__fact-value"><%= user.slack_id.presence || dash %></dd>
+      </div>
 
-    <div class="fraud-subject__fact">
-      <dt class="fraud-subject__fact-label">Banned</dt>
-      <%# The queue only lists unbanned people, but a ban landing mid-review
-          leaves the reviewer on this page, so the state has to be visible. %>
-      <dd class="fraud-subject__fact-value <%= "fraud-subject__fact-value--alert" if user.banned? %>">
-        <% if user.banned? %>
-          Yes
-          <% if user.banned_at %>
-            <span class="fraud-subject__fact-note"><%= time_ago_in_words(user.banned_at) %> ago</span>
+      <div class="fraud-subject__fact">
+        <dt class="fraud-subject__fact-label">Verification</dt>
+        <dd class="fraud-subject__fact-value"><%= user.verification_status.humanize %></dd>
+      </div>
+
+      <div class="fraud-subject__fact">
+        <dt class="fraud-subject__fact-label">Banned</dt>
+        <%# The queue only lists unbanned people, but a ban landing mid-review
+            leaves the reviewer on this page, so the state has to be visible. %>
+        <dd class="fraud-subject__fact-value <%= "fraud-subject__fact-value--alert" if user.banned? %>">
+          <% if user.banned? %>
+            Yes
+            <% if user.banned_at %>
+              <span class="fraud-subject__fact-note"><%= time_ago_in_words(user.banned_at) %> ago</span>
+            <% end %>
+          <% else %>
+            No
           <% end %>
-        <% else %>
-          No
-        <% end %>
-      </dd>
-    </div>
-  </dl>
+        </dd>
+      </div>
+    </dl>
+  </div>
 </section>

--- a/app/views/admin/fraud/subjects/_order_bulk_actions.html.erb
+++ b/app/views/admin/fraud/subjects/_order_bulk_actions.html.erb
@@ -1,0 +1,42 @@
+<% if orders.any? %>
+  <div class="fraud-subject__bulk-actions" aria-label="Bulk order actions">
+    <% if approvable_orders.any? && policy(approvable_orders.first).approve? && user.id != current_user.id %>
+      <%= button_to "Approve all #{pluralize(approvable_orders.size, "order")}",
+                    bulk_approve_admin_shop_orders_path,
+                    params: { order_ids: approvable_orders.map(&:id) },
+                    class: "fraud-subject__verdict fraud-subject__verdict--accept",
+                    data: { turbo_confirm: "Approve all #{approvable_orders.size} approvable orders for #{user.display_name}?" } %>
+    <% end %>
+
+    <% if policy(orders.first).reject? %>
+      <details class="fraud-subject__bulk-reject">
+        <summary class="fraud-subject__verdict fraud-subject__verdict--reject">
+          Reject all <%= pluralize(orders.size, "order") %>
+        </summary>
+
+        <%= form_with url: bulk_reject_admin_shop_orders_path, class: "fraud-subject__bulk-reject-form" do |f| %>
+          <% orders.each do |order| %>
+            <%= hidden_field_tag "order_ids[]", order.id, id: nil %>
+          <% end %>
+
+          <%= f.label :reason, "Reason shown to the buyer", class: "fraud-subject__field-label" %>
+          <%= f.text_field :reason, required: true, class: "fraud-subject__field" %>
+
+          <%= f.label :internal_rejection_reason, "Internal reason", class: "fraud-subject__field-label" %>
+          <%= f.text_area :internal_rejection_reason, rows: 2,
+                          required: current_user.admin? || current_user.fraud_dept?, class: "fraud-subject__field" %>
+
+          <%= f.label :fraud_related_project_id, "Related project", class: "fraud-subject__field-label" %>
+          <%= f.select :fraud_related_project_id,
+                       projects.map { |project| [ project.title, project.id ] },
+                       { include_blank: "Pick a project" },
+                       required: current_user.admin? || current_user.fraud_dept?, class: "fraud-subject__field" %>
+
+          <%= f.submit "Reject all orders",
+                       class: "fraud-subject__verdict fraud-subject__verdict--reject",
+                       data: { turbo_confirm: "Reject all #{orders.size} orders for #{user.display_name}?" } %>
+        <% end %>
+      </details>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/admin/fraud/subjects/_project_history.html.erb
+++ b/app/views/admin/fraud/subjects/_project_history.html.erb
@@ -1,0 +1,64 @@
+<section class="fraud-subject__section" aria-labelledby="fraud-subject-projects">
+  <h2 class="fraud-subject__section-title" id="fraud-subject-projects">
+    Submitted projects
+    <span class="fraud-subject__section-count"><%= project_summaries.size %></span>
+  </h2>
+
+  <% if project_summaries.any? %>
+    <div class="fraud-subject__projects">
+      <% project_summaries.each do |summary| %>
+        <article class="fraud-subject__project">
+          <div class="fraud-subject__item-head">
+            <h3 class="fraud-subject__item-title">
+              <%= link_to summary[:project].title, admin_project_path(summary[:project]) %>
+            </h3>
+            <span class="fraud-subject__item-age">#<%= summary[:project].id %></span>
+          </div>
+
+          <dl class="fraud-subject__facts">
+            <div class="fraud-subject__fact">
+              <dt class="fraud-subject__fact-label">Submissions</dt>
+              <dd class="fraud-subject__fact-value"><%= summary[:submissions].size %></dd>
+            </div>
+            <div class="fraud-subject__fact">
+              <dt class="fraud-subject__fact-label">Status</dt>
+              <dd class="fraud-subject__fact-value">
+                <%= summary[:submissions].map { |ship| ship.certification_status.humanize }.uniq.to_sentence %>
+              </dd>
+            </div>
+            <div class="fraud-subject__fact">
+              <dt class="fraud-subject__fact-label">Stardust gained</dt>
+              <dd class="fraud-subject__fact-value">
+                <%= summary[:payout].positive? ? number_with_delimiter(summary[:payout]) : "None" %>
+              </dd>
+            </div>
+            <div class="fraud-subject__fact">
+              <dt class="fraud-subject__fact-label">Credited time</dt>
+              <dd class="fraud-subject__fact-value">
+                <%= number_with_precision(summary[:total_seconds] / 1.hour.to_f, precision: 2, strip_insignificant_zeros: true) %> hours
+              </dd>
+            </div>
+          </dl>
+
+          <% if summary[:key_seconds].any? %>
+            <h4 class="fraud-subject__mapping-title">Hackatime key mapping</h4>
+            <dl class="fraud-subject__key-mappings">
+              <% summary[:key_seconds].each do |keys, seconds| %>
+                <div class="fraud-subject__key-mapping">
+                  <dt><code><%= keys %></code></dt>
+                  <dd>
+                    <%= number_with_precision(seconds / 1.hour.to_f, precision: 2, strip_insignificant_zeros: true) %> hours logged
+                  </dd>
+                </div>
+              <% end %>
+            </dl>
+          <% else %>
+            <p class="fraud-subject__empty">No credited devlog time or Hackatime key snapshots.</p>
+          <% end %>
+        </article>
+      <% end %>
+    </div>
+  <% else %>
+    <p class="fraud-subject__empty">No projects submitted.</p>
+  <% end %>
+</section>

--- a/app/views/admin/fraud/subjects/index.html.erb
+++ b/app/views/admin/fraud/subjects/index.html.erb
@@ -19,8 +19,11 @@
         <li class="fraud-queue__item">
           <%= link_to admin_fraud_subject_path(subject.user_id), class: "fraud-subject-card" do %>
             <span class="fraud-subject-card__identity">
-              <span class="fraud-subject-card__name"><%= user.display_name %></span>
-              <span class="fraud-subject-card__id">#<%= user.id %></span>
+              <%= image_tag user.avatar, alt: "", class: "fraud-subject-card__avatar", loading: "lazy" %>
+              <span class="fraud-subject-card__identity-copy">
+                <span class="fraud-subject-card__name"><%= user.display_name %></span>
+                <span class="fraud-subject-card__id">#<%= user.id %></span>
+              </span>
             </span>
 
             <span class="fraud-subject-card__counts">
@@ -32,11 +35,6 @@
               <% if subject.order_count.positive? %>
                 <span class="fraud-subject-card__count fraud-subject-card__count--order">
                   <%= pluralize(subject.order_count, "order") %>
-                </span>
-              <% end %>
-              <% if subject.integrity_count.positive? %>
-                <span class="fraud-subject-card__count fraud-subject-card__count--integrity">
-                  <%= pluralize(subject.integrity_count, "check") %>
                 </span>
               <% end %>
             </span>

--- a/app/views/admin/fraud/subjects/show.html.erb
+++ b/app/views/admin/fraud/subjects/show.html.erb
@@ -14,6 +14,8 @@
 
   <%= render "telescreen_tools" %>
 
+  <%= render "project_history", project_summaries: @project_summaries %>
+
   <section class="fraud-subject__section" aria-labelledby="fraud-subject-flags">
     <h2 class="fraud-subject__section-title" id="fraud-subject-flags">Flags</h2>
 
@@ -29,6 +31,9 @@
   <section class="fraud-subject__section" aria-labelledby="fraud-subject-orders">
     <h2 class="fraud-subject__section-title" id="fraud-subject-orders">Shop orders</h2>
 
+    <%= render "order_bulk_actions", user: @user, orders: @orders,
+               approvable_orders: @approvable_orders, projects: @projects_for_rejection %>
+
     <% if @orders.any? %>
       <div class="fraud-subject__items">
         <%= render partial: "order", collection: @orders, as: :order, locals: { user: @user } %>
@@ -37,6 +42,9 @@
       <p class="fraud-subject__empty">No orders waiting.</p>
     <% end %>
   </section>
+
+  <%= render "approved_orders", approved_orders: @approved_orders,
+             approved_orders_count: @approved_orders_count %>
 
   <section class="fraud-subject__section" aria-labelledby="fraud-subject-integrity">
     <h2 class="fraud-subject__section-title" id="fraud-subject-integrity">Integrity checks</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -721,9 +721,9 @@ Rails.application.routes.draw do
     resource :support, only: [ :show ], controller: "support/dashboards"
     resource :fraud, only: [ :show ], controller: "fraud/dashboards"
     namespace :fraud do
-      # One page per person with fraud work waiting: their flags, shop orders
-      # and integrity checks together, ranked by whoever has waited longest on
-      # the thing that matters most.
+      # One page per person with fraud work waiting: reports and shop orders are
+      # ranked by whoever has waited longest on the thing that matters most.
+      # Integrity checks remain supporting context on the subject page.
       resources :subjects, only: [ :index, :show ]
     end
 
@@ -775,6 +775,7 @@ Rails.application.routes.draw do
       resources :orders, only: [ :index, :show ] do
         collection do
           post :bulk_approve
+          post :bulk_reject
         end
         member do
           post :reveal_address

--- a/test/controllers/admin/fraud/subject_verdicts_test.rb
+++ b/test/controllers/admin/fraud/subject_verdicts_test.rb
@@ -99,6 +99,46 @@ class Admin::Fraud::SubjectVerdictsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "the subject page offers bulk order verdicts" do
+    pending_order
+
+    get admin_fraud_subject_path(@subject)
+
+    assert_response :success
+    assert_select "form[action=?] button", bulk_approve_admin_shop_orders_path, text: "Approve all 1 order"
+    assert_select "form[action=?] input[type=submit]", bulk_reject_admin_shop_orders_path, value: "Reject all orders"
+  end
+
+  test "the subject page shows previously approved orders" do
+    order = pending_order
+    order.update_columns(aasm_state: "awaiting_periodical_fulfillment", awaiting_periodical_fulfillment_at: Time.current)
+
+    get admin_fraud_subject_path(@subject)
+
+    assert_response :success
+    assert_select "#fraud-subject-approved-orders", text: /Previously approved orders/
+    assert_match order.shop_item.name, response.body
+    assert_match "Awaiting periodical fulfillment", response.body
+  end
+
+  test "bulk rejection rejects every selected subject order and audits each verdict" do
+    order = pending_order
+    project = Project.create!(title: "Fraud source")
+
+    post bulk_reject_admin_shop_orders_path,
+         params: {
+           order_ids: [ order.id ],
+           reason: "Fraud review failed",
+           internal_rejection_reason: "Matching evidence",
+           fraud_related_project_id: project.id
+         },
+         headers: { "HTTP_REFERER" => admin_fraud_subject_url(@subject) }
+
+    assert_redirected_to admin_fraud_subject_path(@subject)
+    assert_predicate order.reload, :rejected?
+    assert PaperTrail::Version.where(item_type: "ShopOrder", item_id: order.id, whodunnit: @admin.id.to_s).exists?
+  end
+
   test "putting an order on hold keeps it in the queue and re-renders the row" do
     order = pending_order
 

--- a/test/controllers/admin/fraud/subjects_controller_test.rb
+++ b/test/controllers/admin/fraud/subjects_controller_test.rb
@@ -23,6 +23,17 @@ class Admin::Fraud::SubjectsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "a[href=?]", admin_fraud_subject_path(@subject)
+    assert_select ".fraud-subject-card__avatar[src=?]", @subject.avatar
+  end
+
+  test "the queue leaves out someone with only an integrity check" do
+    pending_integrity_check(@project)
+
+    sign_in @squad
+    get admin_fraud_subjects_path
+
+    assert_response :success
+    assert_select "a[href=?]", admin_fraud_subject_path(@subject), count: 0
   end
 
   test "the queue leaves out quality reports the fraud team does not own" do
@@ -75,6 +86,26 @@ class Admin::Fraud::SubjectsControllerTest < ActionDispatch::IntegrationTest
     assert_match @subject.email, response.body
     assert_match "U_FRAUD_SUBJECT", response.body
     assert_match "Needs submission", response.body
+    assert_select ".fraud-subject__avatar[src=?]", @subject.avatar
+  end
+
+  test "the subject page breaks submitted projects down by payout, keys and credited time" do
+    ship = Post::ShipEvent.create!(body: "Ship it", uploading_attachments: true)
+    ship.update_columns(certification_status: "approved", payout: 42)
+    Post.create!(project: @project, user: @subject, postable: ship)
+
+    devlog = Post::Devlog.create!(body: "Built the thing", duration_seconds: 90.minutes.to_i,
+                                  hackatime_projects_key_snapshot: "api,web", uploading_attachments: true)
+    Post.create!(project: @project, user: @subject, postable: devlog)
+
+    sign_in @squad
+    get admin_fraud_subject_path(@subject)
+
+    assert_response :success
+    assert_select "#fraud-subject-projects", text: /Submitted projects/
+    assert_match "42.0", response.body
+    assert_match "api + web", response.body
+    assert_match "1.5 hours logged", response.body
   end
 
   test "the subject page describes the project behind each integrity check" do

--- a/test/services/admin/fraud/subject_queue_test.rb
+++ b/test/services/admin/fraud/subject_queue_test.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
-# The order a fraud reviewer works people in. Flags outrank shop orders outrank
-# integrity checks, because the first two hold up something the person can see
-# happening to them and the third does not.
+# The order a fraud reviewer works people in. Reports outrank shop orders;
+# integrity checks remain available as detail-page context but do not put a
+# person into the default queue.
 class Admin::Fraud::SubjectQueueTest < ActiveSupport::TestCase
   include UserFactory
 
@@ -12,29 +12,32 @@ class Admin::Fraud::SubjectQueueTest < ActiveSupport::TestCase
     @reporter = create_user(slack_id: "u-reporter", display_name: "reporter")
   end
 
-  test "a fresher flag outranks an older integrity check" do
-    flagged = user_with_flag(age: 10.days.ago)
-    checked = user_with_integrity(age: 25.days.ago)
+  test "an integrity check alone does not enter the default queue" do
+    user_with_integrity(age: 25.days.ago)
 
-    assert_equal [ flagged.id, checked.id ], ranked_ids
+    assert_empty subjects
   end
 
-  test "a shop order outranks an integrity check of the same age" do
+  test "a report outranks an order with the same age" do
+    flagged = user_with_flag(age: 5.days.ago)
     ordered = user_with_order(age: 5.days.ago)
-    checked = user_with_integrity(age: 5.days.ago)
 
-    assert_equal [ ordered.id, checked.id ], ranked_ids
+    assert_equal [ flagged.id, ordered.id ], ranked_ids
   end
 
   test "priority is the single highest scoring item, not the sum" do
-    one_old_flag = user_with_flag(age: 20.days.ago)
-    many_fresh_checks = create_user(slack_id: "u-many", display_name: "many")
-    5.times { pending_integrity_for(many_fresh_checks, age: 1.day.ago) }
+    one_old_order = user_with_order(age: 20.days.ago)
+    many_fresh_flags = create_user(slack_id: "u-many", display_name: "many")
+    5.times do
+      project = Project.create!(title: "Flagged #{SecureRandom.hex(4)}")
+      Project::Membership.create!(project:, user: many_fresh_flags, role: :owner)
+      flag_for(project, age: 1.day.ago)
+    end
 
-    assert_equal [ one_old_flag.id, many_fresh_checks.id ], ranked_ids
+    assert_equal [ one_old_order.id, many_fresh_flags.id ], ranked_ids
   end
 
-  test "counts each source separately for one person" do
+  test "counts reports and orders for one person" do
     user = user_with_flag(age: 3.days.ago)
     user.update!(has_gotten_free_stickers: true) # clears the shop-tutorial gate
     order_for(user, age: 2.days.ago)
@@ -43,8 +46,8 @@ class Admin::Fraud::SubjectQueueTest < ActiveSupport::TestCase
     subject = subjects.sole
 
     assert_equal user.id, subject.user_id
-    assert_equal [ 1, 1, 1 ], [ subject.flag_count, subject.order_count, subject.integrity_count ]
-    assert_equal 3, subject.item_count
+    assert_equal [ 1, 1 ], [ subject.flag_count, subject.order_count ]
+    assert_equal 2, subject.item_count
   end
 
   test "leaves out quality reports, buyer-side orders, decided checks and banned people" do


### PR DESCRIPTION
## what's this do?

Improves the admin fraud subject queue and detail pages:

- shows Cachet-powered Slack avatars on queue and subject pages
- keeps integrity checks out of the default queue so it only ranks fraud reports and shop-order reviews
- adds approve-all and reject-all order actions with authorization and PaperTrail auditing
- shows submitted-project payouts and persisted Hackatime key-to-credited-time mappings
- shows previously approved orders
- consolidates order rejection behavior in a shared service

## show it works

Passing:

- `bundle exec rubocop app/controllers/admin/fraud/subjects_controller.rb app/controllers/admin/shop/orders_controller.rb app/controllers/admin/users/order_rejections_controller.rb app/services/admin/fraud/subject_queue.rb app/services/admin/shop_order_rejector.rb test/controllers/admin/fraud/subjects_controller_test.rb test/controllers/admin/fraud/subject_verdicts_test.rb test/services/admin/fraud/subject_queue_test.rb`
- `bundle exec erb_lint app/views/admin/fraud/subjects/index.html.erb app/views/admin/fraud/subjects/show.html.erb app/views/admin/fraud/subjects/_identity.html.erb app/views/admin/fraud/subjects/_approved_orders.html.erb app/views/admin/fraud/subjects/_order_bulk_actions.html.erb app/views/admin/fraud/subjects/_project_history.html.erb`
- `bin/rails dartsass:build`
- Ruby syntax, route, and `git diff --check` checks

The focused Rails test command could not start locally because the host PostgreSQL installation does not have the `vector` extension available while loading the test schema. The checkout also warns that the MJML binary is missing.

## ai?

Implemented with the fx coding assistant.
