### PR TITLE
feat(fraud): hide people another reviewer is holding from the queue

### DIFF
--- a/app/controllers/admin/fraud/subjects_controller.rb
+++ b/app/controllers/admin/fraud/subjects_controller.rb
@@ -9,7 +9,7 @@ class Admin::Fraud::SubjectsController < Admin::ApplicationController
     # GROUP BY, so a SQL page of it still needs a second query to count the
     # groups, and the queue is small enough (about a thousand people) that one
     # pass is cheaper than two round trips.
-    subjects = Admin::Fraud::SubjectQueue.subjects
+    subjects = Admin::Fraud::SubjectQueue.subjects_for(current_user)
     @total_subjects = subjects.size
     @pagy, @subjects = pagy(:offset, subjects, limit: SUBJECTS_PER_PAGE)
     @users = User.where(id: @subjects.map(&:user_id)).index_by(&:id)

--- a/app/services/admin/fraud/subject_queue.rb
+++ b/app/services/admin/fraud/subject_queue.rb
@@ -24,20 +24,35 @@ module Admin
       # One row per person with work waiting, ordered by priority. Banned people
       # are left out: a ban already rejects their orders and soft-deletes their
       # projects, so there is no verdict left to give.
-      def self.relation
-        ::User.where(banned: false)
-              .joins("INNER JOIN (#{items_sql}) fraud_items ON fraud_items.user_id = users.id")
-              .group("users.id")
-              .select(<<~SQL.squish)
-                users.id AS user_id,
-                MAX(fraud_items.weight * EXTRACT(EPOCH FROM (NOW() - fraud_items.created_at)) / 86400.0) AS priority,
-                COUNT(*) FILTER (WHERE fraud_items.kind = 'flag') AS flag_count,
-                COUNT(*) FILTER (WHERE fraud_items.kind = 'order') AS order_count,
-                COUNT(*) FILTER (WHERE fraud_items.kind = 'integrity') AS integrity_count,
-                MIN(fraud_items.created_at) AS oldest_at
-              SQL
-              .order(Arel.sql("priority DESC"))
+      #
+      # Pass a reviewer to get the queue as it should look to them: anyone
+      # another reviewer is currently holding drops out, since opening them only
+      # leads to a page that refuses verdicts.
+      def self.relation(reviewer: nil)
+        scope = ::User.where(banned: false)
+                      .joins("INNER JOIN (#{items_sql}) fraud_items ON fraud_items.user_id = users.id")
+                      .group("users.id")
+                      .select(<<~SQL.squish)
+                        users.id AS user_id,
+                        MAX(fraud_items.weight * EXTRACT(EPOCH FROM (NOW() - fraud_items.created_at)) / 86400.0) AS priority,
+                        COUNT(*) FILTER (WHERE fraud_items.kind = 'flag') AS flag_count,
+                        COUNT(*) FILTER (WHERE fraud_items.kind = 'order') AS order_count,
+                        COUNT(*) FILTER (WHERE fraud_items.kind = 'integrity') AS integrity_count,
+                        MIN(fraud_items.created_at) AS oldest_at
+                      SQL
+                      .order(Arel.sql("priority DESC"))
+
+        reviewer ? scope.where.not(id: held_by_others(reviewer)) : scope
       end
+
+      # A reviewer's own claim is deliberately left in: they should be able to
+      # get back to a person they are part way through.
+      def self.held_by_others(reviewer)
+        ::FraudSubjectClaim.active.where.not(reviewer_id: reviewer.id).select(:subject_id)
+      end
+
+      # The queue as one reviewer should see it.
+      def self.subjects_for(reviewer) = subjects(relation(reviewer: reviewer))
 
       def self.subjects(relation = self.relation)
         relation.map do |row|
@@ -107,11 +122,9 @@ module Admin
       # skipping the one they just finished and anyone another reviewer is
       # currently holding.
       def self.next_subject_id(reviewer:, after: nil)
-        held = ::FraudSubjectClaim.active.where.not(reviewer_id: reviewer.id).pluck(:subject_id)
-        excluded = ([ after&.id ] + held).compact
+        scope = relation(reviewer: reviewer)
+        scope = scope.where.not(id: after.id) if after
 
-        scope = relation
-        scope = scope.where.not(id: excluded) if excluded.any?
         scope.first&.user_id
       end
 

--- a/test/controllers/admin/fraud/subjects_controller_test.rb
+++ b/test/controllers/admin/fraud/subjects_controller_test.rb
@@ -26,6 +26,30 @@ class Admin::Fraud::SubjectsControllerTest < ActionDispatch::IntegrationTest
     assert_select ".fraud-subject-card__avatar[src=?]", @subject.avatar
   end
 
+  test "the queue leaves out someone another reviewer is holding" do
+    flag_the_project
+    holder = create_user(slack_id: "U_FRAUD_HOLDER", display_name: "holder")
+    FraudSubjectClaim.claim(@subject, holder)
+
+    sign_in @squad
+    get admin_fraud_subjects_path
+
+    assert_response :success
+    assert_select "a[href=?]", admin_fraud_subject_path(@subject), count: 0
+    assert_select ".fraud-queue__empty"
+  end
+
+  test "the queue still lists the person the reviewer is holding themselves" do
+    flag_the_project
+    FraudSubjectClaim.claim(@subject, @squad)
+
+    sign_in @squad
+    get admin_fraud_subjects_path
+
+    assert_response :success
+    assert_select "a[href=?]", admin_fraud_subject_path(@subject)
+  end
+
   test "the progress bar gives each waiting item one slot" do
     flag_the_project
     pending_integrity_check(@project)

--- a/test/services/admin/fraud/subject_queue_test.rb
+++ b/test/services/admin/fraud/subject_queue_test.rb
@@ -67,9 +67,52 @@ class Admin::Fraud::SubjectQueueTest < ActiveSupport::TestCase
     assert_equal [ owner.id, teammate.id ].sort, ranked_ids.sort
   end
 
+  test "a person another reviewer is holding drops off the queue" do
+    held = user_with_flag(age: 10.days.ago, display_name: "held")
+    open = user_with_flag(age: 5.days.ago, display_name: "open")
+    holder = create_user(slack_id: "u-holder", display_name: "holder")
+    looker = create_user(slack_id: "u-looker", display_name: "looker")
+    FraudSubjectClaim.claim(held, holder)
+
+    assert_equal [ open.id ], ranked_ids_for(looker)
+    assert_equal [ held.id, open.id ], ranked_ids, "the unfiltered queue still has both"
+  end
+
+  test "a reviewer still sees the person they are holding themselves" do
+    mine = user_with_flag(age: 10.days.ago, display_name: "mine")
+    reviewer = create_user(slack_id: "u-mine", display_name: "minereviewer")
+    FraudSubjectClaim.claim(mine, reviewer)
+
+    assert_equal [ mine.id ], ranked_ids_for(reviewer)
+  end
+
+  test "a lapsed claim puts the person back on the queue" do
+    lapsed = user_with_flag(age: 10.days.ago, display_name: "lapsed")
+    holder = create_user(slack_id: "u-lapsed-holder", display_name: "lapsedholder")
+    looker = create_user(slack_id: "u-lapsed-looker", display_name: "lapsedlooker")
+    claim = FraudSubjectClaim.claim(lapsed, holder)
+    claim.update_columns(claimed_at: (FraudSubjectClaim::CLAIM_TTL + 1.minute).ago)
+
+    assert_equal [ lapsed.id ], ranked_ids_for(looker)
+  end
+
+  test "the next person skips both the one just finished and anyone held" do
+    finished = user_with_flag(age: 30.days.ago, display_name: "finished")
+    held = user_with_flag(age: 20.days.ago, display_name: "nextheld")
+    up_next = user_with_flag(age: 10.days.ago, display_name: "upnext")
+    reviewer = create_user(slack_id: "u-next", display_name: "nextreviewer")
+    holder = create_user(slack_id: "u-next-holder", display_name: "nextholder")
+    FraudSubjectClaim.claim(held, holder)
+
+    assert_equal up_next.id,
+                 Admin::Fraud::SubjectQueue.next_subject_id(reviewer: reviewer, after: finished)
+  end
+
   private
 
   def subjects = Admin::Fraud::SubjectQueue.subjects
+
+  def ranked_ids_for(reviewer) = Admin::Fraud::SubjectQueue.subjects_for(reviewer).map(&:user_id)
 
   def ranked_ids = subjects.map(&:user_id)
 


### PR DESCRIPTION
## what's this do?

previously you would still see already claimed people in the queue, and it would just block you from doing anything. Now they're actually hidden

## show it works

can't show you something that's hidden :p

## ai?

claude
