### PR TITLE
fix(fraud): properly credit fraudsters using the mass approve system

### DIFF
--- a/app/controllers/admin/fraud/subjects_controller.rb
+++ b/app/controllers/admin/fraud/subjects_controller.rb
@@ -26,9 +26,7 @@ class Admin::Fraud::SubjectsController < Admin::ApplicationController
 
     @flags = Admin::Fraud::SubjectQueue.flags_for(@user)
     @orders = Admin::Fraud::SubjectQueue.orders_for(@user)
-    @approvable_orders = @orders.select(&:approvable?)
     @integrity_checks = Admin::Fraud::SubjectQueue.integrity_checks_for(@user)
-    @projects_for_rejection = @user.projects.with_deleted.distinct.order(created_at: :desc)
 
     approved_scope = @user.shop_orders.where(aasm_state: %w[awaiting_periodical_fulfillment fulfilled])
     @approved_orders_count = approved_scope.count

--- a/app/controllers/admin/shop/orders_controller.rb
+++ b/app/controllers/admin/shop/orders_controller.rb
@@ -417,18 +417,11 @@ class Admin::Shop::OrdersController < Admin::ApplicationController
       redirect_back fallback_location: admin_shop_orders_path, alert: "No orders to approve." and return
     end
 
-    approved, failed = orders.map { |order|
+    settled, failed = orders.map { |order|
       Admin::ShopOrderApprover.new(order, actor: current_user).call
     }.partition(&:approved?)
 
-    if approved.any?
-      flash[:notice] = "Approved #{helpers.pluralize(approved.size, 'order')}: #{approved.map { |result| "##{result.order.id}" }.to_sentence}"
-    end
-    if failed.any?
-      flash[:alert] = failed.map { |result| "##{result.order.id}: #{result.message}" }.join(" ")
-    end
-
-    redirect_back fallback_location: admin_shop_orders_path
+    render_bulk_order_outcome(settled, failed, verb: "Approved")
   end
 
   def bulk_reject
@@ -440,7 +433,7 @@ class Admin::Shop::OrdersController < Admin::ApplicationController
       redirect_back fallback_location: admin_shop_orders_path, alert: "No orders to reject." and return
     end
 
-    rejected, failed = orders.map { |order|
+    settled, failed = orders.map { |order|
       Admin::ShopOrderRejector.new(
         order,
         actor: current_user,
@@ -451,14 +444,7 @@ class Admin::Shop::OrdersController < Admin::ApplicationController
       ).call
     }.partition(&:rejected?)
 
-    if rejected.any?
-      flash[:notice] = "Rejected #{helpers.pluralize(rejected.size, 'order')}: #{rejected.map { |result| "##{result.order.id}" }.to_sentence}"
-    end
-    if failed.any?
-      flash[:alert] = failed.map { |result| "##{result.order.id}: #{result.message}" }.join(" ")
-    end
-
-    redirect_back fallback_location: admin_shop_orders_path
+    render_bulk_order_outcome(settled, failed, verb: "Rejected")
   end
 
   def review_order
@@ -702,6 +688,31 @@ class Admin::Shop::OrdersController < Admin::ApplicationController
     end
   end
   private
+
+  # Submitted from the per-person fraud page, a bulk verdict answers the way a
+  # single one does: each settled order is claimed onto the reviewer's payout
+  # and swapped in place, rather than reloading the queue and paying nobody.
+  # The per-order outcome shows on the row it settled, so only failures need a
+  # flash of their own.
+  def render_bulk_order_outcome(settled, failed, verb:)
+    if fraud_subject
+      flash.now[:alert] = bulk_order_failure_message(failed) if failed.any?
+
+      return render_fraud_subject_verdicts(settled.map { |result| [ result.order, result.message ] })
+    end
+
+    if settled.any?
+      flash[:notice] = "#{verb} #{helpers.pluralize(settled.size, 'order')}: " \
+                       "#{settled.map { |result| "##{result.order.id}" }.to_sentence}"
+    end
+    flash[:alert] = bulk_order_failure_message(failed) if failed.any?
+
+    redirect_back fallback_location: admin_shop_orders_path
+  end
+
+  def bulk_order_failure_message(failed)
+    failed.map { |result| "##{result.order.id}: #{result.message}" }.join(" ")
+  end
 
   # Only the fraud queue cares, and only a pending order can qualify, so the
   # question is asked about as few rows as possible. Reloaded with just the

--- a/app/controllers/concerns/fraud_subject_verdict.rb
+++ b/app/controllers/concerns/fraud_subject_verdict.rb
@@ -44,7 +44,19 @@ module FraudSubjectVerdict
   end
 
   def render_fraud_subject_verdict(record, note, refresh_integrity: false)
+    render turbo_stream: fraud_subject_verdict_streams([ [ record, note ] ], refresh_integrity: refresh_integrity)
+  end
+
+  # A bulk action settles a whole pile in one submission. Each item is swapped
+  # and claimed exactly as it would have been one at a time, so the reviewer is
+  # paid the same either way.
+  def render_fraud_subject_verdicts(settled)
+    render turbo_stream: fraud_subject_verdict_streams(settled)
+  end
+
+  def fraud_subject_verdict_streams(settled, refresh_integrity: false)
     streams = []
+    records = settled.map(&:first)
 
     if refresh_integrity
       streams << turbo_stream.replace(
@@ -55,7 +67,7 @@ module FraudSubjectVerdict
 
       # The siblings the cascade settled leave the list above on their own, but
       # their slots in the progress bar would sit there still waiting.
-      Admin::Fraud::SubjectQueue.cascaded_siblings_of(record, user: fraud_subject).each do |sibling|
+      Admin::Fraud::SubjectQueue.cascaded_siblings_of(records.first, user: fraud_subject).each do |sibling|
         streams << turbo_stream.replace(
           ActionView::RecordIdentifier.dom_id(sibling, :progress),
           partial: "admin/fraud/subjects/progress_slot",
@@ -63,11 +75,13 @@ module FraudSubjectVerdict
         )
       end
     else
-      streams << turbo_stream.replace(
-        ActionView::RecordIdentifier.dom_id(record),
-        partial: "admin/fraud/subjects/resolved_item",
-        locals: { record: record, note: note }
-      )
+      settled.each do |record, note|
+        streams << turbo_stream.replace(
+          ActionView::RecordIdentifier.dom_id(record),
+          partial: "admin/fraud/subjects/resolved_item",
+          locals: { record: record, note: note }
+        )
+      end
     end
 
     streams << turbo_stream.replace(
@@ -76,17 +90,27 @@ module FraudSubjectVerdict
       locals: { user: fraud_subject }
     )
 
+    # A settled order leaves the bulk buttons offering work that is no longer
+    # there, so they are re-read alongside the counts.
     streams << turbo_stream.replace(
-      ActionView::RecordIdentifier.dom_id(record, :progress),
-      partial: "admin/fraud/subjects/progress_slot",
-      locals: { record: record }
+      "fraud-subject-order-bulk-actions",
+      partial: "admin/fraud/subjects/order_bulk_actions",
+      locals: { user: fraud_subject }
     )
 
+    records.each do |record|
+      streams << turbo_stream.replace(
+        ActionView::RecordIdentifier.dom_id(record, :progress),
+        partial: "admin/fraud/subjects/progress_slot",
+        locals: { record: record }
+      )
+    end
+
     cleared = fraud_subject_cleared?
-    payout = FraudReviewPayout.claim!(record, reviewer: current_user, subject: fraud_subject)
+    payout = fraud_subject_payout_for(records, cleared: cleared)
 
     if payout
-      payout.complete! if cleared
+      payout.complete! if cleared && payout.completed_at.nil?
       streams << turbo_stream.replace(
         "fraud-subject-payout",
         partial: "admin/fraud/subjects/payout",
@@ -115,7 +139,24 @@ module FraudSubjectVerdict
       )
     end
 
-    render turbo_stream: streams
+    streams << turbo_stream.update("flash-region", partial: "shared/flash") if flash.any?
+
+    streams
+  end
+
+  # Every settled item is claimed; they all land on the one open tally, so the
+  # last claim is that tally with the full run of them counted.
+  #
+  # An item another payout already claimed earns nothing further but can still
+  # be the one that empties the queue, and a tally left open is never payable
+  # (FraudReviewPayout.payable), so the open one is picked up in that case
+  # rather than left to sit unpaid.
+  def fraud_subject_payout_for(records, cleared:)
+    claimed = records.filter_map do |record|
+      FraudReviewPayout.claim!(record, reviewer: current_user, subject: fraud_subject)
+    end
+
+    claimed.last || (cleared ? FraudReviewPayout.unpaid.find_by(reviewer: current_user, subject: fraud_subject, completed_at: nil) : nil)
   end
 
   # A cascading integrity verdict settles siblings this request never touched,

--- a/app/views/admin/fraud/subjects/_order_bulk_actions.html.erb
+++ b/app/views/admin/fraud/subjects/_order_bulk_actions.html.erb
@@ -1,43 +1,52 @@
-<% if orders.any? %>
-  <div class="fraud-subject__bulk-actions" aria-label="Bulk order actions">
-    <% if approvable_orders.any? && policy(approvable_orders.first).approve? && user.id != current_user.id %>
-      <%= button_to "Approve all #{pluralize(approvable_orders.size, "order")}",
-                    bulk_approve_admin_shop_orders_path,
-                    params: { order_ids: approvable_orders.map(&:id) },
-                    class: "fraud-subject__verdict fraud-subject__verdict--accept",
-                    data: { turbo_confirm: "Approve all #{approvable_orders.size} approvable orders for #{user.display_name}?" } %>
-    <% end %>
+<%# Framed and self-sufficient so a verdict can swap it: once the orders it
+    offers are settled, the buttons must stop offering them. %>
+<%= turbo_frame_tag "fraud-subject-order-bulk-actions" do %>
+  <% orders = Admin::Fraud::SubjectQueue.orders_for(user) %>
+  <% approvable_orders = orders.select(&:approvable?) %>
 
-    <% if policy(orders.first).reject? %>
-      <details class="fraud-subject__bulk-reject">
-        <summary class="fraud-subject__verdict fraud-subject__verdict--reject">
-          Reject all <%= pluralize(orders.size, "order") %>
-        </summary>
+  <% if orders.any? %>
+    <div class="fraud-subject__bulk-actions" aria-label="Bulk order actions">
+      <% if approvable_orders.any? && policy(approvable_orders.first).approve? && user.id != current_user.id %>
+        <%= button_to "Approve all #{pluralize(approvable_orders.size, "order")}",
+                      bulk_approve_admin_shop_orders_path,
+                      params: { order_ids: approvable_orders.map(&:id), fraud_subject_id: user.id },
+                      class: "fraud-subject__verdict fraud-subject__verdict--accept",
+                      data: { turbo_confirm: "Approve all #{approvable_orders.size} approvable orders for #{user.display_name}?" } %>
+      <% end %>
 
-        <%= form_with url: bulk_reject_admin_shop_orders_path, class: "fraud-subject__bulk-reject-form" do |f| %>
-          <% orders.each do |order| %>
-            <%= hidden_field_tag "order_ids[]", order.id, id: nil %>
+      <% if policy(orders.first).reject? %>
+        <details class="fraud-subject__bulk-reject">
+          <summary class="fraud-subject__verdict fraud-subject__verdict--reject">
+            Reject all <%= pluralize(orders.size, "order") %>
+          </summary>
+
+          <%= form_with url: bulk_reject_admin_shop_orders_path, class: "fraud-subject__bulk-reject-form" do |f| %>
+            <%= hidden_field_tag :fraud_subject_id, user.id %>
+
+            <% orders.each do |order| %>
+              <%= hidden_field_tag "order_ids[]", order.id, id: nil %>
+            <% end %>
+
+            <%= f.label :reason, "Reason shown to the buyer", class: "fraud-subject__field-label" %>
+            <%= f.text_field :reason, required: true, class: "fraud-subject__field" %>
+
+            <% if Admin::ShopOrderRejector.records_fraud_details?(current_user) %>
+              <%= f.label :internal_rejection_reason, "Internal reason", class: "fraud-subject__field-label" %>
+              <%= f.text_area :internal_rejection_reason, rows: 2, required: true, class: "fraud-subject__field" %>
+
+              <%= f.label :fraud_related_project_id, "Related project", class: "fraud-subject__field-label" %>
+              <%= f.select :fraud_related_project_id,
+                           user.projects.with_deleted.distinct.order(created_at: :desc).map { |project| [ project.title, project.id ] },
+                           { include_blank: "Pick a project" },
+                           required: true, class: "fraud-subject__field" %>
+            <% end %>
+
+            <%= f.submit "Reject all orders",
+                         class: "fraud-subject__verdict fraud-subject__verdict--reject",
+                         data: { turbo_confirm: "Reject all #{orders.size} orders for #{user.display_name}?" } %>
           <% end %>
-
-          <%= f.label :reason, "Reason shown to the buyer", class: "fraud-subject__field-label" %>
-          <%= f.text_field :reason, required: true, class: "fraud-subject__field" %>
-
-          <% if Admin::ShopOrderRejector.records_fraud_details?(current_user) %>
-            <%= f.label :internal_rejection_reason, "Internal reason", class: "fraud-subject__field-label" %>
-            <%= f.text_area :internal_rejection_reason, rows: 2, required: true, class: "fraud-subject__field" %>
-
-            <%= f.label :fraud_related_project_id, "Related project", class: "fraud-subject__field-label" %>
-            <%= f.select :fraud_related_project_id,
-                         projects.map { |project| [ project.title, project.id ] },
-                         { include_blank: "Pick a project" },
-                         required: true, class: "fraud-subject__field" %>
-          <% end %>
-
-          <%= f.submit "Reject all orders",
-                       class: "fraud-subject__verdict fraud-subject__verdict--reject",
-                       data: { turbo_confirm: "Reject all #{orders.size} orders for #{user.display_name}?" } %>
-        <% end %>
-      </details>
-    <% end %>
-  </div>
+        </details>
+      <% end %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/admin/fraud/subjects/show.html.erb
+++ b/app/views/admin/fraud/subjects/show.html.erb
@@ -37,8 +37,7 @@
   <section class="fraud-subject__section" aria-labelledby="fraud-subject-orders">
     <h2 class="fraud-subject__section-title" id="fraud-subject-orders">Shop orders</h2>
 
-    <%= render "order_bulk_actions", user: @user, orders: @orders,
-               approvable_orders: @approvable_orders, projects: @projects_for_rejection %>
+    <%= render "order_bulk_actions", user: @user %>
 
     <% if @orders.any? %>
       <div class="fraud-subject__items">

--- a/test/controllers/admin/fraud/subject_verdicts_test.rb
+++ b/test/controllers/admin/fraud/subject_verdicts_test.rb
@@ -253,7 +253,6 @@ class Admin::Fraud::SubjectVerdictsTest < ActionDispatch::IntegrationTest
   end
 
   test "an order row shows its fulfillment cost, stardust cost and the buyer's country" do
-    order = pending_order
     @subject.update!(geocoded_country: "CA")
 
     get admin_fraud_subject_path(@subject)
@@ -303,6 +302,98 @@ class Admin::Fraud::SubjectVerdictsTest < ActionDispatch::IntegrationTest
     assert_redirected_to admin_fraud_subject_path(@subject)
     assert_predicate order.reload, :rejected?
     assert PaperTrail::Version.where(item_type: "ShopOrder", item_id: order.id, whodunnit: @admin.id.to_s).exists?
+  end
+
+  test "bulk approving from the subject page pays the reviewer for every order" do
+    orders = 2.times.map { pending_order }
+
+    post bulk_approve_admin_shop_orders_path,
+         params: { order_ids: orders.map(&:id), fraud_subject_id: @subject.id }, headers: TURBO_STREAM
+
+    assert_response :success
+    orders.each { |order| assert_equal "awaiting_periodical_fulfillment", order.reload.aasm_state }
+
+    payout = FraudReviewPayout.sole
+    assert_equal [ @admin.id, @subject.id, 2 ], [ payout.reviewer_id, payout.subject_id, payout.order_count ]
+    assert_equal orders.map(&:id).sort, payout.shop_orders.pluck(:id).sort
+    assert_not_nil payout.completed_at, "nothing is left waiting, so the tally is payable"
+    assert_match "fraud-celebration", response.body
+  end
+
+  test "bulk rejecting from the subject page pays the reviewer for every order" do
+    orders = 2.times.map { pending_order }
+    project = Project.create!(title: "Fraud source")
+
+    post bulk_reject_admin_shop_orders_path,
+         params: {
+           order_ids: orders.map(&:id),
+           fraud_subject_id: @subject.id,
+           reason: "Fraud review failed",
+           internal_rejection_reason: "Matching evidence",
+           fraud_related_project_id: project.id
+         }, headers: TURBO_STREAM
+
+    assert_response :success
+    orders.each { |order| assert_predicate order.reload, :rejected? }
+    assert_equal 2, FraudReviewPayout.sole.order_count
+  end
+
+  test "a bulk verdict swaps out every row it settled and refreshes the buttons" do
+    orders = 2.times.map { pending_order }
+
+    post bulk_approve_admin_shop_orders_path,
+         params: { order_ids: orders.map(&:id), fraud_subject_id: @subject.id }, headers: TURBO_STREAM
+
+    assert_response :success
+    orders.each do |order|
+      assert_match ActionView::RecordIdentifier.dom_id(order), response.body
+      assert_match ActionView::RecordIdentifier.dom_id(order, :progress), response.body
+    end
+    assert_match "fraud-subject-order-bulk-actions", response.body
+    assert_no_match(/Approve all \d+ order/, response.body, "the settled orders are no longer on offer")
+  end
+
+  test "a bulk verdict completes a tally an earlier verdict left open" do
+    flag = flag_a_project
+    order = pending_order
+
+    post review_admin_certification_report_path(flag),
+         params: { fraud_subject_id: @subject.id }, headers: TURBO_STREAM
+    assert_nil FraudReviewPayout.sole.completed_at, "the order is still waiting"
+
+    post bulk_approve_admin_shop_orders_path,
+         params: { order_ids: [ order.id ], fraud_subject_id: @subject.id }, headers: TURBO_STREAM
+
+    assert_response :success
+    payout = FraudReviewPayout.sole
+    assert_equal [ 1, 1 ], [ payout.flag_count, payout.order_count ]
+    assert_not_nil payout.completed_at
+    assert_includes FraudReviewPayout.payable, payout
+  end
+
+  test "a bulk verdict cannot jump another reviewer's claim" do
+    other = create_user(slack_id: "U_FRAUD_BULK_HOLDER", display_name: "bulkholder")
+    FraudSubjectClaim.claim(@subject, other)
+    order = pending_order
+
+    post bulk_approve_admin_shop_orders_path,
+         params: { order_ids: [ order.id ], fraud_subject_id: @subject.id }, headers: TURBO_STREAM
+
+    assert_response :conflict
+    assert_equal "pending", order.reload.aasm_state
+    assert_empty FraudReviewPayout.all
+  end
+
+  test "a bulk verdict from the shop queue still redirects" do
+    order = pending_order
+
+    post bulk_approve_admin_shop_orders_path,
+         params: { order_ids: [ order.id ] },
+         headers: { "HTTP_REFERER" => admin_shop_orders_url }
+
+    assert_redirected_to admin_shop_orders_path
+    assert_equal "awaiting_periodical_fulfillment", order.reload.aasm_state
+    assert_empty FraudReviewPayout.all, "a payout is the fraud page's unit of work, not the shop queue's"
   end
 
   test "putting an order on hold keeps it in the queue and re-renders the row" do


### PR DESCRIPTION
## what's this do?

Before, the only way to get credit for doing orders was to approve them one by one. Hitting the mass-approve button didn't credit you with stardust. Now it does.

## show it works

Both bulk paths now pay out, and land in FraudReviewPayout.payable where Fraud::CalculatePayoutsJob will actually credit them

- All 3 rows showed approved for fulfillment
- Payout readout went 1 × 1 × 1 = 0 → 1 × 1 × 3.25 × 1 = 3.25
- Counts refreshed to "0 flags 0 orders 0 checks", celebration fired, "Nothing else waiting" appeared

```
amount=3.25 credited=3 order_count=3
claimed_order_ids=[31, 32, 33]
completed_at=2026-09-11 21:38:42 UTC     payable=1
unclaimed_by_review_payout=0             papertrail_by_admin=6
```
## ai?

Opus 5