### PR TITLE
Feat: ship posts and project description markdown support

### DIFF
--- a/app/components/projects/shelf_card_component.html.erb
+++ b/app/components/projects/shelf_card_component.html.erb
@@ -10,7 +10,7 @@
   <span class="project-shelf-card__body">
     <span class="project-shelf-card__title"><%= project.title %></span>
     <% if description.present? %>
-      <span class="project-shelf-card__description"><%= truncate(strip_tags(description), length: 120) %></span>
+      <span class="project-shelf-card__description"><%= truncate(plain_description, length: 120) %></span>
     <% end %>
   </span>
 <% end %>

--- a/app/components/projects/shelf_card_component.rb
+++ b/app/components/projects/shelf_card_component.rb
@@ -15,6 +15,10 @@ module Projects
       project.display_description.presence || project.description
     end
 
+    def plain_description
+      helpers.strip_tags(helpers.md(description, allow_images: false)).squish
+    end
+
     def engagement_data
       {
         controller: "feed-engagement",

--- a/app/views/projects/_ship_card.html.erb
+++ b/app/views/projects/_ship_card.html.erb
@@ -128,7 +128,7 @@
       </p>
 
       <% if ship_text.present? %>
-        <div class="feed-post-card__body feed-post-card__body--inline project-show__latest-ship-text">
+        <div class="feed-post-card__body feed-post-card__body--inline project-show__latest-ship-text markdown-content">
           <%= md(ship_text, allow_images: false) %>
         </div>
       <% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -466,7 +466,7 @@
             </div>
 
             <% if @project.description.present? %>
-              <p class="project-show__description"><%= @project.description %></p>
+              <div class="project-show__description markdown-content"><%= md(@project.description, allow_images: false) %></div>
             <% end %>
 
             <div class="project-show__read-footer">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -275,7 +275,7 @@
                 </div>
 
                 <% if project.description.present? %>
-                  <p class="profile-project-card__description"><%= project.description %></p>
+                  <p class="profile-project-card__description"><%= strip_tags(md(project.description, allow_images: false)).squish %></p>
                 <% end %>
 
                 <% mission = project.current_mission %>

--- a/app/views/votes/_project_card.html.erb
+++ b/app/views/votes/_project_card.html.erb
@@ -57,7 +57,7 @@
       </div>
 
       <% if project.description.present? %>
-        <p class="project-show__description"><%= project.description %></p>
+        <div class="project-show__description markdown-content"><%= md(project.description, allow_images: false) %></div>
       <% end %>
 
       <% if project.ai_declaration.present? %>


### PR DESCRIPTION
## what's this do?

Adds markdown support to ship posts and project descriptions.

Closes #1149 

## show it works

<!-- screen recording, screenshots, test output— whatever makes sense for the change -->

Project Description Markdown:

https://github.com/user-attachments/assets/7f01f3d0-3f5d-4de4-add5-2472b9dec676

Ship post markdown:

<img width="768" height="275" alt="image" src="https://github.com/user-attachments/assets/a965e9c2-3aa2-4fb0-afcd-3bda65041e8d" />


## ai?

<!-- did you use AI tools? which ones? no judgment, we just wanna know. see AI_POLICY.md for details -->

Opencode for having my dev project be marked as shipped so I could test the ship message markdown