### PR TITLE
feat(streaks): add a refresh button to the streak rail widget

### DIFF
--- a/app/assets/images/icons/refresh.svg
+++ b/app/assets/images/icons/refresh.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13.5 8a5.5 5.5 0 1 1-1.61-3.89" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+<path d="M13.6 1.9v3.1h-3.1" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/app/assets/stylesheets/components/_streak_widget.scss
+++ b/app/assets/stylesheets/components/_streak_widget.scss
@@ -47,6 +47,36 @@
     }
   }
 
+  &__refresh {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    margin-left: auto;
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    color: var(--color-space-text-muted);
+    transition:
+      color 0.15s ease,
+      background 0.15s ease;
+
+    &:hover,
+    &:focus-visible {
+      color: var(--color-space-text);
+      background: var(--color-overlay-light-soft);
+    }
+  }
+
+  &__refresh-icon {
+    width: 14px;
+    height: 14px;
+
+    turbo-frame[busy] & {
+      animation: streak-widget-refresh-spin 700ms linear infinite;
+    }
+  }
+
   &__week {
     display: flex;
     justify-content: space-between;
@@ -277,5 +307,11 @@
     color: var(--color-space-text-muted);
     margin: 0;
     line-height: 1.4;
+  }
+}
+
+@keyframes streak-widget-refresh-spin {
+  to {
+    transform: rotate(360deg);
   }
 }

--- a/app/components/discover_rail/streak_widget.html.erb
+++ b/app/components/discover_rail/streak_widget.html.erb
@@ -23,6 +23,14 @@
         </span>
       <% end %>
     </div>
+    <% if ready? %>
+      <%= link_to helpers.streak_home_discover_rail_path(refresh: 1),
+            class: "streak-widget__refresh",
+            title: "Refresh from Hackatime",
+            aria: { label: "Refresh streak from Hackatime" } do %>
+        <%= helpers.inline_svg_tag "icons/refresh.svg", class: "streak-widget__refresh-icon" %>
+      <% end %>
+    <% end %>
   </div>
 
   <% if setup_needed? %>

--- a/app/controllers/home/discover_rails_controller.rb
+++ b/app/controllers/home/discover_rails_controller.rb
@@ -3,6 +3,7 @@ class Home::DiscoverRailsController < ApplicationController
 
   def streak
     authorize :home, :index?
+    current_user&.sync_streak_now! if params[:refresh].present?
     render layout: false
   end
 

--- a/app/models/concerns/user/streakable.rb
+++ b/app/models/concerns/user/streakable.rb
@@ -4,6 +4,9 @@ module User::Streakable
   # How long a streak sync holds off the next throttled sync (sync_streak_if_stale!).
   STREAK_SYNC_THROTTLE = 15.minutes
 
+  # How long a hand-triggered sync (sync_streak_now!) holds off the next one.
+  MANUAL_STREAK_SYNC_THROTTLE = 20.seconds
+
   included do
     has_many :streak_activities, dependent: :destroy
     has_one :sticky_streak, dependent: :destroy
@@ -57,6 +60,18 @@ module User::Streakable
     return if Rails.cache.read(streak_sync_throttle_key)
 
     sync_streak!
+  end
+
+  # Someone pressing refresh wants numbers they can see now, so sync inline
+  # rather than queueing. Its own short window keeps a mashed button off
+  # Hackatime; the shared window is armed too so no background sync piles on.
+  def sync_streak_now!
+    return unless hackatime_identity.present?
+    return if Rails.cache.read(manual_streak_sync_key)
+
+    Rails.cache.write(manual_streak_sync_key, true, expires_in: MANUAL_STREAK_SYNC_THROTTLE)
+    Rails.cache.write(streak_sync_throttle_key, true, expires_in: STREAK_SYNC_THROTTLE)
+    StreakActivity.sync_for_user!(self)
   end
 
   # Most recent day (streak-day granularity) the user logged any Hackatime
@@ -120,6 +135,10 @@ module User::Streakable
 
   def streak_sync_throttle_key
     "streak_sync:#{id}"
+  end
+
+  def manual_streak_sync_key
+    "streak_sync_manual:#{id}"
   end
 
   def calculate_current_streak

--- a/test/controllers/home/discover_rail_streak_test.rb
+++ b/test/controllers/home/discover_rail_streak_test.rb
@@ -145,6 +145,46 @@ class Home::DiscoverRailStreakTest < ActionDispatch::IntegrationTest
     assert_select ".streak-widget__week [data-tooltip-message-value=?]", "Sticky Streak day 1"
   end
 
+  test "the header offers a refresh control once the widget is set up" do
+    get streak_home_discover_rail_path
+
+    assert_response :success
+    assert_select ".streak-widget__header a.streak-widget__refresh[href=?]",
+                  streak_home_discover_rail_path(refresh: 1)
+  end
+
+  test "refreshing re-reads Hackatime inline and throttles the next press" do
+    today = @user.streak_today_date
+    @user.update!(streak_synced_at: FROZEN_NOW - 1.day)
+    span_start = FROZEN_NOW - 1.hour
+    spans = [ { "start_time" => span_start.to_i, "end_time" => (span_start + 300).to_i, "duration" => 300 } ]
+    calls = 0
+    fetch = ->(*_args, **_kwargs) { calls += 1; spans }
+
+    with_memory_cache do
+      HackatimeService.stub(:fetch_heartbeat_spans, fetch) do
+        get streak_home_discover_rail_path(refresh: 1)
+        get streak_home_discover_rail_path(refresh: 1)
+      end
+    end
+
+    assert_response :success
+    assert_equal 1, calls, "a second press inside the throttle window must not hit Hackatime again"
+    assert_equal 300, @user.streak_activities.find_by(activity_date: today).coded_seconds
+    assert_select ".streak-widget__progress-label", text: /5 \/ 5 minutes today/
+  end
+
+  test "the widget does not sync when it is loaded without the refresh flag" do
+    @user.update!(streak_synced_at: FROZEN_NOW - 1.day)
+    fetch = ->(*_args, **_kwargs) { flunk "a plain load must not call Hackatime inline" }
+
+    HackatimeService.stub(:fetch_heartbeat_spans, fetch) do
+      get streak_home_discover_rail_path
+    end
+
+    assert_response :success
+  end
+
   test "the month nav can page forward to the last calendar month" do
     get streak_home_discover_rail_path
 
@@ -153,6 +193,14 @@ class Home::DiscoverRailStreakTest < ActionDispatch::IntegrationTest
   end
 
   private
+
+  def with_memory_cache
+    original = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    yield
+  ensure
+    Rails.cache = original
+  end
 
   def sticker
     item = ShopItem.new(name: "Orbit Sticker", description: "sticker", ticket_cost: 5,


### PR DESCRIPTION
## what's this do?

adds button to refresh sticky streak cache

## show it works

<img width="334" height="96" alt="image" src="https://github.com/user-attachments/assets/bb6e6036-5c5e-4693-9e27-75ca3ea298c9" />

## ai?

claude
