### PR TITLE
feat(certification): hotkeys and new timelapse view

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -103,6 +103,7 @@
 @use "pages/certification/ships/monitor" as certification_ships_monitor;
 @use "pages/certification/hardware_review" as certification_hardware_review;
 @use "pages/certification/recording_gallery" as certification_recording_gallery;
+@use "pages/certification/lapse_player" as certification_lapse_player;
 @use "pages/certification/mystats" as certification_mystats;
 @use "pages/certification/payouts" as certification_payouts;
 @use "pages/raffle";

--- a/app/assets/stylesheets/pages/admin/_ysws_reviews.scss
+++ b/app/assets/stylesheets/pages/admin/_ysws_reviews.scss
@@ -1539,6 +1539,19 @@ body:has(.certification-ysws) {
       }
     }
 
+    // Keyboard-shortcut cursor (:ysws_review_shortcuts): marks the current devlog
+    // the j/k nav and verdict keys act on. A soft mint-tinted panel with a left
+    // accent rail frames the whole row; negative inline margins let it bleed into
+    // the card's padding and the matching inline padding keeps the content from
+    // shifting as the cursor moves.
+    .devlog-item--kbd-active {
+      margin-inline: calc(-1 * var(--space-s));
+      padding-inline: var(--space-s);
+      border-radius: var(--space-xs);
+      background: color-mix(in srgb, var(--color-brand-mint) 8%, transparent);
+      box-shadow: inset 3px 0 0 0 var(--color-brand-mint);
+    }
+
     .devlog-status.status-frozen {
       background: rgba(255, 255, 255, 0.08);
       color: var(--color-space-text-muted);
@@ -3063,5 +3076,62 @@ body:has(.certification-ysws) {
   &__loading {
     color: rgba(255, 255, 255, 0.6);
     font-style: italic;
+  }
+}
+
+// Keyboard-shortcut affordances (:ysws_review_shortcuts). The controller injects
+// <kbd class="kbd-hint"> badges onto the controls each key drives and pins a
+// fixed legend for the navigation keys — both exist only while the flag is on.
+// Top-level (not nested under .certification-ysws) because the legend mounts on
+// <body>.
+.kbd-hint {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: var(--space-xxs);
+  padding: 0 0.35rem;
+  min-width: 1.15rem;
+  height: 1.15rem;
+  border: 1px solid currentColor;
+  border-radius: 4px;
+  // Inherit the host control's text colour so the badge stays legible on any
+  // surface — dark panels, the mint approve button, the salmon reject button —
+  // and read as a subtle hint rather than a filled chip.
+  background: transparent;
+  color: inherit;
+  opacity: 0.7;
+  font-family: "Exo 2", sans-serif;
+  font-size: 0.68rem;
+  font-weight: 700;
+  line-height: 1;
+  vertical-align: middle;
+}
+
+.ysws-kbd-legend {
+  position: fixed;
+  right: var(--space-m);
+  bottom: var(--space-m);
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  gap: var(--space-s);
+  padding: var(--space-xs) var(--space-s);
+  border: 1px solid var(--color-space-border);
+  border-radius: 999px;
+  background: var(--color-set-2-bg);
+  color: var(--color-space-text-muted);
+  font-size: var(--font-size-xs);
+  box-shadow: 0 4px 16px hsl(245 55% 4% / 0.5);
+
+  &__title {
+    color: var(--color-brand-mint);
+    font-weight: 700;
+  }
+
+  &__item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    white-space: nowrap;
   }
 }

--- a/app/assets/stylesheets/pages/certification/_lapse_player.scss
+++ b/app/assets/stylesheets/pages/certification/_lapse_player.scss
@@ -1,0 +1,282 @@
+// Reusable JKL timelapse viewer for the shared recording gallery (hardware
+// funding review + YSWS review). The lightbox is appended to document.body so
+// it overlays admin chrome; z-index stays high. Scrim uses set-1 (#08061E) per
+// branding — never pure black — and lilac is the accent (branding's default
+// primary).
+
+.lapse-player {
+  // ── Modal lightbox ───────────────────────────────────────────────────────
+  &__lightbox {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-s);
+    padding: var(--space-xl);
+    background: var(--color-backdrop);
+    backdrop-filter: blur(4px);
+  }
+
+  &__lightbox-close {
+    position: absolute;
+    top: var(--space-m);
+    right: var(--space-l);
+    width: 2.5rem;
+    height: 2.5rem;
+    font-size: var(--font-size-xxl);
+    line-height: 1;
+    color: var(--color-space-text);
+    background: var(--color-set-2-bg);
+    border: 0;
+    border-radius: 50%;
+    cursor: pointer;
+  }
+
+  &__lightbox-stage {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    max-width: min(90vw, 1400px);
+    max-height: 80vh;
+  }
+
+  &__lightbox-media {
+    max-width: 100%;
+    max-height: 80vh;
+    object-fit: contain;
+    border-radius: var(--profile-radius);
+  }
+
+  &__lightbox-caption {
+    margin: 0;
+    font-size: var(--font-size-s);
+    color: var(--color-space-text-muted);
+  }
+
+  // ── Custom video player chrome (Vimeo/Plyr-style; overlays the video) ─────
+  // Always visible; the scrim keeps it legible over any frame.
+  &__player {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    padding: var(--space-xl) var(--space-m) var(--space-s);
+    border-radius: 0 0 var(--profile-radius) var(--profile-radius);
+    background: linear-gradient(to top, hsl(245 55% 8% / 0.96) 25%, hsl(245 55% 8% / 0));
+    color: var(--color-space-text);
+    font-size: var(--font-size-xs);
+  }
+
+  &__player-scrub {
+    position: relative;
+    height: 0.35rem;
+    border-radius: 999px;
+    background: var(--color-overlay-light);
+    cursor: pointer;
+    transition: height 0.12s ease;
+
+    &:hover {
+      height: 0.55rem;
+    }
+  }
+
+  &__player-buffered {
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 0;
+    border-radius: 999px;
+    background: var(--color-overlay-light);
+  }
+
+  &__player-progress {
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 0;
+    border-radius: 999px;
+    background: var(--color-brand-lilac);
+  }
+
+  &__player-handle {
+    position: absolute;
+    right: 0;
+    top: 50%;
+    width: 0.85rem;
+    height: 0.85rem;
+    border-radius: 50%;
+    background: var(--color-brand-lilac);
+    box-shadow: 0 0 0 3px hsl(245 55% 8% / 0.6);
+    transform: translate(50%, -50%) scale(0);
+    transition: transform 0.12s ease;
+  }
+
+  &__player-scrub:hover &__player-handle {
+    transform: translate(50%, -50%) scale(1);
+  }
+
+  &__player-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-m);
+  }
+
+  &__player-cluster {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xxs);
+  }
+
+  &__player-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.9rem;
+    height: 1.9rem;
+    padding: 0 var(--space-xs);
+    border: 0;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--color-space-text);
+    font-size: var(--font-size-m);
+    line-height: 1;
+    cursor: pointer;
+    transition: background 0.12s ease;
+
+    &:hover {
+      background: var(--color-overlay-light);
+    }
+  }
+
+  &__player-time {
+    margin-left: var(--space-xs);
+    font-variant-numeric: tabular-nums;
+    color: var(--color-space-text-muted);
+  }
+
+  &__player-speed {
+    display: flex;
+    align-items: center;
+    gap: 1px;
+    padding: 2px;
+    border-radius: 999px;
+    background: var(--color-overlay-light-soft);
+  }
+
+  &__player-speed-label {
+    padding: 0 var(--space-xs);
+    color: var(--color-space-text-muted);
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+  }
+
+  &__player-pill {
+    padding: 3px 7px;
+    border: 0;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--color-space-text-muted);
+    font-size: 0.68rem;
+    font-variant-numeric: tabular-nums;
+    cursor: pointer;
+    transition:
+      background 0.12s ease,
+      color 0.12s ease;
+
+    &:hover {
+      color: var(--color-space-text);
+    }
+
+    &.is-active {
+      background: var(--color-brand-lilac);
+      color: var(--color-set-1-bg);
+      font-weight: 700;
+    }
+  }
+}
+
+// ── Gallery tile as a clickable video thumbnail ──────────────────────────────
+// The recording gallery tile becomes an <a> wired to the lapse-player
+// controller; make it read as a play-on-click video thumbnail.
+.recording-gallery {
+  &__thumb {
+    width: 100%;
+    height: 100%;
+    // contain, not cover: show the whole frame at its true aspect ratio. The
+    // dark card background fills the letterbox bars cleanly.
+    object-fit: contain;
+    background: var(--color-set-1-bg);
+  }
+
+  // Each grid cell now stacks the clickable media tile above its meta block;
+  // the anchor holds only the media, so the column gap lives on the <li>.
+  &__list > li {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
+
+  // Clickable tile: the anchor wraps the media frame. Focus-visible ring uses
+  // the lilac accent to match the player.
+  &__item[href] {
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
+
+    &:focus-visible {
+      outline: 2px solid var(--color-brand-lilac);
+      outline-offset: 2px;
+    }
+
+    &:hover .recording-gallery__play {
+      background: var(--color-brand-lilac);
+      color: var(--color-set-1-bg);
+    }
+  }
+
+  // Centered play affordance over the poster.
+  &__play {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 3rem;
+    height: 3rem;
+    padding-left: 0.15rem;
+    border-radius: 50%;
+    background: hsl(245 55% 8% / 0.7);
+    color: var(--color-space-text);
+    font-size: var(--font-size-l);
+    line-height: 1;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    transition:
+      background 0.15s ease,
+      color 0.15s ease;
+  }
+
+  // Clip duration badge, bottom-right of the frame (mirrors the source badge).
+  &__duration {
+    position: absolute;
+    right: var(--space-xs);
+    bottom: var(--space-xs);
+    z-index: 1;
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    background: hsl(245 55% 8% / 0.78);
+    color: var(--color-space-text);
+    font-size: 0.7rem;
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+  }
+}

--- a/app/controllers/admin/certification/ysws_controller.rb
+++ b/app/controllers/admin/certification/ysws_controller.rb
@@ -147,6 +147,11 @@ class Admin::Certification::YswsController < Admin::Certification::ApplicationCo
     # banner and the per-devlog notes both disappear from a single check.
     @mac_analysis = @review.mac_analysis if Flipper.enabled?(:mac_analysis, current_user)
 
+    # Flag-gated keyboard-shortcut layer for the review GUI (j/k nav, verdict
+    # keys, lapse lightbox). Off by default; attaches its Stimulus controller
+    # only when enabled for this reviewer.
+    @ysws_review_shortcuts = Flipper.enabled?(:ysws_review_shortcuts, current_user)
+
     @lapse_timelapses = lapse_timelapses_for_ysws_review
     @lookout_recordings = lookout_recordings_for_ysws_review
     # Owner Hackatime uid for Telescreen deep-links on Lapse recordings.

--- a/app/javascript/controllers/certification/lapse_player_controller.js
+++ b/app/javascript/controllers/certification/lapse_player_controller.js
@@ -1,0 +1,331 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Reusable timelapse viewer for the shared recording gallery (hardware funding
+// review + YSWS review). Each gallery tile is a clickable <a> pointing at the
+// raw video; clicking one opens a modal lightbox with a Premiere-style JKL
+// transport instead of navigating away.
+//
+// Self-contained: the lightbox is appended to document.body (the gallery panel
+// is small and clip-scrolled), and the document keydown listener is bound ONLY
+// while the lightbox is open so it never fights page typing when closed.
+export default class extends Controller {
+  static targets = ["item"];
+
+  disconnect() {
+    this.stopReverse();
+    this.closeLightbox();
+  }
+
+  // Clicking a tile opens it in the JKL lightbox instead of navigating to the
+  // raw R2 video. Builds the playlist from every sibling tile and opens at the
+  // clicked index. ctrl/middle-click still follows the href (browser default).
+  open(event) {
+    event.preventDefault();
+    const link = event.currentTarget;
+    const items = this.itemTargets.map((tile) => ({ type: "video", src: tile.href }));
+    if (!items.length) return;
+    this.showLightbox(items, Math.max(0, this.itemTargets.indexOf(link)));
+  }
+
+  // ── Modal keyboard shortcuts (bound only while the lightbox is open) ──────
+  onKeydown(event) {
+    if (!this.lightbox || event.altKey) return;
+    if (event.key === "Escape") return this.consume(event, () => this.closeLightbox());
+    // Video → Premiere-style JKL transport + arrow scrubbing (shift = coarse).
+    if (this.lbVideo) {
+      if (event.code === "Space") return this.consume(event, () => this.togglePlay());
+      if (event.code === "KeyJ") return this.consume(event, () => this.nudgeRate(-1));
+      if (event.code === "KeyK") return this.consume(event, () => this.togglePlay());
+      if (event.code === "KeyL") return this.consume(event, () => this.nudgeRate(1));
+      // vim: h mirrors ← scrub (→'s vim key `l` is taken by forward-transport).
+      if (event.key === "ArrowLeft" || event.code === "KeyH") return this.consume(event, () => this.stepVideo(event.shiftKey ? -10 : -1));
+      if (event.key === "ArrowRight") return this.consume(event, () => this.stepVideo(event.shiftKey ? 10 : 1));
+      return;
+    }
+    // Non-video slides → prev/next (vim h/l mirror ←/→).
+    if (event.key === "ArrowLeft" || event.code === "KeyH") return this.consume(event, () => this.stepLightbox(-1));
+    if (event.key === "ArrowRight" || event.code === "KeyL") return this.consume(event, () => this.stepLightbox(1));
+  }
+
+  consume(event, fn) {
+    event.preventDefault();
+    fn();
+  }
+
+  // ── Lightbox ─────────────────────────────────────────────────────────────
+  showLightbox(items, index) {
+    this.closeLightbox();
+    this.lbItems = items;
+    this.lbIndex = index;
+
+    const box = document.createElement("div");
+    box.className = "lapse-player__lightbox";
+    box.setAttribute("role", "dialog");
+    box.setAttribute("aria-modal", "true");
+    // Backdrop click closes a non-video lightbox; for video it doesn't — so
+    // clicking near the player (to pause) never closes it. Use × or esc.
+    box.addEventListener("click", (e) => { if (e.target === box && !this.lbVideo) this.closeLightbox(); });
+
+    const close = document.createElement("button");
+    close.type = "button";
+    close.className = "lapse-player__lightbox-close";
+    close.setAttribute("aria-label", "Close");
+    close.textContent = "×";
+    close.addEventListener("click", () => this.closeLightbox());
+
+    this.lbStage = document.createElement("div");
+    this.lbStage.className = "lapse-player__lightbox-stage";
+    this.lbCaption = document.createElement("p");
+    this.lbCaption.className = "lapse-player__lightbox-caption";
+
+    box.append(close, this.lbStage, this.lbCaption);
+    document.body.appendChild(box);
+    this.lightbox = box;
+
+    this.onKeydown = this.onKeydown.bind(this);
+    document.addEventListener("keydown", this.onKeydown);
+
+    this.renderLightbox();
+  }
+
+  renderLightbox() {
+    const item = this.lbItems[this.lbIndex];
+    this.stopReverse();
+    this.lbStage.innerHTML = "";
+    if (item.type === "video") {
+      this.mountVideoPlayer(item);
+    } else {
+      const img = document.createElement("img");
+      img.src = item.src;
+      img.alt = item.alt || "";
+      img.className = "lapse-player__lightbox-media";
+      this.lbStage.appendChild(img);
+      this.lbVideo = null;
+      const nav = this.lbItems.length > 1 ? " · ←/→" : "";
+      this.lbCaption.textContent = `${this.lbIndex + 1} / ${this.lbItems.length}${nav} · esc to close`;
+    }
+  }
+
+  // ── Custom player chrome ─────────────────────────────────────────────────
+  // Native controls are off so the transport has one look: a scrubber, a
+  // play/pause + frame-step cluster, and a visual JKL speed ladder. Every
+  // control calls the same methods the keyboard does, so the two stay in sync.
+  mountVideoPlayer(item) {
+    const video = document.createElement("video");
+    Object.assign(video, { src: item.src, controls: false, autoplay: true, playsInline: true });
+    video.className = "lapse-player__lightbox-media";
+    video.addEventListener("click", (event) => { event.stopPropagation(); this.togglePlay(); });
+    video.addEventListener("loadedmetadata", () => this.syncPlayerUI());
+    video.addEventListener("timeupdate", () => this.syncPlayerUI());
+    video.addEventListener("ended", () => this.applyRate(0));
+    this.lbVideo = video;
+    this.rate = 1;      // signed speed: + forward, − reverse, 0 paused (autoplay = 1×)
+    this.lastRate = 1;  // K resumes here after a pause
+
+    this.lbStage.append(video, this.buildPlayerBar());
+    this.syncPlayerUI();
+  }
+
+  // Vimeo/Plyr-style layout: a full-width scrubber (buffered + played + a handle
+  // that appears on hover) above a control row split into a left transport
+  // cluster and a right JKL speed ladder.
+  buildPlayerBar() {
+    const bar = document.createElement("div");
+    bar.className = "lapse-player__player";
+
+    const scrub = document.createElement("div");
+    scrub.className = "lapse-player__player-scrub";
+    this.lbBuffered = document.createElement("div");
+    this.lbBuffered.className = "lapse-player__player-buffered";
+    this.lbProgress = document.createElement("div");
+    this.lbProgress.className = "lapse-player__player-progress";
+    this.lbHandle = document.createElement("div");
+    this.lbHandle.className = "lapse-player__player-handle";
+    this.lbProgress.appendChild(this.lbHandle);
+    scrub.append(this.lbBuffered, this.lbProgress);
+    scrub.addEventListener("pointerdown", (event) => this.scrubFrom(event, scrub));
+
+    const row = document.createElement("div");
+    row.className = "lapse-player__player-row";
+
+    const left = document.createElement("div");
+    left.className = "lapse-player__player-cluster";
+    this.lbPlayBtn = this.playerButton("❚❚", "Play / pause · k or space", () => this.togglePlay());
+    const back = this.playerButton("⟨", "Step back 1s · ← / h (shift = 10s)", () => this.stepVideo(-1));
+    const fwd = this.playerButton("⟩", "Step forward 1s · → (shift = 10s)", () => this.stepVideo(1));
+    this.lbTime = document.createElement("span");
+    this.lbTime.className = "lapse-player__player-time";
+    left.append(this.lbPlayBtn, back, fwd, this.lbTime);
+
+    const right = document.createElement("div");
+    right.className = "lapse-player__player-cluster";
+    const speed = document.createElement("div");
+    speed.className = "lapse-player__player-speed";
+    const speedLabel = document.createElement("span");
+    speedLabel.className = "lapse-player__player-speed-label";
+    speedLabel.textContent = "JKL";
+    speed.appendChild(speedLabel);
+    this.lbSpeedPills = this.RATE_LADDER.map((r) => {
+      const pill = document.createElement("button");
+      pill.type = "button";
+      pill.className = "lapse-player__player-pill";
+      pill.textContent = r < 0 ? `${-r}◀` : `${r}▶`;
+      pill.title = `${r < 0 ? "reverse" : "forward"} ${Math.abs(r)}× · j / l`;
+      pill.addEventListener("click", () => this.applyRate(r));
+      speed.appendChild(pill);
+      return pill;
+    });
+    right.appendChild(speed);
+
+    row.append(left, right);
+    bar.append(scrub, row);
+    return bar;
+  }
+
+  playerButton(label, title, onClick) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "lapse-player__player-btn";
+    button.title = title;
+    button.textContent = label;
+    button.addEventListener("click", onClick);
+    return button;
+  }
+
+  // Click / drag anywhere on the track to seek (pauses first, like a scrub).
+  scrubFrom(event, track) {
+    const seek = (clientX) => {
+      if (!this.lbVideo?.duration) return;
+      const rect = track.getBoundingClientRect();
+      const frac = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+      this.applyRate(0);
+      this.lbVideo.currentTime = frac * this.lbVideo.duration;
+      this.syncPlayerUI();
+    };
+    seek(event.clientX);
+    const move = (e) => seek(e.clientX);
+    const up = () => {
+      document.removeEventListener("pointermove", move);
+      document.removeEventListener("pointerup", up);
+    };
+    document.addEventListener("pointermove", move);
+    document.addEventListener("pointerup", up);
+  }
+
+  syncPlayerUI() {
+    if (!this.lbVideo) return;
+    const video = this.lbVideo;
+    if (this.lbPlayBtn) this.lbPlayBtn.textContent = this.rate ? "❚❚" : "▶";
+    const pct = video.duration ? (video.currentTime / video.duration) * 100 : 0;
+    if (this.lbProgress) this.lbProgress.style.width = `${pct}%`;
+    if (this.lbBuffered && video.duration && video.buffered.length) {
+      const end = video.buffered.end(video.buffered.length - 1);
+      this.lbBuffered.style.width = `${(end / video.duration) * 100}%`;
+    }
+    if (this.lbTime) this.lbTime.textContent = `${this.fmtTime(video.currentTime)} / ${this.fmtTime(video.duration)}`;
+    this.lbSpeedPills?.forEach((pill, i) => pill.classList.toggle("is-active", this.RATE_LADDER[i] === this.rate));
+    if (this.lbCaption) {
+      this.lbCaption.textContent =
+        `${this.lbIndex + 1} / ${this.lbItems.length} · j/k/l transport · ←/→ scrub (shift = 10s) · esc to close`;
+    }
+  }
+
+  fmtTime(seconds) {
+    if (!isFinite(seconds)) return "0:00";
+    const m = Math.floor(seconds / 60);
+    const s = Math.floor(seconds % 60);
+    return `${m}:${String(s).padStart(2, "0")}`;
+  }
+
+  // ── Premiere-style JKL transport ─────────────────────────────────────────
+  // One shared signed-speed ladder: L nudges toward faster-forward, J toward
+  // faster-reverse, meeting in the middle (…4×▶ 2×▶ 1×▶ | 1×◀ 2×◀…). So from 8×
+  // forward, J steps down to 4×. HTML5 video can't play backwards, so reverse is
+  // emulated with a timer that walks currentTime back.
+  RATE_LADDER = [ -8, -4, -2, -1, 1, 2, 4, 8 ];
+
+  nudgeRate(direction) {
+    if (!this.lbVideo) return;
+    let next;
+    if (!this.rate) {
+      next = direction > 0 ? 1 : -1;
+    } else {
+      const i = this.RATE_LADDER.indexOf(this.rate);
+      next = i === -1
+        ? (direction > 0 ? 1 : -1)
+        : this.RATE_LADDER[Math.max(0, Math.min(this.RATE_LADDER.length - 1, i + direction))];
+    }
+    this.applyRate(next);
+  }
+
+  // K: pause when playing, resume when paused. Pausing also resets the resume
+  // speed to +1× so play always restarts forward (never at a stale J/L speed).
+  togglePlay() {
+    if (!this.lbVideo) return;
+    if (this.rate) {
+      this.lastRate = 1;
+      this.applyRate(0);
+    } else {
+      this.applyRate(this.lastRate || 1);
+    }
+  }
+
+  applyRate(rate) {
+    if (!this.lbVideo) return;
+    this.rate = rate;
+    if (rate) this.lastRate = rate;
+    this.stopReverse();
+    if (rate > 0) {
+      this.lbVideo.playbackRate = rate;
+      this.lbVideo.play();
+    } else if (rate < 0) {
+      this.lbVideo.pause();
+      this.reverseSpeed = -rate;
+      this.startReverse();
+    } else {
+      this.lbVideo.pause();
+    }
+    this.syncPlayerUI();
+  }
+
+  startReverse() {
+    this.stopReverse();
+    this.reverseTimer = setInterval(() => {
+      if (!this.lbVideo) return this.stopReverse();
+      const t = this.lbVideo.currentTime - this.reverseSpeed * 0.066;
+      if (t <= 0) {
+        this.lbVideo.currentTime = 0;
+        this.applyRate(0); // hit the start → stop
+      } else {
+        this.lbVideo.currentTime = t;
+      }
+    }, 66);
+  }
+
+  stopReverse() {
+    clearInterval(this.reverseTimer);
+    this.reverseTimer = null;
+  }
+
+  stepVideo(seconds) {
+    if (!this.lbVideo) return;
+    this.applyRate(0); // frame-scrub pauses first
+    const max = this.lbVideo.duration || Number.MAX_SAFE_INTEGER;
+    this.lbVideo.currentTime = Math.max(0, Math.min(max, this.lbVideo.currentTime + seconds));
+    this.syncPlayerUI();
+  }
+
+  stepLightbox(direction) {
+    const count = this.lbItems.length;
+    this.lbIndex = (this.lbIndex + direction + count) % count;
+    this.renderLightbox();
+  }
+
+  closeLightbox() {
+    this.stopReverse();
+    if (this.onKeydown) document.removeEventListener("keydown", this.onKeydown);
+    this.lightbox?.remove();
+    this.lightbox = null;
+    this.lbVideo = null;
+  }
+}

--- a/app/javascript/controllers/certification/ysws/keyboard_shortcuts_controller.js
+++ b/app/javascript/controllers/certification/ysws/keyboard_shortcuts_controller.js
@@ -1,0 +1,288 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Flag-gated (:ysws_review_shortcuts) keyboard layer for the YSWS review page.
+// Mirrors the hardware cockpit's keybinding technique — a single document
+// keydown maintains a "current devlog" cursor and dispatches shortcuts to the
+// existing per-devlog controls. It only clicks buttons that already exist
+// (approve/reject/adjust) and opens the lapse lightbox owned by the recording-
+// gallery slice by clicking its first tile; no JS coupling with that controller.
+//
+// When active it also decorates the controls it drives with on-screen <kbd>
+// hint badges and pins a compact legend for the navigation keys, so the
+// shortcuts are discoverable without opening the ? help overlay.
+//
+//   j / k        next / previous devlog (clamped)
+//   e            jump to the review-decision panel (focus minutes)
+//   a / r        approve / reject the current devlog
+//   - / shift+-  decrease approved minutes by 15 / 30
+//   t            open the current devlog's lapse recordings in the lightbox
+//   ctrl+space   focus the current devlog's internal-notes box
+//   ?            toggle the keyboard-shortcut help overlay (Escape closes)
+
+// Per-control hint badges: [selector within a devlog, key label]. The decision
+// panel title (E) and notes label (⌃Space) are placed separately in decorateHints.
+const HINTS = [
+  [".btn-approve", "A"],
+  [".btn-reject", "R"],
+  ['.adjust-btn[data-adjust-action="-15"]', "−"],
+  ['.adjust-btn[data-adjust-action="-30"]', "⇧−"],
+];
+
+// Rows for the ? help overlay.
+const SHORTCUTS = [
+  ["J / K", "Prev / next devlog"],
+  ["E", "Jump to decision"],
+  ["A / R", "Approve / reject"],
+  ["− / ⇧−", "Cut 15 / 30 min"],
+  ["T", "Open lapse recordings"],
+  ["⌃ Space", "Focus internal notes"],
+  ["?", "Show this help"],
+];
+
+export default class extends Controller {
+  connect() {
+    this.currentIndex = 0;
+    this.onKeydown = this.onKeydown.bind(this);
+    document.addEventListener("keydown", this.onKeydown);
+    this.decorateHints();
+    this.buildLegend();
+    this.observeScroll();
+    this.markCurrent(0);
+  }
+
+  disconnect() {
+    document.removeEventListener("keydown", this.onKeydown);
+    this.observer?.disconnect();
+    this.clearHighlight();
+    this.undecorateHints();
+    this.legend?.remove();
+    this.dialog?.remove();
+  }
+
+  onKeydown(event) {
+    // The help overlay is modal: Escape closes it and nothing else fires.
+    if (this.dialog?.open) {
+      if (event.key === "Escape") return this.consume(event, () => this.dialog.close());
+      return;
+    }
+
+    // ctrl/⌘ + space focuses the current devlog's internal-notes box. It's a
+    // chord (never inserts text), so it works even while typing elsewhere and is
+    // handled before the plain-key guards below.
+    if ((event.ctrlKey || event.metaKey) && !event.altKey && event.code === "Space") {
+      return this.consume(event, () => this.openNotes());
+    }
+
+    // Escape drops focus out of a field (e.g. the internal-notes box opened with
+    // ctrl+space, or the minutes input) so the reviewer can jump back to the
+    // single-key shortcuts. Handled before the typing guard so it fires while a
+    // field is focused.
+    if (event.key === "Escape") {
+      const el = document.activeElement;
+      if (el && el !== document.body && this.element.contains(el) && typeof el.blur === "function") {
+        return this.consume(event, () => el.blur());
+      }
+      return;
+    }
+
+    // Ctrl/Meta/Alt combos are left to the browser (Escape aside — unused here
+    // but kept explicit); single-key shortcuts must never fight text entry.
+    if (event.ctrlKey || event.metaKey || event.altKey) return;
+    if (this.isTyping(event.target)) return;
+
+    switch (event.key) {
+      case "j": return this.consume(event, () => this.stepDevlog(1));
+      case "k": return this.consume(event, () => this.stepDevlog(-1));
+      case "e": return this.consume(event, () => this.openDecision());
+      case "a": return this.consume(event, () => this.clickCurrent(".btn-approve"));
+      case "r": return this.consume(event, () => this.clickCurrent(".btn-reject"));
+      case "-": return this.consume(event, () => this.adjustTime("-15"));
+      case "_": return this.consume(event, () => this.adjustTime("-30"));
+      case "t": return this.consume(event, () => this.openLapses());
+      case "?": return this.consume(event, () => this.toggleHelp());
+    }
+  }
+
+  consume(event, fn) {
+    event.preventDefault();
+    fn();
+  }
+
+  isTyping(el) {
+    if (!el) return false;
+    return ["INPUT", "TEXTAREA", "SELECT"].includes(el.tagName) || el.isContentEditable;
+  }
+
+  // ── Devlog navigation ──────────────────────────────────────────────────
+  // Only the current review's (non-frozen) cards carry the decision controls, so
+  // navigation, the verdict/time/lapse keys, and the cursor all operate on these.
+  // Frozen prior-review cards render first in the DOM; including them made the
+  // cursor land on a card with no buttons, so a/r/e appeared to do nothing.
+  devlogEls() {
+    return Array.from(this.element.querySelectorAll(".devlog-item:not(.devlog-item--frozen)"));
+  }
+
+  currentDevlog() {
+    return this.devlogEls()[this.currentIndex] || null;
+  }
+
+  stepDevlog(delta) {
+    this.setDevlog(this.currentIndex + delta);
+  }
+
+  // Update the cursor WITHOUT scrolling — shared by keyboard nav (which then
+  // scrolls) and the scroll observer (which must not).
+  markCurrent(index) {
+    const els = this.devlogEls();
+    if (!els.length) return;
+    this.currentIndex = Math.max(0, Math.min(index, els.length - 1));
+    els.forEach((el, i) => el.classList.toggle("devlog-item--kbd-active", i === this.currentIndex));
+  }
+
+  // j/k: move the cursor and float the card to the top of the viewport.
+  setDevlog(index) {
+    this.markCurrent(index);
+    this.devlogEls()[this.currentIndex]?.scrollIntoView({ block: "start", behavior: "smooth" });
+  }
+
+  // Track the top-most visible devlog so the verdict/time/lapse keys act on the
+  // card the reviewer has SCROLLED to, not only the one j/k last moved to —
+  // otherwise the cursor and the viewport drift apart and the keys feel random.
+  observeScroll() {
+    const els = this.devlogEls();
+    if (!els.length || typeof IntersectionObserver === "undefined") return;
+    this.visible = new Set();
+    this.observer = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) this.visible.add(entry.target);
+        else this.visible.delete(entry.target);
+      }
+      const list = this.devlogEls();
+      const topMost = list.find((el) => this.visible.has(el)); // DOM order = visual order
+      if (topMost) {
+        const i = list.indexOf(topMost);
+        if (i !== this.currentIndex) this.markCurrent(i);
+      }
+    }, { root: null, rootMargin: "0px 0px -60% 0px", threshold: 0 });
+    els.forEach((el) => this.observer.observe(el));
+  }
+
+  clearHighlight() {
+    this.element
+      .querySelectorAll(".devlog-item--kbd-active")
+      .forEach((el) => el.classList.remove("devlog-item--kbd-active"));
+  }
+
+  // ── Actions on the current devlog ───────────────────────────────────────
+  // "e" brings the current devlog's decision panel into view. It deliberately
+  // does NOT focus a field: focusing an input trips the typing guard and would
+  // swallow the a/r verdict keys the reviewer reaches for next.
+  openDecision() {
+    const panel = this.currentDevlog()?.querySelector(".devlog-review-panel");
+    panel?.scrollIntoView({ block: "center", behavior: "smooth" });
+  }
+
+  // Click a control on the current devlog if present and enabled. The devlog
+  // controller autosaves; single-press is fine since these are reversible.
+  clickCurrent(selector) {
+    const devlog = this.currentDevlog();
+    if (!devlog) return;
+    const btn = devlog.querySelector(selector);
+    if (btn && !btn.disabled) btn.click();
+  }
+
+  adjustTime(delta) {
+    this.clickCurrent(`.adjust-btn[data-adjust-action="${delta}"]`);
+  }
+
+  // Open the current devlog's first recording tile — this hands off to the
+  // recording-gallery slice, which owns the JKL lightbox. Fall back to the
+  // page-level recordings card when the current devlog has no footage.
+  openLapses() {
+    const devlog = this.currentDevlog();
+    const tile =
+      devlog?.querySelector(".devlog-recordings-section .recording-gallery__item") ||
+      this.element.querySelector(".recordings-card .recording-gallery__item");
+    if (tile) tile.click();
+  }
+
+  // ── Help overlay ────────────────────────────────────────────────────────
+  toggleHelp() {
+    if (!this.dialog) this.buildDialog();
+    if (this.dialog.open) this.dialog.close();
+    else this.dialog.showModal();
+  }
+
+  buildDialog() {
+    const dialog = document.createElement("dialog");
+    dialog.className = "kbd-help";
+    dialog.addEventListener("click", (e) => {
+      if (e.target === dialog) dialog.close();
+    });
+
+    const rows = SHORTCUTS.map(
+      ([key, desc]) =>
+        `<div class="kbd-help__row"><kbd class="kbd-help__key">${key}</kbd><span class="kbd-help__desc">${desc}</span></div>`,
+    ).join("");
+
+    dialog.innerHTML =
+      `<div class="kbd-help__content">` +
+      `<h2 class="kbd-help__title">Keyboard shortcuts</h2>` +
+      rows +
+      `</div>`;
+
+    document.body.appendChild(dialog);
+    this.dialog = dialog;
+  }
+
+  // ctrl+space: bring the current devlog's notes box into view and focus it.
+  openNotes() {
+    const devlog = this.currentDevlog();
+    const notes = devlog?.querySelector(".notes-textarea");
+    if (!notes || notes.disabled) return;
+    notes.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    notes.focus();
+  }
+
+  // ── On-screen hint badges + legend ──────────────────────────────────────
+  // Tag each control a key drives with a small <kbd> badge, and pin a legend
+  // for the keys that aren't attached to a single button (j/k nav, t, ?).
+  decorateHints() {
+    this.devlogEls().forEach((devlog) => {
+      if (devlog.classList.contains("devlog-item--frozen")) return;
+      HINTS.forEach(([selector, label]) => {
+        const el = devlog.querySelector(selector);
+        if (el) this.addHint(el, label);
+      });
+      const title = devlog.querySelector(".devlog-review-panel .panel-title");
+      if (title) this.addHint(title, "E");
+      const notes = devlog.querySelector(".notes-textarea");
+      const notesLabel = notes?.closest(".panel-section")?.querySelector(".panel-label");
+      if (notesLabel) this.addHint(notesLabel, "⌃Space");
+    });
+  }
+
+  addHint(el, label) {
+    if (el.querySelector(":scope > .kbd-hint")) return; // already decorated
+    const kbd = document.createElement("kbd");
+    kbd.className = "kbd-hint";
+    kbd.textContent = label;
+    el.appendChild(kbd);
+  }
+
+  undecorateHints() {
+    this.element.querySelectorAll(".kbd-hint").forEach((el) => el.remove());
+  }
+
+  buildLegend() {
+    const legend = document.createElement("div");
+    legend.className = "ysws-kbd-legend";
+    legend.innerHTML =
+      `<span class="ysws-kbd-legend__title">Shortcuts</span>` +
+      [["J / K", "devlogs"], ["T", "lapses"], ["?", "more"]]
+        .map(([key, desc]) => `<span class="ysws-kbd-legend__item"><kbd class="kbd-hint">${key}</kbd>${desc}</span>`)
+        .join("");
+    document.body.appendChild(legend);
+    this.legend = legend;
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -34,6 +34,12 @@ application.register(
   Certification__FeedbackTemplatesController,
 );
 
+import Certification__LapsePlayerController from "./certification/lapse_player_controller";
+application.register(
+  "certification--lapse-player",
+  Certification__LapsePlayerController,
+);
+
 import Certification__QueueController from "./certification/queue_controller";
 application.register("certification--queue", Certification__QueueController);
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -109,6 +109,12 @@ application.register(
   Certification__Ysws__GithubCalendarController,
 );
 
+import Certification__Ysws__KeyboardShortcutsController from "./certification/ysws/keyboard_shortcuts_controller";
+application.register(
+  "certification--ysws--keyboard-shortcuts",
+  Certification__Ysws__KeyboardShortcutsController,
+);
+
 import Certification__Ysws__MediaViewerController from "./certification/ysws/media_viewer_controller";
 application.register(
   "certification--ysws--media-viewer",

--- a/app/views/admin/certification/funding_requests/_recording_gallery.html.erb
+++ b/app/views/admin/certification/funding_requests/_recording_gallery.html.erb
@@ -4,7 +4,7 @@
       items:      array of { source:, video_url:, poster_url:, processing:,
                   name:, duration: (seconds), recorded_at: (Time or nil),
                   telescreen_url: (optional Telescreen deep-link) } %>
-<div class="ship-review__panel recording-gallery">
+<div class="ship-review__panel recording-gallery" data-controller="certification--lapse-player">
   <h2 class="ship-review__panel-title"><%= title %></h2>
 
   <% if items.blank? %>
@@ -12,22 +12,39 @@
   <% else %>
     <ul class="recording-gallery__list">
       <% items.each do |item| %>
-        <li class="recording-gallery__item">
-          <div class="recording-gallery__media">
-            <% if item[:source].present? %>
-              <span class="recording-gallery__source"><%= item[:source] %></span>
-            <% end %>
-            <% if item[:video_url].present? %>
-              <video controls playsinline preload="none"
-                     class="recording-gallery__video"
-                     poster="<%= item[:poster_url] %>">
-                <source src="<%= item[:video_url] %>" type="video/mp4">
-                Your browser does not support the video tag.
-              </video>
-            <% else %>
-              <div class="recording-gallery__processing"><%= item[:processing] %></div>
-            <% end %>
-          </div>
+        <li>
+          <% if item[:video_url].present? %>
+            <%# Clickable thumbnail: the JKL lapse-player opens it in a modal;
+                ctrl/middle-click still follows the href to the raw video. %>
+            <a class="recording-gallery__item"
+               href="<%= item[:video_url] %>"
+               data-certification--lapse-player-target="item"
+               data-action="click->certification--lapse-player#open"
+               target="_blank" rel="noopener noreferrer">
+              <div class="recording-gallery__media">
+                <% if item[:source].present? %>
+                  <span class="recording-gallery__source"><%= item[:source] %></span>
+                <% end %>
+                <% if item[:poster_url].present? %>
+                  <img class="recording-gallery__thumb" loading="lazy"
+                       src="<%= item[:poster_url] %>" alt="">
+                <% end %>
+                <span class="recording-gallery__play" aria-hidden="true">▶</span>
+                <% if item[:duration].present? %>
+                  <span class="recording-gallery__duration"><%= format_clock(item[:duration]) %></span>
+                <% end %>
+              </div>
+            </a>
+          <% else %>
+            <div class="recording-gallery__item">
+              <div class="recording-gallery__media">
+                <% if item[:source].present? %>
+                  <span class="recording-gallery__source"><%= item[:source] %></span>
+                <% end %>
+                <div class="recording-gallery__processing"><%= item[:processing] %></div>
+              </div>
+            </div>
+          <% end %>
           <div class="recording-gallery__meta">
             <span class="recording-gallery__name"><%= item[:name] %></span>
             <span class="recording-gallery__sub">

--- a/app/views/admin/certification/ysws/show.html.erb
+++ b/app/views/admin/certification/ysws/show.html.erb
@@ -1,6 +1,12 @@
 <% content_for :title, "YSWS Review ##{@review.id}" %>
 
-<main class="certification-ysws" role="main" data-controller="certification--ysws--review-sidebar certification--ysws--fraud-report certification--ysws--media-viewer certification--ysws--complete-review certification--ysws--return-to-ship-cert" data-certification--ysws--fraud-report-review-id-value="<%= @review.id %>" data-certification--ysws--complete-review-review-id-value="<%= @review.id %>" data-certification--ysws--return-to-ship-cert-review-id-value="<%= @review.id %>">
+<%
+  # Base Stimulus controllers for the review page; the keyboard-shortcut layer
+  # is appended only when its flag is on so no keydown listener is bound off.
+  ysws_controllers = "certification--ysws--review-sidebar certification--ysws--fraud-report certification--ysws--media-viewer certification--ysws--complete-review certification--ysws--return-to-ship-cert"
+  ysws_controllers += " certification--ysws--keyboard-shortcuts" if @ysws_review_shortcuts
+%>
+<main class="certification-ysws" role="main" data-controller="<%= ysws_controllers %>" data-certification--ysws--fraud-report-review-id-value="<%= @review.id %>" data-certification--ysws--complete-review-review-id-value="<%= @review.id %>" data-certification--ysws--return-to-ship-cert-review-id-value="<%= @review.id %>">
   <%= render Admin::Certification::MACAnalysisBannerComponent.new(analysis: @mac_analysis, repo_url: @review.project&.repo_url, total_minutes: @review.original_minutes) %>
 
   <!-- Header Section -->

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -52,6 +52,7 @@ Rails.application.config.after_initialize do
         mac_analysis
         sticky_streaks
         public_api_2026-08-28
+        ysws_review_shortcuts
       ].each { |flag| Flipper.add(flag) }
     end
   rescue StandardError => e


### PR DESCRIPTION
## what's this do?

adds a better Lapse viewer to the ysws certification page, along with a bunch of new hotkeys to use it!

New lapse viewer is modal based. You click a Lapse and it opens a modal on the same page. JKL can adjust the speed forward/backward along with pause, the same as Premier Pro works. ctrl+shift+left/right switches between the lapses attached to a devlog.

### list of new hotkeys

#### YSWS review page

these are behind a new `:ysws_review_shortcuts` flag.

| Key | Action |
| --- | --- |
| `j` / `k` | Next / previous devlog |
| `a` / `r` | Approve / reject current devlog |
| `5` / `2` | Set approved minutes to 50% / 25% |
| `=` / `+` (shift+=) | Add 15 / 30 min |
| `-` / `_` (shift+-) | Cut 15 / 30 min |
| `t` | Open current devlog's lapse recordings |
| `ctrl`/`⌘`+`space` | Focus current devlog's internal-notes box |
| `Escape` | Blur the focused field (back to single-key shortcuts) |
| `ctrl`/`⌘`+`enter` ×2 | Complete the review (double-tap to confirm) |
| `?` | Toggle the shortcut help overlay (Escape closes) |

#### lapse specific

| Key | Action |
| --- | --- |
| `j` / `l` | JKL transport — reverse / forward speed ladder |
| `k` / `space` | Play / pause |
| `←` / `→` (or `h`) | Scrub ∓1s (shift = ∓10s) |
| `ctrl`/`⌘`+`shift`+`←` / `→` | Page between that devlog's recordings (newest addition) |
| `Escape` | Close the lightbox |

## show it works


https://github.com/user-attachments/assets/2e4044f6-f317-4415-be53-8cc5181c1b0d



## ai?

claude opus 4.8 w/ omp.sh