### PR TITLE
feat(shop): expire shop order holds after seven days

### DIFF
--- a/app/assets/stylesheets/pages/shop/_admin_order_show.scss
+++ b/app/assets/stylesheets/pages/shop/_admin_order_show.scss
@@ -1123,3 +1123,17 @@
     }
   }
 }
+
+.hold-countdown {
+  display: block;
+  margin-top: var(--space-xxs);
+  color: var(--color-space-text-muted);
+  font-family: var(--font-family-text);
+  font-size: var(--font-size-xs);
+  white-space: nowrap;
+
+  strong {
+    color: var(--color-brand-yellow);
+    font-variant-numeric: tabular-nums;
+  }
+}

--- a/app/javascript/controllers/countdown_controller.js
+++ b/app/javascript/controllers/countdown_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
-// Live "Xh Ymin" countdown to a fixed instant (the next daily reset). Ticks
-// every half-minute so the minute display stays current; clamps at zero.
+// Live countdown to a fixed instant. Ticks every half-minute so the minute
+// display stays current; includes days for longer windows and clamps at zero.
 export default class extends Controller {
   static values = { resetAt: String, expiredText: String };
 
@@ -23,8 +23,10 @@ export default class extends Controller {
     }
 
     const secs = Math.max(0, Math.floor(remaining / 1000));
-    const hours = Math.floor(secs / 3600);
+    const totalHours = Math.floor(secs / 3600);
+    const days = Math.floor(totalHours / 24);
+    const hours = totalHours % 24;
     const mins = Math.floor((secs % 3600) / 60);
-    this.element.textContent = `${hours}h ${mins}min`;
+    this.element.textContent = days > 0 ? `${days}d ${hours}h ${mins}min` : `${hours}h ${mins}min`;
   }
 }

--- a/app/javascript/controllers/countdown_controller.js
+++ b/app/javascript/controllers/countdown_controller.js
@@ -27,6 +27,7 @@ export default class extends Controller {
     const days = Math.floor(totalHours / 24);
     const hours = totalHours % 24;
     const mins = Math.floor((secs % 3600) / 60);
-    this.element.textContent = days > 0 ? `${days}d ${hours}h ${mins}min` : `${hours}h ${mins}min`;
+    this.element.textContent =
+      days > 0 ? `${days}d ${hours}h ${mins}min` : `${hours}h ${mins}min`;
   }
 }

--- a/app/jobs/shop/release_expired_order_holds_job.rb
+++ b/app/jobs/shop/release_expired_order_holds_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class Shop::ReleaseExpiredOrderHoldsJob < ApplicationJob
+  queue_as :latency_10s
+
+  WHODUNNIT = name.freeze
+
+  def perform(now = Time.current)
+    ShopOrder.expired_holds(now).find_each do |order|
+      release_if_expired(order, now)
+    end
+  end
+
+  private
+
+  def release_if_expired(order, now)
+    order.with_lock do
+      return unless order.hold_expired?(now)
+
+      PaperTrail.request(whodunnit: WHODUNNIT) do
+        order.paper_trail_event = "automatic_hold_release"
+        order.take_off_hold!
+      end
+    end
+  end
+end

--- a/app/models/shop_order.rb
+++ b/app/models/shop_order.rb
@@ -133,7 +133,15 @@ class ShopOrder < ApplicationRecord
   before_create :freeze_item_price
   before_create :set_region_from_address
   after_commit :notify_user_of_status_change, if: :saved_change_to_aasm_state?
+  after_commit :schedule_hold_release, if: :placed_on_hold?
 
+  HOLD_DURATION = 7.days
+
+  scope :expired_holds, ->(now = Time.current) {
+    cutoff = now - HOLD_DURATION
+    where(aasm_state: "on_hold")
+      .where("on_hold_at <= :cutoff OR (on_hold_at IS NULL AND updated_at <= :cutoff)", cutoff: cutoff)
+  }
   scope :worth_counting, -> { where.not(aasm_state: %w[rejected refunded]) }
   scope :real, -> { without_item_type("ShopItem::FreeStickers") }
   scope :manually_fulfilled, -> { joins(:shop_item).merge(ShopItem.where(type: ShopItem::MANUAL_FULFILLMENT_TYPES)) }
@@ -278,6 +286,17 @@ class ShopOrder < ApplicationRecord
         create_refund_payout
       end
     end
+  end
+
+  def hold_expires_at
+    return unless on_hold?
+
+    (on_hold_at || updated_at) + HOLD_DURATION
+  end
+
+  def hold_expired?(now = Time.current)
+    expiration = hold_expires_at
+    expiration.present? && expiration <= now
   end
 
   def digital?
@@ -439,6 +458,15 @@ class ShopOrder < ApplicationRecord
   end
 
   private
+
+  def placed_on_hold?
+    saved_change_to_aasm_state? && on_hold?
+  end
+
+  def schedule_hold_release
+    expiration = hold_expires_at
+    Shop::ReleaseExpiredOrderHoldsJob.set(wait_until: expiration).perform_later(expiration)
+  end
 
   def freeze_item_price
     return unless shop_item

--- a/app/views/admin/fraud/subjects/_order.html.erb
+++ b/app/views/admin/fraud/subjects/_order.html.erb
@@ -9,6 +9,7 @@
 
     <p class="fraud-subject__item-meta">
       <%= order.aasm_state.humanize %> · <%= order.shop_item.type.demodulize.underscore.humanize %>
+      <%= render "admin/shop/orders/hold_countdown", order: order %>
     </p>
 
     <dl class="fraud-subject__facts">

--- a/app/views/admin/shop/orders/_grouped_table.html.erb
+++ b/app/views/admin/shop/orders/_grouped_table.html.erb
@@ -52,6 +52,7 @@
               <span class="badge badge-<%= order.aasm_state %>">
                 <%= order.aasm_state.humanize %>
               </span>
+              <%= render "admin/shop/orders/hold_countdown", order: order %>
             </td>
             <td><%= order.created_at.strftime("%b %d, %Y") %></td>
             <td>

--- a/app/views/admin/shop/orders/_hold_countdown.html.erb
+++ b/app/views/admin/shop/orders/_hold_countdown.html.erb
@@ -1,0 +1,8 @@
+<% if order.on_hold? && order.hold_expires_at.present? %>
+  <span class="hold-countdown">
+    Automatically releases in
+    <strong data-controller="countdown"
+            data-countdown-reset-at-value="<%= order.hold_expires_at.iso8601 %>"
+            data-countdown-expired-text-value="release queued"><%= distance_of_time_in_words(Time.current, order.hold_expires_at) %></strong>
+  </span>
+<% end %>

--- a/app/views/admin/shop/orders/show.html.erb
+++ b/app/views/admin/shop/orders/show.html.erb
@@ -110,6 +110,9 @@
           <span class="aorder__row-label">Status</span>
           <span class="aorder__row-value">
             <span class="aorder__state-badge aorder__state-badge--<%= display_s %>"><%= display_s.humanize %></span>
+            <% if policy(@order).view_on_hold_state? %>
+              <%= render "admin/shop/orders/hold_countdown", order: @order %>
+            <% end %>
           </span>
         </div>
         <% unless policy(current_user).view_order_full_details? %>

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -122,6 +122,12 @@ production:
     concurrency: 1
     description: "Retry fulfillment for free sticker orders stuck in pending"
 
+  shop_release_expired_order_holds:
+    class: Shop::ReleaseExpiredOrderHoldsJob
+    schedule: every minute
+    concurrency: 1
+    description: "Release shop orders after they have been on hold for seven days"
+
   shop_calculate_fulfillment_payouts:
     class: Shop::CalculateFulfillmentPayoutsJob
     schedule: every Friday at 12pm Europe/London

--- a/test/controllers/admin/fraud/subject_verdicts_test.rb
+++ b/test/controllers/admin/fraud/subject_verdicts_test.rb
@@ -102,12 +102,16 @@ class Admin::Fraud::SubjectVerdictsTest < ActionDispatch::IntegrationTest
   test "putting an order on hold keeps it in the queue and re-renders the row" do
     order = pending_order
 
-    post place_on_hold_admin_shop_order_path(order),
-         params: { fraud_subject_id: @subject.id }, headers: TURBO_STREAM
+    assert_enqueued_with(job: Shop::ReleaseExpiredOrderHoldsJob) do
+      post place_on_hold_admin_shop_order_path(order),
+           params: { fraud_subject_id: @subject.id }, headers: TURBO_STREAM
+    end
 
     assert_response :success
     assert_equal "on_hold", order.reload.aasm_state
     assert_match "Release hold", response.body
+    assert_match "Automatically releases in", response.body
+    assert_select "[data-controller='countdown'][data-countdown-reset-at-value]"
   end
 
   test "releasing a hold puts the order back to pending" do

--- a/test/jobs/shop/release_expired_order_holds_job_test.rb
+++ b/test/jobs/shop/release_expired_order_holds_job_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class Shop::ReleaseExpiredOrderHoldsJobTest < ActiveJob::TestCase
+  setup do
+    user = User.create!(
+      slack_id: "U_EXPIRED_HOLD_#{SecureRandom.hex(6)}",
+      email: "expired-hold-#{SecureRandom.hex(4)}@example.com",
+      display_name: "Expired Hold User"
+    )
+    item = ShopItem.create!(
+      name: "Held Item #{SecureRandom.hex(4)}",
+      ticket_cost: 0,
+      type: "ShopItem::ThirdPartyPhysical",
+      enabled: true
+    )
+    @order = user.shop_orders.new(
+      shop_item: item,
+      quantity: 1,
+      frozen_item_price: 0,
+      frozen_address: { "country" => "US" },
+      aasm_state: "on_hold"
+    )
+    @order.save!(validate: false)
+  end
+
+  test "releases an order after seven days on hold and audits the transition" do
+    now = Time.zone.parse("2026-09-09 12:00:00")
+    @order.update_columns(on_hold_at: now - 7.days, updated_at: now - 7.days)
+
+    Shop::ReleaseExpiredOrderHoldsJob.perform_now(now)
+
+    assert_predicate @order.reload, :pending?
+    version = @order.versions.order(:created_at).last
+    assert_equal "automatic_hold_release", version.event
+    assert_equal "Shop::ReleaseExpiredOrderHoldsJob", version.whodunnit
+  end
+
+  test "does not release an order before seven days" do
+    now = Time.zone.parse("2026-09-09 12:00:00")
+    @order.update_columns(on_hold_at: now - 7.days + 1.second, updated_at: now - 7.days + 1.second)
+
+    Shop::ReleaseExpiredOrderHoldsJob.perform_now(now)
+
+    assert_predicate @order.reload, :on_hold?
+  end
+
+  test "uses updated_at for legacy holds without an on-hold timestamp" do
+    now = Time.zone.parse("2026-09-09 12:00:00")
+    @order.update_columns(on_hold_at: nil, updated_at: now - 8.days)
+
+    Shop::ReleaseExpiredOrderHoldsJob.perform_now(now)
+
+    assert_predicate @order.reload, :pending?
+  end
+end


### PR DESCRIPTION
## what's this do?

Ensures shop-order holds expire after seven days:

- schedules an automatic release for the exact expiration time whenever an order enters `on_hold`
- runs a one-minute recurring safety sweep for legacy or missed scheduled jobs
- rechecks each order under a row lock before releasing it
- records automatic releases in PaperTrail as `Shop::ReleaseExpiredOrderHoldsJob`
- shows a live days/hours/minutes countdown on admin order lists, order details, and fraud subject pages
- falls back to `updated_at` for legacy held orders missing `on_hold_at`

No database migration is required because `shop_orders.on_hold_at` already exists and is maintained by AASM.

## show it works

Passing (exit 0):

- Ruby syntax checks for the model, job, and tests
- `node --check app/javascript/controllers/countdown_controller.js`
- focused RuboCop (4 files, no offenses)
- focused ERB lint (4 templates, no errors)
- `bin/rails dartsass:build`
- `config/recurring.yml` YAML parsing
- `git diff --check`

Added job coverage for releasing at seven days, preserving newer holds, handling legacy timestamps, and PaperTrail attribution. Added controller coverage for the scheduled job and rendered countdown.

The focused Rails tests could not start locally (exit 1) because the host PostgreSQL installation does not have the `vector` extension required while loading `db/schema.rb`. Rails also reports the locally missing MJML binary. Prettier was unavailable because `node_modules/.bin/prettier` is absent; JavaScript syntax and Sass compilation passed independently.

## ai?

Implemented with the fx coding assistant.
