### PR TITLE
Cloudflare Only trust for CF-Connecting-IP

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -137,7 +137,7 @@ class ApplicationController < ActionController::Base
   end
 
   def client_ip_address
-    request.headers["CF-Connecting-IP"].presence || request.remote_ip
+    RackAttackClient.ip(request)
   end
 
   def prepare_boot_splash

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,8 +1,18 @@
 require "rack/attack"
+require "ipaddr"
 
 Rack::Attack.cache.store = Rails.cache
 
 module RackAttackClient
+  CLOUDFLARE_IP_RANGES = %w[
+    173.245.48.0/20 103.21.244.0/22 103.22.200.0/22 103.31.4.0/22
+    141.101.64.0/18 108.162.192.0/18 190.93.240.0/20 188.114.96.0/20
+    197.234.240.0/22 198.41.128.0/17 162.158.0.0/15 104.16.0.0/13
+    104.24.0.0/14 172.64.0.0/13 131.0.72.0/22
+    2400:cb00::/32 2606:4700::/32 2803:f800::/32 2405:b500::/32
+    2405:8100::/32 2a06:98c0::/29 2c0f:f248::/32
+  ].map { |range| IPAddr.new(range) }.freeze
+
   STATIC_PATHS = %r{\A/(assets|favicon\.ico|robots\.txt|manifest\.json|apple-touch-icon)}.freeze
   AUTH_PATHS = %r{\A/(auth/[^/]+/callback|oauth/callback|auth/failure)\z}.freeze
   ADMIN_PATHS = %r{\A/admin(/|\z)}.freeze
@@ -13,7 +23,17 @@ module RackAttackClient
   API_V1_DEVLOG_PATH = %r{\A/api/v1/devlogs/\d+\z}.freeze
 
   def self.ip(request)
-    request.get_header("HTTP_CF_CONNECTING_IP").presence || request.ip
+    cf_ip = request.get_header("HTTP_CF_CONNECTING_IP")
+    return cf_ip if cf_ip.present? && cloudflare_proxy?(request)
+
+    request.ip
+  end
+
+  def self.cloudflare_proxy?(request)
+    peer_ip = IPAddr.new(request.get_header("REMOTE_ADDR"))
+    CLOUDFLARE_IP_RANGES.any? { |range| range.include?(peer_ip) }
+  rescue IPAddr::InvalidAddressError
+    false
   end
 
   def self.user_or_ip(request)

--- a/test/initializers/rack_attack_test.rb
+++ b/test/initializers/rack_attack_test.rb
@@ -17,6 +17,30 @@ class RackAttackTest < ActiveSupport::TestCase
     assert_equal "ip:192.0.2.1", RackAttackClient.user_or_ip(request)
   end
 
+  test "does not trust CF-Connecting-IP from a non-Cloudflare peer" do
+    request = Rack::Attack::Request.new(
+      Rack::MockRequest.env_for(
+        "/",
+        "REMOTE_ADDR" => "192.0.2.1",
+        "HTTP_CF_CONNECTING_IP" => "198.51.100.42"
+      )
+    )
+
+    assert_equal "192.0.2.1", RackAttackClient.ip(request)
+  end
+
+  test "trusts CF-Connecting-IP from a Cloudflare peer" do
+    request = Rack::Attack::Request.new(
+      Rack::MockRequest.env_for(
+        "/",
+        "REMOTE_ADDR" => "173.245.48.1",
+        "HTTP_CF_CONNECTING_IP" => "198.51.100.42"
+      )
+    )
+
+    assert_equal "198.51.100.42", RackAttackClient.ip(request)
+  end
+
   test "installs Rack Attack once and after the session middleware" do
     middleware = middleware_classes(Rails.application.app)
     rack_attack_index = middleware.index(Rack::Attack)


### PR DESCRIPTION
## what's this do?

<!-- a sentence or two! -->
Only trusts CF-Connecting-IP when the request comes from a Cloudflare IP range.

## show it works

Added tests:
<img width="1032" height="138" alt="image" src="https://github.com/user-attachments/assets/5a899612-5b5c-4bed-bf0f-a3f77567bb76" />


## ai?

Yes, OpenCode, mainly for IP ranges and for the tests
